### PR TITLE
Metadata url

### DIFF
--- a/src/azure/Templates/AzureLongRunningMethodTemplate.cshtml
+++ b/src/azure/Templates/AzureLongRunningMethodTemplate.cshtml
@@ -23,7 +23,7 @@
 @EmptyLine
 }
         # Construct URL
-        url = '@(Model.Url)'
+        url = self.@(((string)Model.Name).ToPythonCase()).metadata['url']
         @(Model.BuildUrlPath("url", Model.LogicalParameters))
 @EmptyLine
         # Construct parameters
@@ -204,3 +204,4 @@ else
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    @(((string)Model.Name).ToPythonCase()).metadata = {'url': '@(Model.Url)'}

--- a/src/azure/Templates/AzurePagingMethodTemplate.cshtml
+++ b/src/azure/Templates/AzurePagingMethodTemplate.cshtml
@@ -48,7 +48,7 @@
 @EmptyLine
             if not next_link:
                 # Construct URL
-                url = '@(Model.Url)'
+                url = self.@(((string)Model.Name).ToPythonCase()).metadata['url']
                 @(Model.BuildUrlPath("url", Model.LogicalParameters))
 @EmptyLine
                 # Construct parameters
@@ -117,3 +117,4 @@ else
             return client_raw_response
 @EmptyLine
         return deserialized
+    @(((string)Model.Name).ToPythonCase()).metadata = {'url': '@(Model.Url)'}

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -51,7 +51,7 @@
 @EmptyLine
 }
         # Construct URL
-        url = '@(Model.Url)'
+        url = self.@(((string)Model.Name).ToPythonCase()).metadata['url']
         @(Model.BuildUrlPath("url", Model.LogicalParameters))
 @EmptyLine
         # Construct parameters
@@ -158,3 +158,4 @@ else
 {
         @:@Model.ReturnEmptyResponse
 }
+    @(((string)Model.Name).ToPythonCase()).metadata = {'url': '@(Model.Url)'}

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/operations/duration_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/operations/duration_operations.py
@@ -48,7 +48,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -80,6 +80,7 @@ class DurationOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/duration/null'}
 
     def put_positive_duration(
             self, duration_body, custom_headers=None, raw=False, **operation_config):
@@ -97,7 +98,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/positiveduration'
+        url = self.put_positive_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -126,6 +127,7 @@ class DurationOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_positive_duration.metadata = {'url': '/duration/positiveduration'}
 
     def get_positive_duration(
             self, custom_headers=None, raw=False, **operation_config):
@@ -141,7 +143,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/positiveduration'
+        url = self.get_positive_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -173,6 +175,7 @@ class DurationOperations(object):
             return client_raw_response
 
         return deserialized
+    get_positive_duration.metadata = {'url': '/duration/positiveduration'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -188,7 +191,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -220,3 +223,4 @@ class DurationOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/duration/invalid'}

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/parameter_grouping_operations.py
@@ -66,7 +66,7 @@ class ParameterGroupingOperations(object):
             path = parameter_grouping_post_required_parameters.path
 
         # Construct URL
-        url = '/parameterGrouping/postRequired/{path}'
+        url = self.post_required.metadata['url']
         path_format_arguments = {
             'path': self._serialize.url("path", path, 'str')
         }
@@ -103,6 +103,7 @@ class ParameterGroupingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required.metadata = {'url': '/parameterGrouping/postRequired/{path}'}
 
     def post_optional(
             self, parameter_grouping_post_optional_parameters=None, custom_headers=None, raw=False, **operation_config):
@@ -130,7 +131,7 @@ class ParameterGroupingOperations(object):
             query = parameter_grouping_post_optional_parameters.query
 
         # Construct URL
-        url = '/parameterGrouping/postOptional'
+        url = self.post_optional.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -159,6 +160,7 @@ class ParameterGroupingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional.metadata = {'url': '/parameterGrouping/postOptional'}
 
     def post_multi_param_groups(
             self, first_parameter_group=None, parameter_grouping_post_multi_param_groups_second_param_group=None, custom_headers=None, raw=False, **operation_config):
@@ -195,7 +197,7 @@ class ParameterGroupingOperations(object):
             query_two = parameter_grouping_post_multi_param_groups_second_param_group.query_two
 
         # Construct URL
-        url = '/parameterGrouping/postMultipleParameterGroups'
+        url = self.post_multi_param_groups.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -228,6 +230,7 @@ class ParameterGroupingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_multi_param_groups.metadata = {'url': '/parameterGrouping/postMultipleParameterGroups'}
 
     def post_shared_parameter_group_object(
             self, first_parameter_group=None, custom_headers=None, raw=False, **operation_config):
@@ -254,7 +257,7 @@ class ParameterGroupingOperations(object):
             query_one = first_parameter_group.query_one
 
         # Construct URL
-        url = '/parameterGrouping/sharedParameterGroupObject'
+        url = self.post_shared_parameter_group_object.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -283,3 +286,4 @@ class ParameterGroupingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_shared_parameter_group_object.metadata = {'url': '/parameterGrouping/sharedParameterGroupObject'}

--- a/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/auto_rest_report_service_for_azure.py
+++ b/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/auto_rest_report_service_for_azure.py
@@ -88,7 +88,7 @@ class AutoRestReportServiceForAzure(object):
         :raises: :class:`ErrorException<azurereport.models.ErrorException>`
         """
         # Construct URL
-        url = '/report/azure'
+        url = self.get_report.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -122,3 +122,4 @@ class AutoRestReportServiceForAzure(object):
             return client_raw_response
 
         return deserialized
+    get_report.metadata = {'url': '/report/azure'}

--- a/test/azure/Expected/AcceptanceTests/AzureResource/azureresource/auto_rest_resource_flattening_test_service.py
+++ b/test/azure/Expected/AcceptanceTests/AzureResource/azureresource/auto_rest_resource_flattening_test_service.py
@@ -85,7 +85,7 @@ class AutoRestResourceFlatteningTestService(object):
         :raises: :class:`ErrorException<azureresource.models.ErrorException>`
         """
         # Construct URL
-        url = '/azure/resource-flatten/array'
+        url = self.put_array.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -117,6 +117,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_array.metadata = {'url': '/azure/resource-flatten/array'}
 
     def get_array(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +134,7 @@ class AutoRestResourceFlatteningTestService(object):
         :raises: :class:`ErrorException<azureresource.models.ErrorException>`
         """
         # Construct URL
-        url = '/azure/resource-flatten/array'
+        url = self.get_array.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -165,6 +166,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_array.metadata = {'url': '/azure/resource-flatten/array'}
 
     def put_dictionary(
             self, resource_dictionary=None, custom_headers=None, raw=False, **operation_config):
@@ -183,7 +185,7 @@ class AutoRestResourceFlatteningTestService(object):
         :raises: :class:`ErrorException<azureresource.models.ErrorException>`
         """
         # Construct URL
-        url = '/azure/resource-flatten/dictionary'
+        url = self.put_dictionary.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -215,6 +217,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_dictionary.metadata = {'url': '/azure/resource-flatten/dictionary'}
 
     def get_dictionary(
             self, custom_headers=None, raw=False, **operation_config):
@@ -231,7 +234,7 @@ class AutoRestResourceFlatteningTestService(object):
         :raises: :class:`ErrorException<azureresource.models.ErrorException>`
         """
         # Construct URL
-        url = '/azure/resource-flatten/dictionary'
+        url = self.get_dictionary.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -263,6 +266,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary.metadata = {'url': '/azure/resource-flatten/dictionary'}
 
     def put_resource_collection(
             self, resource_complex_object=None, custom_headers=None, raw=False, **operation_config):
@@ -282,7 +286,7 @@ class AutoRestResourceFlatteningTestService(object):
         :raises: :class:`ErrorException<azureresource.models.ErrorException>`
         """
         # Construct URL
-        url = '/azure/resource-flatten/resourcecollection'
+        url = self.put_resource_collection.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -314,6 +318,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_resource_collection.metadata = {'url': '/azure/resource-flatten/resourcecollection'}
 
     def get_resource_collection(
             self, custom_headers=None, raw=False, **operation_config):
@@ -330,7 +335,7 @@ class AutoRestResourceFlatteningTestService(object):
         :raises: :class:`ErrorException<azureresource.models.ErrorException>`
         """
         # Construct URL
-        url = '/azure/resource-flatten/resourcecollection'
+        url = self.get_resource_collection.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -362,3 +367,4 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_resource_collection.metadata = {'url': '/azure/resource-flatten/resourcecollection'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/api_version_default_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/api_version_default_operations.py
@@ -51,7 +51,7 @@ class ApiVersionDefaultOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview'
+        url = self.get_method_global_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -77,6 +77,7 @@ class ApiVersionDefaultOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_global_valid.metadata = {'url': '/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview'}
 
     def get_method_global_not_provided_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -93,7 +94,7 @@ class ApiVersionDefaultOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview'
+        url = self.get_method_global_not_provided_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -119,6 +120,7 @@ class ApiVersionDefaultOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_global_not_provided_valid.metadata = {'url': '/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview'}
 
     def get_path_global_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -135,7 +137,7 @@ class ApiVersionDefaultOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview'
+        url = self.get_path_global_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class ApiVersionDefaultOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_path_global_valid.metadata = {'url': '/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview'}
 
     def get_swagger_global_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -177,7 +180,7 @@ class ApiVersionDefaultOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview'
+        url = self.get_swagger_global_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -203,3 +206,4 @@ class ApiVersionDefaultOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_swagger_global_valid.metadata = {'url': '/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/api_version_local_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/api_version_local_operations.py
@@ -52,7 +52,7 @@ class ApiVersionLocalOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/method/string/none/query/local/2.0'
+        url = self.get_method_local_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -78,6 +78,7 @@ class ApiVersionLocalOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_local_valid.metadata = {'url': '/azurespecials/apiVersion/method/string/none/query/local/2.0'}
 
     def get_method_local_null(
             self, api_version=None, custom_headers=None, raw=False, **operation_config):
@@ -98,7 +99,7 @@ class ApiVersionLocalOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/method/string/none/query/local/null'
+        url = self.get_method_local_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -125,6 +126,7 @@ class ApiVersionLocalOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_local_null.metadata = {'url': '/azurespecials/apiVersion/method/string/none/query/local/null'}
 
     def get_path_local_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -142,7 +144,7 @@ class ApiVersionLocalOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/path/string/none/query/local/2.0'
+        url = self.get_path_local_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -168,6 +170,7 @@ class ApiVersionLocalOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_path_local_valid.metadata = {'url': '/azurespecials/apiVersion/path/string/none/query/local/2.0'}
 
     def get_swagger_local_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -185,7 +188,7 @@ class ApiVersionLocalOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/apiVersion/swagger/string/none/query/local/2.0'
+        url = self.get_swagger_local_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -211,3 +214,4 @@ class ApiVersionLocalOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_swagger_local_valid.metadata = {'url': '/azurespecials/apiVersion/swagger/string/none/query/local/2.0'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/header_operations.py
@@ -52,7 +52,7 @@ class HeaderOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/customNamedRequestId'
+        url = self.custom_named_request_id.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -81,6 +81,7 @@ class HeaderOperations(object):
                 'foo-request-id': 'str',
             })
             return client_raw_response
+    custom_named_request_id.metadata = {'url': '/azurespecials/customNamedRequestId'}
 
     def custom_named_request_id_param_grouping(
             self, header_custom_named_request_id_param_grouping_parameters, custom_headers=None, raw=False, **operation_config):
@@ -106,7 +107,7 @@ class HeaderOperations(object):
             foo_client_request_id = header_custom_named_request_id_param_grouping_parameters.foo_client_request_id
 
         # Construct URL
-        url = '/azurespecials/customNamedRequestIdParamGrouping'
+        url = self.custom_named_request_id_param_grouping.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -135,6 +136,7 @@ class HeaderOperations(object):
                 'foo-request-id': 'str',
             })
             return client_raw_response
+    custom_named_request_id_param_grouping.metadata = {'url': '/azurespecials/customNamedRequestIdParamGrouping'}
 
     def custom_named_request_id_head(
             self, foo_client_request_id, custom_headers=None, raw=False, **operation_config):
@@ -154,7 +156,7 @@ class HeaderOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/customNamedRequestIdHead'
+        url = self.custom_named_request_id_head.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -185,3 +187,4 @@ class HeaderOperations(object):
                 })
             return client_raw_response
         return deserialized
+    custom_named_request_id_head.metadata = {'url': '/azurespecials/customNamedRequestIdHead'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/odata_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/odata_operations.py
@@ -57,7 +57,7 @@ class OdataOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/odata/filter'
+        url = self.get_with_filter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -88,3 +88,4 @@ class OdataOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_with_filter.metadata = {'url': '/azurespecials/odata/filter'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/skip_url_encoding_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/skip_url_encoding_operations.py
@@ -57,7 +57,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'
+        url = self.get_method_path_valid.metadata['url']
         path_format_arguments = {
             'unencodedPathParam': self._serialize.url("unencoded_path_param", unencoded_path_param, 'str', skip_quote=True)
         }
@@ -86,6 +86,7 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_path_valid.metadata = {'url': '/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}'}
 
     def get_path_path_valid(
             self, unencoded_path_param, custom_headers=None, raw=False, **operation_config):
@@ -106,7 +107,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'
+        url = self.get_path_path_valid.metadata['url']
         path_format_arguments = {
             'unencodedPathParam': self._serialize.url("unencoded_path_param", unencoded_path_param, 'str', skip_quote=True)
         }
@@ -135,6 +136,7 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_path_path_valid.metadata = {'url': '/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}'}
 
     def get_swagger_path_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -152,7 +154,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'
+        url = self.get_swagger_path_valid.metadata['url']
         path_format_arguments = {
             'unencodedPathParam': self._serialize.url("self.unencoded_path_param", self.unencoded_path_param, 'str', skip_quote=True)
         }
@@ -181,6 +183,7 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_swagger_path_valid.metadata = {'url': '/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}'}
 
     def get_method_query_valid(
             self, q1, custom_headers=None, raw=False, **operation_config):
@@ -201,7 +204,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/method/query/valid'
+        url = self.get_method_query_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -227,6 +230,7 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_query_valid.metadata = {'url': '/azurespecials/skipUrlEncoding/method/query/valid'}
 
     def get_method_query_null(
             self, q1=None, custom_headers=None, raw=False, **operation_config):
@@ -245,7 +249,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/method/query/null'
+        url = self.get_method_query_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -272,6 +276,7 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_method_query_null.metadata = {'url': '/azurespecials/skipUrlEncoding/method/query/null'}
 
     def get_path_query_valid(
             self, q1, custom_headers=None, raw=False, **operation_config):
@@ -292,7 +297,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/path/query/valid'
+        url = self.get_path_query_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -318,6 +323,7 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_path_query_valid.metadata = {'url': '/azurespecials/skipUrlEncoding/path/query/valid'}
 
     def get_swagger_query_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -335,7 +341,7 @@ class SkipUrlEncodingOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/skipUrlEncoding/swagger/query/valid'
+        url = self.get_swagger_query_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -361,3 +367,4 @@ class SkipUrlEncodingOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_swagger_query_valid.metadata = {'url': '/azurespecials/skipUrlEncoding/swagger/query/valid'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/subscription_in_credentials_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/subscription_in_credentials_operations.py
@@ -52,7 +52,7 @@ class SubscriptionInCredentialsOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_method_global_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -81,6 +81,7 @@ class SubscriptionInCredentialsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_method_global_valid.metadata = {'url': '/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'}
 
     def post_method_global_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -99,7 +100,7 @@ class SubscriptionInCredentialsOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'
+        url = self.post_method_global_null.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -128,6 +129,7 @@ class SubscriptionInCredentialsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_method_global_null.metadata = {'url': '/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}'}
 
     def post_method_global_not_provided_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -145,7 +147,7 @@ class SubscriptionInCredentialsOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_method_global_not_provided_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -175,6 +177,7 @@ class SubscriptionInCredentialsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_method_global_not_provided_valid.metadata = {'url': '/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}'}
 
     def post_path_global_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -192,7 +195,7 @@ class SubscriptionInCredentialsOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_path_global_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -221,6 +224,7 @@ class SubscriptionInCredentialsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_path_global_valid.metadata = {'url': '/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'}
 
     def post_swagger_global_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -238,7 +242,7 @@ class SubscriptionInCredentialsOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_swagger_global_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -267,3 +271,4 @@ class SubscriptionInCredentialsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_swagger_global_valid.metadata = {'url': '/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/subscription_in_method_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/subscription_in_method_operations.py
@@ -53,7 +53,7 @@ class SubscriptionInMethodOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_method_local_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("subscription_id", subscription_id, 'str')
         }
@@ -82,6 +82,7 @@ class SubscriptionInMethodOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_method_local_valid.metadata = {'url': '/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'}
 
     def post_method_local_null(
             self, subscription_id, custom_headers=None, raw=False, **operation_config):
@@ -103,7 +104,7 @@ class SubscriptionInMethodOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'
+        url = self.post_method_local_null.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("subscription_id", subscription_id, 'str')
         }
@@ -132,6 +133,7 @@ class SubscriptionInMethodOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_method_local_null.metadata = {'url': '/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}'}
 
     def post_path_local_valid(
             self, subscription_id, custom_headers=None, raw=False, **operation_config):
@@ -152,7 +154,7 @@ class SubscriptionInMethodOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_path_local_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("subscription_id", subscription_id, 'str')
         }
@@ -181,6 +183,7 @@ class SubscriptionInMethodOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_path_local_valid.metadata = {'url': '/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'}
 
     def post_swagger_local_valid(
             self, subscription_id, custom_headers=None, raw=False, **operation_config):
@@ -201,7 +204,7 @@ class SubscriptionInMethodOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'
+        url = self.post_swagger_local_valid.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("subscription_id", subscription_id, 'str')
         }
@@ -230,3 +233,4 @@ class SubscriptionInMethodOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_swagger_local_valid.metadata = {'url': '/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}'}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/xms_client_request_id_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/xms_client_request_id_operations.py
@@ -50,7 +50,7 @@ class XMsClientRequestIdOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/azurespecials/overwrite/x-ms-client-request-id/method/'
+        url = self.get.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -77,6 +77,7 @@ class XMsClientRequestIdOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get.metadata = {'url': '/azurespecials/overwrite/x-ms-client-request-id/method/'}
 
     def param_get(
             self, x_ms_client_request_id, custom_headers=None, raw=False, **operation_config):
@@ -97,7 +98,7 @@ class XMsClientRequestIdOperations(object):
          :class:`ErrorException<azurespecialproperties.models.ErrorException>`
         """
         # Construct URL
-        url = '/azurespecials/overwrite/x-ms-client-request-id/via-param/method/'
+        url = self.param_get.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -123,3 +124,4 @@ class XMsClientRequestIdOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_get.metadata = {'url': '/azurespecials/overwrite/x-ms-client-request-id/via-param/method/'}

--- a/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/paths_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/paths_operations.py
@@ -50,7 +50,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<custombaseurl.models.ErrorException>`
         """
         # Construct URL
-        url = '/customuri'
+        url = self.get_empty.metadata['url']
         path_format_arguments = {
             'accountName': self._serialize.url("account_name", account_name, 'str', skip_quote=True),
             'host': self._serialize.url("self.config.host", self.config.host, 'str', skip_quote=True)
@@ -80,3 +80,4 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_empty.metadata = {'url': '/customuri'}

--- a/test/azure/Expected/AcceptanceTests/Head/head/operations/http_success_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Head/head/operations/http_success_operations.py
@@ -45,7 +45,7 @@ class HttpSuccessOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.head200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -74,6 +74,7 @@ class HttpSuccessOperations(object):
             client_raw_response = ClientRawResponse(deserialized, response)
             return client_raw_response
         return deserialized
+    head200.metadata = {'url': '/http/success/200'}
 
     def head204(
             self, custom_headers=None, raw=False, **operation_config):
@@ -89,7 +90,7 @@ class HttpSuccessOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.head204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class HttpSuccessOperations(object):
             client_raw_response = ClientRawResponse(deserialized, response)
             return client_raw_response
         return deserialized
+    head204.metadata = {'url': '/http/success/204'}
 
     def head404(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class HttpSuccessOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/http/success/404'
+        url = self.head404.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -162,3 +164,4 @@ class HttpSuccessOperations(object):
             client_raw_response = ClientRawResponse(deserialized, response)
             return client_raw_response
         return deserialized
+    head404.metadata = {'url': '/http/success/404'}

--- a/test/azure/Expected/AcceptanceTests/HeadExceptions/headexceptions/operations/head_exception_operations.py
+++ b/test/azure/Expected/AcceptanceTests/HeadExceptions/headexceptions/operations/head_exception_operations.py
@@ -45,7 +45,7 @@ class HeadExceptionOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.head200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -72,6 +72,7 @@ class HeadExceptionOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head200.metadata = {'url': '/http/success/200'}
 
     def head204(
             self, custom_headers=None, raw=False, **operation_config):
@@ -87,7 +88,7 @@ class HeadExceptionOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.head204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -114,6 +115,7 @@ class HeadExceptionOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head204.metadata = {'url': '/http/success/204'}
 
     def head404(
             self, custom_headers=None, raw=False, **operation_config):
@@ -129,7 +131,7 @@ class HeadExceptionOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/http/success/404'
+        url = self.head404.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -156,3 +158,4 @@ class HeadExceptionOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head404.metadata = {'url': '/http/success/404'}

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lr_os_custom_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lr_os_custom_header_operations.py
@@ -41,7 +41,7 @@ class LROsCustomHeaderOperations(object):
     def _put_async_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/customheader/putasync/retry/succeeded'
+        url = self.put_async_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -163,12 +163,13 @@ class LROsCustomHeaderOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_retry_succeeded.metadata = {'url': '/lro/customheader/putasync/retry/succeeded'}
 
 
     def _put201_creating_succeeded200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/customheader/put/201/creating/succeeded/200'
+        url = self.put201_creating_succeeded200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -276,12 +277,13 @@ class LROsCustomHeaderOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put201_creating_succeeded200.metadata = {'url': '/lro/customheader/put/201/creating/succeeded/200'}
 
 
     def _post202_retry200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/customheader/post/202/retry/200'
+        url = self.post202_retry200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -384,12 +386,13 @@ class LROsCustomHeaderOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_retry200.metadata = {'url': '/lro/customheader/post/202/retry/200'}
 
 
     def _post_async_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/customheader/postasync/retry/succeeded'
+        url = self.post_async_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -494,3 +497,4 @@ class LROsCustomHeaderOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_retry_succeeded.metadata = {'url': '/lro/customheader/postasync/retry/succeeded'}

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lr_os_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lr_os_operations.py
@@ -41,7 +41,7 @@ class LROsOperations(object):
     def _put200_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/200/succeeded'
+        url = self.put200_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -144,12 +144,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put200_succeeded.metadata = {'url': '/lro/put/200/succeeded'}
 
 
     def _put200_succeeded_no_state_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/200/succeeded/nostate'
+        url = self.put200_succeeded_no_state.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -252,12 +253,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put200_succeeded_no_state.metadata = {'url': '/lro/put/200/succeeded/nostate'}
 
 
     def _put202_retry200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/202/retry/200'
+        url = self.put202_retry200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -361,12 +363,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put202_retry200.metadata = {'url': '/lro/put/202/retry/200'}
 
 
     def _put201_creating_succeeded200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/201/creating/succeeded/200'
+        url = self.put201_creating_succeeded200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -473,12 +476,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put201_creating_succeeded200.metadata = {'url': '/lro/put/201/creating/succeeded/200'}
 
 
     def _put200_updating_succeeded204_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/200/updating/succeeded/200'
+        url = self.put200_updating_succeeded204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -583,12 +587,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put200_updating_succeeded204.metadata = {'url': '/lro/put/200/updating/succeeded/200'}
 
 
     def _put201_creating_failed200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/201/created/failed/200'
+        url = self.put201_creating_failed200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -695,12 +700,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put201_creating_failed200.metadata = {'url': '/lro/put/201/created/failed/200'}
 
 
     def _put200_acceptedcanceled200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/200/accepted/canceled/200'
+        url = self.put200_acceptedcanceled200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -805,12 +811,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put200_acceptedcanceled200.metadata = {'url': '/lro/put/200/accepted/canceled/200'}
 
 
     def _put_no_header_in_retry_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/put/noheader/202/200'
+        url = self.put_no_header_in_retry.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -926,12 +933,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_no_header_in_retry.metadata = {'url': '/lro/put/noheader/202/200'}
 
 
     def _put_async_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putasync/retry/succeeded'
+        url = self.put_async_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1052,12 +1060,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_retry_succeeded.metadata = {'url': '/lro/putasync/retry/succeeded'}
 
 
     def _put_async_no_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putasync/noretry/succeeded'
+        url = self.put_async_no_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1176,12 +1185,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_no_retry_succeeded.metadata = {'url': '/lro/putasync/noretry/succeeded'}
 
 
     def _put_async_retry_failed_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putasync/retry/failed'
+        url = self.put_async_retry_failed.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1302,12 +1312,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_retry_failed.metadata = {'url': '/lro/putasync/retry/failed'}
 
 
     def _put_async_no_retrycanceled_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putasync/noretry/canceled'
+        url = self.put_async_no_retrycanceled.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1426,12 +1437,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_no_retrycanceled.metadata = {'url': '/lro/putasync/noretry/canceled'}
 
 
     def _put_async_no_header_in_retry_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putasync/noheader/201/200'
+        url = self.put_async_no_header_in_retry.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1547,12 +1559,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_no_header_in_retry.metadata = {'url': '/lro/putasync/noheader/201/200'}
 
 
     def _put_non_resource_initial(
             self, sku=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putnonresource/202/200'
+        url = self.put_non_resource.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1654,12 +1667,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_non_resource.metadata = {'url': '/lro/putnonresource/202/200'}
 
 
     def _put_async_non_resource_initial(
             self, sku=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/putnonresourceasync/202/200'
+        url = self.put_async_non_resource.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1761,6 +1775,7 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_non_resource.metadata = {'url': '/lro/putnonresourceasync/202/200'}
 
 
     def _put_sub_resource_initial(
@@ -1770,7 +1785,7 @@ class LROsOperations(object):
             product = models.SubProduct(provisioning_state=provisioning_state)
 
         # Construct URL
-        url = '/lro/putsubresource/202/200'
+        url = self.put_sub_resource.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1872,6 +1887,7 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_sub_resource.metadata = {'url': '/lro/putsubresource/202/200'}
 
 
     def _put_async_sub_resource_initial(
@@ -1881,7 +1897,7 @@ class LROsOperations(object):
             product = models.SubProduct(provisioning_state=provisioning_state)
 
         # Construct URL
-        url = '/lro/putsubresourceasync/202/200'
+        url = self.put_async_sub_resource.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1983,12 +1999,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_sub_resource.metadata = {'url': '/lro/putsubresourceasync/202/200'}
 
 
     def _delete_provisioning202_accepted200_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/provisioning/202/accepted/200/succeeded'
+        url = self.delete_provisioning202_accepted200_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2103,12 +2120,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_provisioning202_accepted200_succeeded.metadata = {'url': '/lro/delete/provisioning/202/accepted/200/succeeded'}
 
 
     def _delete_provisioning202_deleting_failed200_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/provisioning/202/deleting/200/failed'
+        url = self.delete_provisioning202_deleting_failed200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2223,12 +2241,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_provisioning202_deleting_failed200.metadata = {'url': '/lro/delete/provisioning/202/deleting/200/failed'}
 
 
     def _delete_provisioning202_deletingcanceled200_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/provisioning/202/deleting/200/canceled'
+        url = self.delete_provisioning202_deletingcanceled200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2343,12 +2362,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_provisioning202_deletingcanceled200.metadata = {'url': '/lro/delete/provisioning/202/deleting/200/canceled'}
 
 
     def _delete204_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/204/succeeded'
+        url = self.delete204_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2428,12 +2448,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete204_succeeded.metadata = {'url': '/lro/delete/204/succeeded'}
 
 
     def _delete202_retry200_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/202/retry/200'
+        url = self.delete202_retry200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2541,12 +2562,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete202_retry200.metadata = {'url': '/lro/delete/202/retry/200'}
 
 
     def _delete202_no_retry204_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/202/noretry/204'
+        url = self.delete202_no_retry204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2654,12 +2676,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete202_no_retry204.metadata = {'url': '/lro/delete/202/noretry/204'}
 
 
     def _delete_no_header_in_retry_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/delete/noheader'
+        url = self.delete_no_header_in_retry.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2748,12 +2771,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_no_header_in_retry.metadata = {'url': '/lro/delete/noheader'}
 
 
     def _delete_async_no_header_in_retry_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/deleteasync/noheader/202/204'
+        url = self.delete_async_no_header_in_retry.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2842,12 +2866,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_no_header_in_retry.metadata = {'url': '/lro/deleteasync/noheader/202/204'}
 
 
     def _delete_async_retry_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/deleteasync/retry/succeeded'
+        url = self.delete_async_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2940,12 +2965,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_retry_succeeded.metadata = {'url': '/lro/deleteasync/retry/succeeded'}
 
 
     def _delete_async_no_retry_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/deleteasync/noretry/succeeded'
+        url = self.delete_async_no_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3038,12 +3064,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_no_retry_succeeded.metadata = {'url': '/lro/deleteasync/noretry/succeeded'}
 
 
     def _delete_async_retry_failed_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/deleteasync/retry/failed'
+        url = self.delete_async_retry_failed.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3136,12 +3163,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_retry_failed.metadata = {'url': '/lro/deleteasync/retry/failed'}
 
 
     def _delete_async_retrycanceled_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/deleteasync/retry/canceled'
+        url = self.delete_async_retrycanceled.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3234,12 +3262,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_retrycanceled.metadata = {'url': '/lro/deleteasync/retry/canceled'}
 
 
     def _post200_with_payload_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/post/payload/200'
+        url = self.post200_with_payload.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3335,12 +3364,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post200_with_payload.metadata = {'url': '/lro/post/payload/200'}
 
 
     def _post202_retry200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/post/202/retry/200'
+        url = self.post202_retry200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3441,12 +3471,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_retry200.metadata = {'url': '/lro/post/202/retry/200'}
 
 
     def _post202_no_retry204_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/post/202/noretry/204'
+        url = self.post202_no_retry204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3564,12 +3595,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_no_retry204.metadata = {'url': '/lro/post/202/noretry/204'}
 
 
     def _post_async_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/postasync/retry/succeeded'
+        url = self.post_async_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3690,12 +3722,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_retry_succeeded.metadata = {'url': '/lro/postasync/retry/succeeded'}
 
 
     def _post_async_no_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/postasync/noretry/succeeded'
+        url = self.post_async_no_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3816,12 +3849,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_no_retry_succeeded.metadata = {'url': '/lro/postasync/noretry/succeeded'}
 
 
     def _post_async_retry_failed_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/postasync/retry/failed'
+        url = self.post_async_retry_failed.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -3925,12 +3959,13 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_retry_failed.metadata = {'url': '/lro/postasync/retry/failed'}
 
 
     def _post_async_retrycanceled_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/postasync/retry/canceled'
+        url = self.post_async_retrycanceled.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -4034,3 +4069,4 @@ class LROsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_retrycanceled.metadata = {'url': '/lro/postasync/retry/canceled'}

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lro_retrys_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lro_retrys_operations.py
@@ -41,7 +41,7 @@ class LRORetrysOperations(object):
     def _put201_creating_succeeded200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/put/201/creating/succeeded/200'
+        url = self.put201_creating_succeeded200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -148,12 +148,13 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put201_creating_succeeded200.metadata = {'url': '/lro/retryerror/put/201/creating/succeeded/200'}
 
 
     def _put_async_relative_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/putasync/retry/succeeded'
+        url = self.put_async_relative_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -274,12 +275,13 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_relative_retry_succeeded.metadata = {'url': '/lro/retryerror/putasync/retry/succeeded'}
 
 
     def _delete_provisioning202_accepted200_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/delete/provisioning/202/accepted/200/succeeded'
+        url = self.delete_provisioning202_accepted200_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -394,12 +396,13 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_provisioning202_accepted200_succeeded.metadata = {'url': '/lro/retryerror/delete/provisioning/202/accepted/200/succeeded'}
 
 
     def _delete202_retry200_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/delete/202/retry/200'
+        url = self.delete202_retry200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -490,12 +493,13 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete202_retry200.metadata = {'url': '/lro/retryerror/delete/202/retry/200'}
 
 
     def _delete_async_relative_retry_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/deleteasync/retry/succeeded'
+        url = self.delete_async_relative_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -588,12 +592,13 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_relative_retry_succeeded.metadata = {'url': '/lro/retryerror/deleteasync/retry/succeeded'}
 
 
     def _post202_retry200_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/post/202/retry/200'
+        url = self.post202_retry200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -694,12 +699,13 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_retry200.metadata = {'url': '/lro/retryerror/post/202/retry/200'}
 
 
     def _post_async_relative_retry_succeeded_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/retryerror/postasync/retry/succeeded'
+        url = self.post_async_relative_retry_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -803,3 +809,4 @@ class LRORetrysOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_relative_retry_succeeded.metadata = {'url': '/lro/retryerror/postasync/retry/succeeded'}

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lrosa_ds_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/lrosa_ds_operations.py
@@ -41,7 +41,7 @@ class LROSADsOperations(object):
     def _put_non_retry400_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/put/400'
+        url = self.put_non_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -145,12 +145,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_non_retry400.metadata = {'url': '/lro/nonretryerror/put/400'}
 
 
     def _put_non_retry201_creating400_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/put/201/creating/400'
+        url = self.put_non_retry201_creating400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -255,12 +256,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_non_retry201_creating400.metadata = {'url': '/lro/nonretryerror/put/201/creating/400'}
 
 
     def _put_non_retry201_creating400_invalid_json_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/put/201/creating/400/invalidjson'
+        url = self.put_non_retry201_creating400_invalid_json.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -365,12 +367,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_non_retry201_creating400_invalid_json.metadata = {'url': '/lro/nonretryerror/put/201/creating/400/invalidjson'}
 
 
     def _put_async_relative_retry400_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/putasync/retry/400'
+        url = self.put_async_relative_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -490,12 +493,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_relative_retry400.metadata = {'url': '/lro/nonretryerror/putasync/retry/400'}
 
 
     def _delete_non_retry400_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/delete/400'
+        url = self.delete_non_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -584,12 +588,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_non_retry400.metadata = {'url': '/lro/nonretryerror/delete/400'}
 
 
     def _delete202_non_retry400_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/delete/202/retry/400'
+        url = self.delete202_non_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -679,12 +684,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete202_non_retry400.metadata = {'url': '/lro/nonretryerror/delete/202/retry/400'}
 
 
     def _delete_async_relative_retry400_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/deleteasync/retry/400'
+        url = self.delete_async_relative_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -777,12 +783,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_relative_retry400.metadata = {'url': '/lro/nonretryerror/deleteasync/retry/400'}
 
 
     def _post_non_retry400_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/post/400'
+        url = self.post_non_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -881,12 +888,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_non_retry400.metadata = {'url': '/lro/nonretryerror/post/400'}
 
 
     def _post202_non_retry400_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/post/202/retry/400'
+        url = self.post202_non_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -986,12 +994,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_non_retry400.metadata = {'url': '/lro/nonretryerror/post/202/retry/400'}
 
 
     def _post_async_relative_retry400_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/nonretryerror/postasync/retry/400'
+        url = self.post_async_relative_retry400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1094,12 +1103,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_relative_retry400.metadata = {'url': '/lro/nonretryerror/postasync/retry/400'}
 
 
     def _put_error201_no_provisioning_state_payload_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/put/201/noprovisioningstatepayload'
+        url = self.put_error201_no_provisioning_state_payload.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1204,12 +1214,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_error201_no_provisioning_state_payload.metadata = {'url': '/lro/error/put/201/noprovisioningstatepayload'}
 
 
     def _put_async_relative_retry_no_status_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/putasync/retry/nostatus'
+        url = self.put_async_relative_retry_no_status.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1330,12 +1341,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_relative_retry_no_status.metadata = {'url': '/lro/error/putasync/retry/nostatus'}
 
 
     def _put_async_relative_retry_no_status_payload_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/putasync/retry/nostatuspayload'
+        url = self.put_async_relative_retry_no_status_payload.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1456,12 +1468,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_relative_retry_no_status_payload.metadata = {'url': '/lro/error/putasync/retry/nostatuspayload'}
 
 
     def _delete204_succeeded_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/delete/204/nolocation'
+        url = self.delete204_succeeded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1542,12 +1555,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete204_succeeded.metadata = {'url': '/lro/error/delete/204/nolocation'}
 
 
     def _delete_async_relative_retry_no_status_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/deleteasync/retry/nostatus'
+        url = self.delete_async_relative_retry_no_status.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1640,12 +1654,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_relative_retry_no_status.metadata = {'url': '/lro/error/deleteasync/retry/nostatus'}
 
 
     def _post202_no_location_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/post/202/nolocation'
+        url = self.post202_no_location.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1745,12 +1760,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_no_location.metadata = {'url': '/lro/error/post/202/nolocation'}
 
 
     def _post_async_relative_retry_no_payload_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/postasync/retry/nopayload'
+        url = self.post_async_relative_retry_no_payload.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1854,12 +1870,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_relative_retry_no_payload.metadata = {'url': '/lro/error/postasync/retry/nopayload'}
 
 
     def _put200_invalid_json_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/put/200/invalidjson'
+        url = self.put200_invalid_json.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1962,12 +1979,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put200_invalid_json.metadata = {'url': '/lro/error/put/200/invalidjson'}
 
 
     def _put_async_relative_retry_invalid_header_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/putasync/retry/invalidheader'
+        url = self.put_async_relative_retry_invalid_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2087,12 +2105,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_relative_retry_invalid_header.metadata = {'url': '/lro/error/putasync/retry/invalidheader'}
 
 
     def _put_async_relative_retry_invalid_json_polling_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/putasync/retry/invalidjsonpolling'
+        url = self.put_async_relative_retry_invalid_json_polling.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2213,12 +2232,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    put_async_relative_retry_invalid_json_polling.metadata = {'url': '/lro/error/putasync/retry/invalidjsonpolling'}
 
 
     def _delete202_retry_invalid_header_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/delete/202/retry/invalidheader'
+        url = self.delete202_retry_invalid_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2309,12 +2329,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete202_retry_invalid_header.metadata = {'url': '/lro/error/delete/202/retry/invalidheader'}
 
 
     def _delete_async_relative_retry_invalid_header_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/deleteasync/retry/invalidheader'
+        url = self.delete_async_relative_retry_invalid_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2407,12 +2428,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_relative_retry_invalid_header.metadata = {'url': '/lro/error/deleteasync/retry/invalidheader'}
 
 
     def _delete_async_relative_retry_invalid_json_polling_initial(
             self, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/deleteasync/retry/invalidjsonpolling'
+        url = self.delete_async_relative_retry_invalid_json_polling.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2505,12 +2527,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    delete_async_relative_retry_invalid_json_polling.metadata = {'url': '/lro/error/deleteasync/retry/invalidjsonpolling'}
 
 
     def _post202_retry_invalid_header_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/post/202/retry/invalidheader'
+        url = self.post202_retry_invalid_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2610,12 +2633,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post202_retry_invalid_header.metadata = {'url': '/lro/error/post/202/retry/invalidheader'}
 
 
     def _post_async_relative_retry_invalid_header_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/postasync/retry/invalidheader'
+        url = self.post_async_relative_retry_invalid_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2718,12 +2742,13 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_relative_retry_invalid_header.metadata = {'url': '/lro/error/postasync/retry/invalidheader'}
 
 
     def _post_async_relative_retry_invalid_json_polling_initial(
             self, product=None, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/lro/error/postasync/retry/invalidjsonpolling'
+        url = self.post_async_relative_retry_invalid_json_polling.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2827,3 +2852,4 @@ class LROSADsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    post_async_relative_retry_invalid_json_polling.metadata = {'url': '/lro/error/postasync/retry/invalidjsonpolling'}

--- a/test/azure/Expected/AcceptanceTests/Paging/paging/operations/paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Paging/paging/operations/paging_operations.py
@@ -52,7 +52,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/single'
+                url = self.get_single_pages.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -92,6 +92,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_single_pages.metadata = {'url': '/paging/single'}
 
     def get_multiple_pages(
             self, client_request_id=None, paging_get_multiple_pages_options=None, custom_headers=None, raw=False, **operation_config):
@@ -123,7 +124,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple'
+                url = self.get_multiple_pages.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -169,6 +170,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages.metadata = {'url': '/paging/multiple'}
 
     def get_odata_multiple_pages(
             self, client_request_id=None, paging_get_odata_multiple_pages_options=None, custom_headers=None, raw=False, **operation_config):
@@ -201,7 +203,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/odata'
+                url = self.get_odata_multiple_pages.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -247,6 +249,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_odata_multiple_pages.metadata = {'url': '/paging/multiple/odata'}
 
     def get_multiple_pages_with_offset(
             self, paging_get_multiple_pages_with_offset_options, client_request_id=None, custom_headers=None, raw=False, **operation_config):
@@ -281,7 +284,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/withpath/{offset}'
+                url = self.get_multiple_pages_with_offset.metadata['url']
                 path_format_arguments = {
                     'offset': self._serialize.url("offset", offset, 'int')
                 }
@@ -331,6 +334,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_with_offset.metadata = {'url': '/paging/multiple/withpath/{offset}'}
 
     def get_multiple_pages_retry_first(
             self, custom_headers=None, raw=False, **operation_config):
@@ -350,7 +354,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/retryfirst'
+                url = self.get_multiple_pages_retry_first.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -390,6 +394,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_retry_first.metadata = {'url': '/paging/multiple/retryfirst'}
 
     def get_multiple_pages_retry_second(
             self, custom_headers=None, raw=False, **operation_config):
@@ -410,7 +415,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/retrysecond'
+                url = self.get_multiple_pages_retry_second.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -450,6 +455,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_retry_second.metadata = {'url': '/paging/multiple/retrysecond'}
 
     def get_single_pages_failure(
             self, custom_headers=None, raw=False, **operation_config):
@@ -468,7 +474,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/single/failure'
+                url = self.get_single_pages_failure.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -508,6 +514,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_single_pages_failure.metadata = {'url': '/paging/single/failure'}
 
     def get_multiple_pages_failure(
             self, custom_headers=None, raw=False, **operation_config):
@@ -526,7 +533,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/failure'
+                url = self.get_multiple_pages_failure.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -566,6 +573,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_failure.metadata = {'url': '/paging/multiple/failure'}
 
     def get_multiple_pages_failure_uri(
             self, custom_headers=None, raw=False, **operation_config):
@@ -584,7 +592,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/failureuri'
+                url = self.get_multiple_pages_failure_uri.metadata['url']
 
                 # Construct parameters
                 query_parameters = {}
@@ -624,6 +632,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_failure_uri.metadata = {'url': '/paging/multiple/failureuri'}
 
     def get_multiple_pages_fragment_next_link(
             self, api_version, tenant, custom_headers=None, raw=False, **operation_config):
@@ -646,7 +655,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/fragment/{tenant}'
+                url = self.get_multiple_pages_fragment_next_link.metadata['url']
                 path_format_arguments = {
                     'tenant': self._serialize.url("tenant", tenant, 'str')
                 }
@@ -697,6 +706,7 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_fragment_next_link.metadata = {'url': '/paging/multiple/fragment/{tenant}'}
 
     def get_multiple_pages_fragment_with_grouping_next_link(
             self, custom_parameter_group, custom_headers=None, raw=False, **operation_config):
@@ -725,7 +735,7 @@ class PagingOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/paging/multiple/fragmentwithgrouping/{tenant}'
+                url = self.get_multiple_pages_fragment_with_grouping_next_link.metadata['url']
                 path_format_arguments = {
                     'tenant': self._serialize.url("tenant", tenant, 'str')
                 }
@@ -776,3 +786,4 @@ class PagingOperations(object):
             return client_raw_response
 
         return deserialized
+    get_multiple_pages_fragment_with_grouping_next_link.metadata = {'url': '/paging/multiple/fragmentwithgrouping/{tenant}'}

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/storage_accounts_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/storage_accounts_operations.py
@@ -59,7 +59,7 @@ class StorageAccountsOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'
+        url = self.check_name_availability.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -102,12 +102,13 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    check_name_availability.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability'}
 
 
     def _create_initial(
             self, resource_group_name, account_name, parameters, custom_headers=None, raw=False, **operation_config):
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+        url = self.create.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'accountName': self._serialize.url("account_name", account_name, 'str'),
@@ -226,6 +227,7 @@ class StorageAccountsOperations(object):
         return AzureOperationPoller(
             long_running_send, get_long_running_output,
             get_long_running_status, long_running_operation_timeout)
+    create.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'}
 
     def delete(
             self, resource_group_name, account_name, custom_headers=None, raw=False, **operation_config):
@@ -248,7 +250,7 @@ class StorageAccountsOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+        url = self.delete.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'accountName': self._serialize.url("account_name", account_name, 'str'),
@@ -282,6 +284,7 @@ class StorageAccountsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'}
 
     def get_properties(
             self, resource_group_name, account_name, custom_headers=None, raw=False, **operation_config):
@@ -307,7 +310,7 @@ class StorageAccountsOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+        url = self.get_properties.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'accountName': self._serialize.url("account_name", account_name, 'str'),
@@ -348,6 +351,7 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    get_properties.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'}
 
     def update(
             self, resource_group_name, account_name, parameters, custom_headers=None, raw=False, **operation_config):
@@ -383,7 +387,7 @@ class StorageAccountsOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'
+        url = self.update.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'accountName': self._serialize.url("account_name", account_name, 'str'),
@@ -428,6 +432,7 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    update.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}'}
 
     def list_keys(
             self, resource_group_name, account_name, custom_headers=None, raw=False, **operation_config):
@@ -449,7 +454,7 @@ class StorageAccountsOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'
+        url = self.list_keys.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'accountName': self._serialize.url("account_name", account_name, 'str'),
@@ -490,6 +495,7 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    list_keys.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys'}
 
     def list(
             self, custom_headers=None, raw=False, **operation_config):
@@ -511,7 +517,7 @@ class StorageAccountsOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'
+                url = self.list.metadata['url']
                 path_format_arguments = {
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
                 }
@@ -556,6 +562,7 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    list.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts'}
 
     def list_by_resource_group(
             self, resource_group_name, custom_headers=None, raw=False, **operation_config):
@@ -580,7 +587,7 @@ class StorageAccountsOperations(object):
 
             if not next_link:
                 # Construct URL
-                url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'
+                url = self.list_by_resource_group.metadata['url']
                 path_format_arguments = {
                     'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
                     'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
@@ -626,6 +633,7 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    list_by_resource_group.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts'}
 
     def regenerate_key(
             self, resource_group_name, account_name, key_name=None, custom_headers=None, raw=False, **operation_config):
@@ -653,7 +661,7 @@ class StorageAccountsOperations(object):
         regenerate_key1 = models.StorageAccountRegenerateKeyParameters(key_name=key_name)
 
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'
+        url = self.regenerate_key.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'accountName': self._serialize.url("account_name", account_name, 'str'),
@@ -698,3 +706,4 @@ class StorageAccountsOperations(object):
             return client_raw_response
 
         return deserialized
+    regenerate_key.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey'}

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/usage_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/usage_operations.py
@@ -53,7 +53,7 @@ class UsageOperations(object):
         :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
+        url = self.list.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str')
         }
@@ -92,3 +92,4 @@ class UsageOperations(object):
             return client_raw_response
 
         return deserialized
+    list.metadata = {'url': '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'}

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/group_operations.py
@@ -55,7 +55,7 @@ class GroupOperations(object):
          :class:`ErrorException<subscriptionidapiversion.models.ErrorException>`
         """
         # Construct URL
-        url = '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'
+        url = self.get_sample_resource_group.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str')
@@ -93,3 +93,4 @@ class GroupOperations(object):
             return client_raw_response
 
         return deserialized
+    get_sample_resource_group.metadata = {'url': '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/array_operations.py
@@ -47,7 +47,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/array/null'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/array/invalid'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/array/empty'}
 
     def put_empty(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -178,7 +181,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/empty'
+        url = self.put_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -203,6 +206,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_empty.metadata = {'url': '/array/empty'}
 
     def get_boolean_tfft(
             self, custom_headers=None, raw=False, **operation_config):
@@ -218,7 +222,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/boolean/tfft'
+        url = self.get_boolean_tfft.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -246,6 +250,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_boolean_tfft.metadata = {'url': '/array/prim/boolean/tfft'}
 
     def put_boolean_tfft(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -263,7 +268,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/boolean/tfft'
+        url = self.put_boolean_tfft.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -288,6 +293,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_boolean_tfft.metadata = {'url': '/array/prim/boolean/tfft'}
 
     def get_boolean_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -303,7 +309,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/boolean/true.null.false'
+        url = self.get_boolean_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -331,6 +337,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_boolean_invalid_null.metadata = {'url': '/array/prim/boolean/true.null.false'}
 
     def get_boolean_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -346,7 +353,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/boolean/true.boolean.false'
+        url = self.get_boolean_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -374,6 +381,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_boolean_invalid_string.metadata = {'url': '/array/prim/boolean/true.boolean.false'}
 
     def get_integer_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -389,7 +397,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/integer/1.-1.3.300'
+        url = self.get_integer_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -417,6 +425,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_integer_valid.metadata = {'url': '/array/prim/integer/1.-1.3.300'}
 
     def put_integer_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -434,7 +443,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/integer/1.-1.3.300'
+        url = self.put_integer_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -459,6 +468,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_integer_valid.metadata = {'url': '/array/prim/integer/1.-1.3.300'}
 
     def get_int_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -474,7 +484,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/integer/1.null.zero'
+        url = self.get_int_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -502,6 +512,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_int_invalid_null.metadata = {'url': '/array/prim/integer/1.null.zero'}
 
     def get_int_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -517,7 +528,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/integer/1.integer.0'
+        url = self.get_int_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -545,6 +556,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_int_invalid_string.metadata = {'url': '/array/prim/integer/1.integer.0'}
 
     def get_long_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -560,7 +572,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/long/1.-1.3.300'
+        url = self.get_long_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -588,6 +600,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long_valid.metadata = {'url': '/array/prim/long/1.-1.3.300'}
 
     def put_long_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -605,7 +618,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/long/1.-1.3.300'
+        url = self.put_long_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -630,6 +643,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_long_valid.metadata = {'url': '/array/prim/long/1.-1.3.300'}
 
     def get_long_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -645,7 +659,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/long/1.null.zero'
+        url = self.get_long_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -673,6 +687,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long_invalid_null.metadata = {'url': '/array/prim/long/1.null.zero'}
 
     def get_long_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -688,7 +703,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/long/1.integer.0'
+        url = self.get_long_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -716,6 +731,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long_invalid_string.metadata = {'url': '/array/prim/long/1.integer.0'}
 
     def get_float_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -731,7 +747,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/float/0--0.01-1.2e20'
+        url = self.get_float_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -759,6 +775,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float_valid.metadata = {'url': '/array/prim/float/0--0.01-1.2e20'}
 
     def put_float_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -776,7 +793,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/float/0--0.01-1.2e20'
+        url = self.put_float_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -801,6 +818,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_float_valid.metadata = {'url': '/array/prim/float/0--0.01-1.2e20'}
 
     def get_float_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -816,7 +834,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/float/0.0-null-1.2e20'
+        url = self.get_float_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -844,6 +862,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float_invalid_null.metadata = {'url': '/array/prim/float/0.0-null-1.2e20'}
 
     def get_float_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -859,7 +878,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/float/1.number.0'
+        url = self.get_float_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -887,6 +906,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float_invalid_string.metadata = {'url': '/array/prim/float/1.number.0'}
 
     def get_double_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -902,7 +922,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/double/0--0.01-1.2e20'
+        url = self.get_double_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -930,6 +950,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double_valid.metadata = {'url': '/array/prim/double/0--0.01-1.2e20'}
 
     def put_double_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -947,7 +968,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/double/0--0.01-1.2e20'
+        url = self.put_double_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -972,6 +993,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_double_valid.metadata = {'url': '/array/prim/double/0--0.01-1.2e20'}
 
     def get_double_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -987,7 +1009,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/double/0.0-null-1.2e20'
+        url = self.get_double_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1015,6 +1037,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double_invalid_null.metadata = {'url': '/array/prim/double/0.0-null-1.2e20'}
 
     def get_double_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1030,7 +1053,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/double/1.number.0'
+        url = self.get_double_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1058,6 +1081,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double_invalid_string.metadata = {'url': '/array/prim/double/1.number.0'}
 
     def get_string_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1073,7 +1097,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/string/foo1.foo2.foo3'
+        url = self.get_string_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1101,6 +1125,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string_valid.metadata = {'url': '/array/prim/string/foo1.foo2.foo3'}
 
     def put_string_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1118,7 +1143,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/string/foo1.foo2.foo3'
+        url = self.put_string_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1143,6 +1168,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_string_valid.metadata = {'url': '/array/prim/string/foo1.foo2.foo3'}
 
     def get_string_with_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1158,7 +1184,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/string/foo.null.foo2'
+        url = self.get_string_with_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1186,6 +1212,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string_with_null.metadata = {'url': '/array/prim/string/foo.null.foo2'}
 
     def get_string_with_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1201,7 +1228,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/string/foo.123.foo2'
+        url = self.get_string_with_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1229,6 +1256,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string_with_invalid.metadata = {'url': '/array/prim/string/foo.123.foo2'}
 
     def get_uuid_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1246,7 +1274,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/uuid/valid'
+        url = self.get_uuid_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1274,6 +1302,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_uuid_valid.metadata = {'url': '/array/prim/uuid/valid'}
 
     def put_uuid_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1293,7 +1322,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/uuid/valid'
+        url = self.put_uuid_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1318,6 +1347,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_uuid_valid.metadata = {'url': '/array/prim/uuid/valid'}
 
     def get_uuid_invalid_chars(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1333,7 +1363,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/uuid/invalidchars'
+        url = self.get_uuid_invalid_chars.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1361,6 +1391,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_uuid_invalid_chars.metadata = {'url': '/array/prim/uuid/invalidchars'}
 
     def get_date_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1376,7 +1407,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date/valid'
+        url = self.get_date_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1404,6 +1435,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_valid.metadata = {'url': '/array/prim/date/valid'}
 
     def put_date_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1421,7 +1453,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date/valid'
+        url = self.put_date_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1446,6 +1478,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_valid.metadata = {'url': '/array/prim/date/valid'}
 
     def get_date_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1461,7 +1494,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date/invalidnull'
+        url = self.get_date_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1489,6 +1522,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_invalid_null.metadata = {'url': '/array/prim/date/invalidnull'}
 
     def get_date_invalid_chars(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1504,7 +1538,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date/invalidchars'
+        url = self.get_date_invalid_chars.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1532,6 +1566,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_invalid_chars.metadata = {'url': '/array/prim/date/invalidchars'}
 
     def get_date_time_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1548,7 +1583,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date-time/valid'
+        url = self.get_date_time_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1576,6 +1611,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_valid.metadata = {'url': '/array/prim/date-time/valid'}
 
     def put_date_time_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1594,7 +1630,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date-time/valid'
+        url = self.put_date_time_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1619,6 +1655,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_time_valid.metadata = {'url': '/array/prim/date-time/valid'}
 
     def get_date_time_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1634,7 +1671,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date-time/invalidnull'
+        url = self.get_date_time_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1662,6 +1699,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_invalid_null.metadata = {'url': '/array/prim/date-time/invalidnull'}
 
     def get_date_time_invalid_chars(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1677,7 +1715,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date-time/invalidchars'
+        url = self.get_date_time_invalid_chars.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1705,6 +1743,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_invalid_chars.metadata = {'url': '/array/prim/date-time/invalidchars'}
 
     def get_date_time_rfc1123_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1721,7 +1760,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date-time-rfc1123/valid'
+        url = self.get_date_time_rfc1123_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1749,6 +1788,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_rfc1123_valid.metadata = {'url': '/array/prim/date-time-rfc1123/valid'}
 
     def put_date_time_rfc1123_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1767,7 +1807,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/date-time-rfc1123/valid'
+        url = self.put_date_time_rfc1123_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1792,6 +1832,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_time_rfc1123_valid.metadata = {'url': '/array/prim/date-time-rfc1123/valid'}
 
     def get_duration_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1807,7 +1848,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/duration/valid'
+        url = self.get_duration_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1835,6 +1876,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_duration_valid.metadata = {'url': '/array/prim/duration/valid'}
 
     def put_duration_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1852,7 +1894,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/duration/valid'
+        url = self.put_duration_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1877,6 +1919,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_duration_valid.metadata = {'url': '/array/prim/duration/valid'}
 
     def get_byte_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1893,7 +1936,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/byte/valid'
+        url = self.get_byte_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1921,6 +1964,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_byte_valid.metadata = {'url': '/array/prim/byte/valid'}
 
     def put_byte_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1939,7 +1983,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/byte/valid'
+        url = self.put_byte_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1964,6 +2008,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_byte_valid.metadata = {'url': '/array/prim/byte/valid'}
 
     def get_byte_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1980,7 +2025,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/byte/invalidnull'
+        url = self.get_byte_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2008,6 +2053,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_byte_invalid_null.metadata = {'url': '/array/prim/byte/invalidnull'}
 
     def get_base64_url(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2024,7 +2070,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/prim/base64url/valid'
+        url = self.get_base64_url.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2052,6 +2098,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_base64_url.metadata = {'url': '/array/prim/base64url/valid'}
 
     def get_complex_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2068,7 +2115,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/complex/null'
+        url = self.get_complex_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2096,6 +2143,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_null.metadata = {'url': '/array/complex/null'}
 
     def get_complex_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2112,7 +2160,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/complex/empty'
+        url = self.get_complex_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2140,6 +2188,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_empty.metadata = {'url': '/array/complex/empty'}
 
     def get_complex_item_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2157,7 +2206,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/complex/itemnull'
+        url = self.get_complex_item_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2185,6 +2234,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_item_null.metadata = {'url': '/array/complex/itemnull'}
 
     def get_complex_item_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2202,7 +2252,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/complex/itemempty'
+        url = self.get_complex_item_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2230,6 +2280,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_item_empty.metadata = {'url': '/array/complex/itemempty'}
 
     def get_complex_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2247,7 +2298,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/complex/valid'
+        url = self.get_complex_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2275,6 +2326,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_valid.metadata = {'url': '/array/complex/valid'}
 
     def put_complex_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -2293,7 +2345,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/complex/valid'
+        url = self.put_complex_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2318,6 +2370,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_complex_valid.metadata = {'url': '/array/complex/valid'}
 
     def get_array_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2333,7 +2386,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/array/null'
+        url = self.get_array_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2361,6 +2414,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_null.metadata = {'url': '/array/array/null'}
 
     def get_array_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2376,7 +2430,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/array/empty'
+        url = self.get_array_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2404,6 +2458,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_empty.metadata = {'url': '/array/array/empty'}
 
     def get_array_item_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2420,7 +2475,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/array/itemnull'
+        url = self.get_array_item_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2448,6 +2503,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_item_null.metadata = {'url': '/array/array/itemnull'}
 
     def get_array_item_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2464,7 +2520,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/array/itemempty'
+        url = self.get_array_item_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2492,6 +2548,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_item_empty.metadata = {'url': '/array/array/itemempty'}
 
     def get_array_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2508,7 +2565,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/array/valid'
+        url = self.get_array_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2536,6 +2593,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_valid.metadata = {'url': '/array/array/valid'}
 
     def put_array_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -2554,7 +2612,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/array/valid'
+        url = self.put_array_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2579,6 +2637,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_array_valid.metadata = {'url': '/array/array/valid'}
 
     def get_dictionary_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2594,7 +2653,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/dictionary/null'
+        url = self.get_dictionary_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2622,6 +2681,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_null.metadata = {'url': '/array/dictionary/null'}
 
     def get_dictionary_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2637,7 +2697,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/dictionary/empty'
+        url = self.get_dictionary_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2665,6 +2725,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_empty.metadata = {'url': '/array/dictionary/empty'}
 
     def get_dictionary_item_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2682,7 +2743,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/dictionary/itemnull'
+        url = self.get_dictionary_item_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2710,6 +2771,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_item_null.metadata = {'url': '/array/dictionary/itemnull'}
 
     def get_dictionary_item_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2727,7 +2789,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/dictionary/itemempty'
+        url = self.get_dictionary_item_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2755,6 +2817,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_item_empty.metadata = {'url': '/array/dictionary/itemempty'}
 
     def get_dictionary_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2772,7 +2835,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/dictionary/valid'
+        url = self.get_dictionary_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2800,6 +2863,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_valid.metadata = {'url': '/array/dictionary/valid'}
 
     def put_dictionary_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -2819,7 +2883,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodyarray.models.ErrorException>`
         """
         # Construct URL
-        url = '/array/dictionary/valid'
+        url = self.put_dictionary_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2844,3 +2908,4 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_dictionary_valid.metadata = {'url': '/array/dictionary/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/operations/bool_model_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/operations/bool_model_operations.py
@@ -47,7 +47,7 @@ class BoolModelOperations(object):
         :raises: :class:`ErrorException<bodyboolean.models.ErrorException>`
         """
         # Construct URL
-        url = '/bool/true'
+        url = self.get_true.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class BoolModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_true.metadata = {'url': '/bool/true'}
 
     def put_true(
             self, custom_headers=None, raw=False, **operation_config):
@@ -92,7 +93,7 @@ class BoolModelOperations(object):
         bool_body = True
 
         # Construct URL
-        url = '/bool/true'
+        url = self.put_true.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -117,6 +118,7 @@ class BoolModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_true.metadata = {'url': '/bool/true'}
 
     def get_false(
             self, custom_headers=None, raw=False, **operation_config):
@@ -132,7 +134,7 @@ class BoolModelOperations(object):
         :raises: :class:`ErrorException<bodyboolean.models.ErrorException>`
         """
         # Construct URL
-        url = '/bool/false'
+        url = self.get_false.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -160,6 +162,7 @@ class BoolModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_false.metadata = {'url': '/bool/false'}
 
     def put_false(
             self, custom_headers=None, raw=False, **operation_config):
@@ -177,7 +180,7 @@ class BoolModelOperations(object):
         bool_body = False
 
         # Construct URL
-        url = '/bool/false'
+        url = self.put_false.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -202,6 +205,7 @@ class BoolModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_false.metadata = {'url': '/bool/false'}
 
     def get_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -217,7 +221,7 @@ class BoolModelOperations(object):
         :raises: :class:`ErrorException<bodyboolean.models.ErrorException>`
         """
         # Construct URL
-        url = '/bool/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -245,6 +249,7 @@ class BoolModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/bool/null'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -260,7 +265,7 @@ class BoolModelOperations(object):
         :raises: :class:`ErrorException<bodyboolean.models.ErrorException>`
         """
         # Construct URL
-        url = '/bool/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -288,3 +293,4 @@ class BoolModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/bool/invalid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/operations/byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/operations/byte_operations.py
@@ -47,7 +47,7 @@ class ByteOperations(object):
         :raises: :class:`ErrorException<bodybyte.models.ErrorException>`
         """
         # Construct URL
-        url = '/byte/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class ByteOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/byte/null'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class ByteOperations(object):
         :raises: :class:`ErrorException<bodybyte.models.ErrorException>`
         """
         # Construct URL
-        url = '/byte/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class ByteOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/byte/empty'}
 
     def get_non_ascii(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class ByteOperations(object):
         :raises: :class:`ErrorException<bodybyte.models.ErrorException>`
         """
         # Construct URL
-        url = '/byte/nonAscii'
+        url = self.get_non_ascii.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class ByteOperations(object):
             return client_raw_response
 
         return deserialized
+    get_non_ascii.metadata = {'url': '/byte/nonAscii'}
 
     def put_non_ascii(
             self, byte_body, custom_headers=None, raw=False, **operation_config):
@@ -179,7 +182,7 @@ class ByteOperations(object):
         :raises: :class:`ErrorException<bodybyte.models.ErrorException>`
         """
         # Construct URL
-        url = '/byte/nonAscii'
+        url = self.put_non_ascii.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class ByteOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_non_ascii.metadata = {'url': '/byte/nonAscii'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -219,7 +223,7 @@ class ByteOperations(object):
         :raises: :class:`ErrorException<bodybyte.models.ErrorException>`
         """
         # Construct URL
-        url = '/byte/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -247,3 +251,4 @@ class ByteOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/byte/invalid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/array_operations.py
@@ -48,7 +48,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/array/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -76,6 +76,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/array/valid'}
 
     def put_valid(
             self, array=None, custom_headers=None, raw=False, **operation_config):
@@ -95,7 +96,7 @@ class ArrayOperations(object):
         complex_body = models.ArrayWrapper(array=array)
 
         # Construct URL
-        url = '/complex/array/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -120,6 +121,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/array/valid'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -136,7 +138,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/array/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -164,6 +166,7 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/complex/array/empty'}
 
     def put_empty(
             self, array=None, custom_headers=None, raw=False, **operation_config):
@@ -183,7 +186,7 @@ class ArrayOperations(object):
         complex_body = models.ArrayWrapper(array=array)
 
         # Construct URL
-        url = '/complex/array/empty'
+        url = self.put_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -208,6 +211,7 @@ class ArrayOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_empty.metadata = {'url': '/complex/array/empty'}
 
     def get_not_provided(
             self, custom_headers=None, raw=False, **operation_config):
@@ -225,7 +229,7 @@ class ArrayOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/array/notprovided'
+        url = self.get_not_provided.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -253,3 +257,4 @@ class ArrayOperations(object):
             return client_raw_response
 
         return deserialized
+    get_not_provided.metadata = {'url': '/complex/array/notprovided'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/basic_operations.py
@@ -50,7 +50,7 @@ class BasicOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/basic/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -78,6 +78,7 @@ class BasicOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/basic/valid'}
 
     def put_valid(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -95,7 +96,7 @@ class BasicOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/basic/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -121,6 +122,7 @@ class BasicOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/basic/valid'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -137,7 +139,7 @@ class BasicOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/basic/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -165,6 +167,7 @@ class BasicOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/complex/basic/invalid'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -181,7 +184,7 @@ class BasicOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/basic/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -209,6 +212,7 @@ class BasicOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/complex/basic/empty'}
 
     def get_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -225,7 +229,7 @@ class BasicOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/basic/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -253,6 +257,7 @@ class BasicOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/complex/basic/null'}
 
     def get_not_provided(
             self, custom_headers=None, raw=False, **operation_config):
@@ -270,7 +275,7 @@ class BasicOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/basic/notprovided'
+        url = self.get_not_provided.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -298,3 +303,4 @@ class BasicOperations(object):
             return client_raw_response
 
         return deserialized
+    get_not_provided.metadata = {'url': '/complex/basic/notprovided'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/dictionary_operations.py
@@ -48,7 +48,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/dictionary/typed/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -76,6 +76,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/dictionary/typed/valid'}
 
     def put_valid(
             self, default_program=None, custom_headers=None, raw=False, **operation_config):
@@ -95,7 +96,7 @@ class DictionaryOperations(object):
         complex_body = models.DictionaryWrapper(default_program=default_program)
 
         # Construct URL
-        url = '/complex/dictionary/typed/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -120,6 +121,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/dictionary/typed/valid'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -136,7 +138,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/dictionary/typed/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -164,6 +166,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/complex/dictionary/typed/empty'}
 
     def put_empty(
             self, default_program=None, custom_headers=None, raw=False, **operation_config):
@@ -183,7 +186,7 @@ class DictionaryOperations(object):
         complex_body = models.DictionaryWrapper(default_program=default_program)
 
         # Construct URL
-        url = '/complex/dictionary/typed/empty'
+        url = self.put_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -208,6 +211,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_empty.metadata = {'url': '/complex/dictionary/typed/empty'}
 
     def get_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -224,7 +228,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/dictionary/typed/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -252,6 +256,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/complex/dictionary/typed/null'}
 
     def get_not_provided(
             self, custom_headers=None, raw=False, **operation_config):
@@ -269,7 +274,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/dictionary/typed/notprovided'
+        url = self.get_not_provided.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -297,3 +302,4 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_not_provided.metadata = {'url': '/complex/dictionary/typed/notprovided'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/inheritance_operations.py
@@ -48,7 +48,7 @@ class InheritanceOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/inheritance/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -76,6 +76,7 @@ class InheritanceOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/inheritance/valid'}
 
     def put_valid(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -96,7 +97,7 @@ class InheritanceOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/inheritance/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -121,3 +122,4 @@ class InheritanceOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/inheritance/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/polymorphicrecursive_operations.py
@@ -47,7 +47,7 @@ class PolymorphicrecursiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphicrecursive/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class PolymorphicrecursiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/polymorphicrecursive/valid'}
 
     def put_valid(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -144,7 +145,7 @@ class PolymorphicrecursiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphicrecursive/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -169,3 +170,4 @@ class PolymorphicrecursiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/polymorphicrecursive/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/polymorphism_operations.py
@@ -47,7 +47,7 @@ class PolymorphismOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphism/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class PolymorphismOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/polymorphism/valid'}
 
     def put_valid(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -124,7 +125,7 @@ class PolymorphismOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphism/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -149,6 +150,7 @@ class PolymorphismOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/polymorphism/valid'}
 
     def get_complicated(
             self, custom_headers=None, raw=False, **operation_config):
@@ -166,7 +168,7 @@ class PolymorphismOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphism/complicated'
+        url = self.get_complicated.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -194,6 +196,7 @@ class PolymorphismOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complicated.metadata = {'url': '/complex/polymorphism/complicated'}
 
     def put_complicated(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -212,7 +215,7 @@ class PolymorphismOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphism/complicated'
+        url = self.put_complicated.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -237,6 +240,7 @@ class PolymorphismOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_complicated.metadata = {'url': '/complex/polymorphism/complicated'}
 
     def put_missing_discriminator(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -255,7 +259,7 @@ class PolymorphismOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphism/missingdiscriminator'
+        url = self.put_missing_discriminator.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -287,6 +291,7 @@ class PolymorphismOperations(object):
             return client_raw_response
 
         return deserialized
+    put_missing_discriminator.metadata = {'url': '/complex/polymorphism/missingdiscriminator'}
 
     def put_valid_missing_required(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -331,7 +336,7 @@ class PolymorphismOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/polymorphism/missingrequired/invalid'
+        url = self.put_valid_missing_required.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -356,3 +361,4 @@ class PolymorphismOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid_missing_required.metadata = {'url': '/complex/polymorphism/missingrequired/invalid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/primitive_operations.py
@@ -48,7 +48,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/integer'
+        url = self.get_int.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -76,6 +76,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_int.metadata = {'url': '/complex/primitive/integer'}
 
     def put_int(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -93,7 +94,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/integer'
+        url = self.put_int.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_int.metadata = {'url': '/complex/primitive/integer'}
 
     def get_long(
             self, custom_headers=None, raw=False, **operation_config):
@@ -134,7 +136,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/long'
+        url = self.get_long.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -162,6 +164,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long.metadata = {'url': '/complex/primitive/long'}
 
     def put_long(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -179,7 +182,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/long'
+        url = self.put_long.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_long.metadata = {'url': '/complex/primitive/long'}
 
     def get_float(
             self, custom_headers=None, raw=False, **operation_config):
@@ -220,7 +224,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/float'
+        url = self.get_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -248,6 +252,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float.metadata = {'url': '/complex/primitive/float'}
 
     def put_float(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -265,7 +270,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/float'
+        url = self.put_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -290,6 +295,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_float.metadata = {'url': '/complex/primitive/float'}
 
     def get_double(
             self, custom_headers=None, raw=False, **operation_config):
@@ -306,7 +312,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/double'
+        url = self.get_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -334,6 +340,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double.metadata = {'url': '/complex/primitive/double'}
 
     def put_double(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -352,7 +359,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/double'
+        url = self.put_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -377,6 +384,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_double.metadata = {'url': '/complex/primitive/double'}
 
     def get_bool(
             self, custom_headers=None, raw=False, **operation_config):
@@ -393,7 +401,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/bool'
+        url = self.get_bool.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -421,6 +429,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_bool.metadata = {'url': '/complex/primitive/bool'}
 
     def put_bool(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -438,7 +447,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/bool'
+        url = self.put_bool.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -463,6 +472,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_bool.metadata = {'url': '/complex/primitive/bool'}
 
     def get_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -479,7 +489,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/string'
+        url = self.get_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -507,6 +517,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string.metadata = {'url': '/complex/primitive/string'}
 
     def put_string(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -524,7 +535,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/string'
+        url = self.put_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -549,6 +560,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_string.metadata = {'url': '/complex/primitive/string'}
 
     def get_date(
             self, custom_headers=None, raw=False, **operation_config):
@@ -565,7 +577,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/date'
+        url = self.get_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -593,6 +605,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date.metadata = {'url': '/complex/primitive/date'}
 
     def put_date(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -610,7 +623,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/date'
+        url = self.put_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -635,6 +648,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date.metadata = {'url': '/complex/primitive/date'}
 
     def get_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -651,7 +665,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/datetime'
+        url = self.get_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -679,6 +693,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time.metadata = {'url': '/complex/primitive/datetime'}
 
     def put_date_time(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -697,7 +712,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/datetime'
+        url = self.put_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -722,6 +737,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_time.metadata = {'url': '/complex/primitive/datetime'}
 
     def get_date_time_rfc1123(
             self, custom_headers=None, raw=False, **operation_config):
@@ -738,7 +754,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/datetimerfc1123'
+        url = self.get_date_time_rfc1123.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -766,6 +782,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_rfc1123.metadata = {'url': '/complex/primitive/datetimerfc1123'}
 
     def put_date_time_rfc1123(
             self, complex_body, custom_headers=None, raw=False, **operation_config):
@@ -784,7 +801,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/datetimerfc1123'
+        url = self.put_date_time_rfc1123.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -809,6 +826,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_time_rfc1123.metadata = {'url': '/complex/primitive/datetimerfc1123'}
 
     def get_duration(
             self, custom_headers=None, raw=False, **operation_config):
@@ -825,7 +843,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/duration'
+        url = self.get_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -853,6 +871,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_duration.metadata = {'url': '/complex/primitive/duration'}
 
     def put_duration(
             self, field=None, custom_headers=None, raw=False, **operation_config):
@@ -872,7 +891,7 @@ class PrimitiveOperations(object):
         complex_body = models.DurationWrapper(field=field)
 
         # Construct URL
-        url = '/complex/primitive/duration'
+        url = self.put_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -897,6 +916,7 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_duration.metadata = {'url': '/complex/primitive/duration'}
 
     def get_byte(
             self, custom_headers=None, raw=False, **operation_config):
@@ -913,7 +933,7 @@ class PrimitiveOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/primitive/byte'
+        url = self.get_byte.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -941,6 +961,7 @@ class PrimitiveOperations(object):
             return client_raw_response
 
         return deserialized
+    get_byte.metadata = {'url': '/complex/primitive/byte'}
 
     def put_byte(
             self, field=None, custom_headers=None, raw=False, **operation_config):
@@ -960,7 +981,7 @@ class PrimitiveOperations(object):
         complex_body = models.ByteWrapper(field=field)
 
         # Construct URL
-        url = '/complex/primitive/byte'
+        url = self.put_byte.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -985,3 +1006,4 @@ class PrimitiveOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_byte.metadata = {'url': '/complex/primitive/byte'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/readonlyproperty_operations.py
@@ -48,7 +48,7 @@ class ReadonlypropertyOperations(object):
         :raises: :class:`ErrorException<bodycomplex.models.ErrorException>`
         """
         # Construct URL
-        url = '/complex/readonlyproperty/valid'
+        url = self.get_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -76,6 +76,7 @@ class ReadonlypropertyOperations(object):
             return client_raw_response
 
         return deserialized
+    get_valid.metadata = {'url': '/complex/readonlyproperty/valid'}
 
     def put_valid(
             self, size=None, custom_headers=None, raw=False, **operation_config):
@@ -95,7 +96,7 @@ class ReadonlypropertyOperations(object):
         complex_body = models.ReadonlyObj(size=size)
 
         # Construct URL
-        url = '/complex/readonlyproperty/valid'
+        url = self.put_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -120,3 +121,4 @@ class ReadonlypropertyOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_valid.metadata = {'url': '/complex/readonlyproperty/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/operations/date_model_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/operations/date_model_operations.py
@@ -47,7 +47,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class DateModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/date/null'}
 
     def get_invalid_date(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/invaliddate'
+        url = self.get_invalid_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class DateModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid_date.metadata = {'url': '/date/invaliddate'}
 
     def get_overflow_date(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/overflowdate'
+        url = self.get_overflow_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class DateModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_overflow_date.metadata = {'url': '/date/overflowdate'}
 
     def get_underflow_date(
             self, custom_headers=None, raw=False, **operation_config):
@@ -176,7 +179,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/underflowdate'
+        url = self.get_underflow_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class DateModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_underflow_date.metadata = {'url': '/date/underflowdate'}
 
     def put_max_date(
             self, date_body, custom_headers=None, raw=False, **operation_config):
@@ -221,7 +225,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/max'
+        url = self.put_max_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -246,6 +250,7 @@ class DateModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_max_date.metadata = {'url': '/date/max'}
 
     def get_max_date(
             self, custom_headers=None, raw=False, **operation_config):
@@ -261,7 +266,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/max'
+        url = self.get_max_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -289,6 +294,7 @@ class DateModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_max_date.metadata = {'url': '/date/max'}
 
     def put_min_date(
             self, date_body, custom_headers=None, raw=False, **operation_config):
@@ -306,7 +312,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/min'
+        url = self.put_min_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -331,6 +337,7 @@ class DateModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_min_date.metadata = {'url': '/date/min'}
 
     def get_min_date(
             self, custom_headers=None, raw=False, **operation_config):
@@ -346,7 +353,7 @@ class DateModelOperations(object):
         :raises: :class:`ErrorException<bodydate.models.ErrorException>`
         """
         # Construct URL
-        url = '/date/min'
+        url = self.get_min_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -374,3 +381,4 @@ class DateModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_min_date.metadata = {'url': '/date/min'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/operations/datetime_model_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/operations/datetime_model_operations.py
@@ -47,7 +47,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/datetime/null'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/datetime/invalid'}
 
     def get_overflow(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/overflow'
+        url = self.get_overflow.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_overflow.metadata = {'url': '/datetime/overflow'}
 
     def get_underflow(
             self, custom_headers=None, raw=False, **operation_config):
@@ -176,7 +179,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/underflow'
+        url = self.get_underflow.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_underflow.metadata = {'url': '/datetime/underflow'}
 
     def put_utc_max_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -221,7 +225,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/utc'
+        url = self.put_utc_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -246,6 +250,7 @@ class DatetimeModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_utc_max_date_time.metadata = {'url': '/datetime/max/utc'}
 
     def get_utc_lowercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -261,7 +266,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/utc/lowercase'
+        url = self.get_utc_lowercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -289,6 +294,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_utc_lowercase_max_date_time.metadata = {'url': '/datetime/max/utc/lowercase'}
 
     def get_utc_uppercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -304,7 +310,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/utc/uppercase'
+        url = self.get_utc_uppercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -332,6 +338,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_utc_uppercase_max_date_time.metadata = {'url': '/datetime/max/utc/uppercase'}
 
     def put_local_positive_offset_max_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -350,7 +357,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/localpositiveoffset'
+        url = self.put_local_positive_offset_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -375,6 +382,7 @@ class DatetimeModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_local_positive_offset_max_date_time.metadata = {'url': '/datetime/max/localpositiveoffset'}
 
     def get_local_positive_offset_lowercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -391,7 +399,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/localpositiveoffset/lowercase'
+        url = self.get_local_positive_offset_lowercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -419,6 +427,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_local_positive_offset_lowercase_max_date_time.metadata = {'url': '/datetime/max/localpositiveoffset/lowercase'}
 
     def get_local_positive_offset_uppercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -435,7 +444,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/localpositiveoffset/uppercase'
+        url = self.get_local_positive_offset_uppercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -463,6 +472,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_local_positive_offset_uppercase_max_date_time.metadata = {'url': '/datetime/max/localpositiveoffset/uppercase'}
 
     def put_local_negative_offset_max_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -481,7 +491,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/localnegativeoffset'
+        url = self.put_local_negative_offset_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -506,6 +516,7 @@ class DatetimeModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_local_negative_offset_max_date_time.metadata = {'url': '/datetime/max/localnegativeoffset'}
 
     def get_local_negative_offset_uppercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -522,7 +533,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/localnegativeoffset/uppercase'
+        url = self.get_local_negative_offset_uppercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -550,6 +561,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_local_negative_offset_uppercase_max_date_time.metadata = {'url': '/datetime/max/localnegativeoffset/uppercase'}
 
     def get_local_negative_offset_lowercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -566,7 +578,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/max/localnegativeoffset/lowercase'
+        url = self.get_local_negative_offset_lowercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -594,6 +606,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_local_negative_offset_lowercase_max_date_time.metadata = {'url': '/datetime/max/localnegativeoffset/lowercase'}
 
     def put_utc_min_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -611,7 +624,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/min/utc'
+        url = self.put_utc_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -636,6 +649,7 @@ class DatetimeModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_utc_min_date_time.metadata = {'url': '/datetime/min/utc'}
 
     def get_utc_min_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -651,7 +665,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/min/utc'
+        url = self.get_utc_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -679,6 +693,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_utc_min_date_time.metadata = {'url': '/datetime/min/utc'}
 
     def put_local_positive_offset_min_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -696,7 +711,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/min/localpositiveoffset'
+        url = self.put_local_positive_offset_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -721,6 +736,7 @@ class DatetimeModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_local_positive_offset_min_date_time.metadata = {'url': '/datetime/min/localpositiveoffset'}
 
     def get_local_positive_offset_min_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -736,7 +752,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/min/localpositiveoffset'
+        url = self.get_local_positive_offset_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -764,6 +780,7 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_local_positive_offset_min_date_time.metadata = {'url': '/datetime/min/localpositiveoffset'}
 
     def put_local_negative_offset_min_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -781,7 +798,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/min/localnegativeoffset'
+        url = self.put_local_negative_offset_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -806,6 +823,7 @@ class DatetimeModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_local_negative_offset_min_date_time.metadata = {'url': '/datetime/min/localnegativeoffset'}
 
     def get_local_negative_offset_min_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -821,7 +839,7 @@ class DatetimeModelOperations(object):
         :raises: :class:`ErrorException<bodydatetime.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetime/min/localnegativeoffset'
+        url = self.get_local_negative_offset_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -849,3 +867,4 @@ class DatetimeModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_local_negative_offset_min_date_time.metadata = {'url': '/datetime/min/localnegativeoffset'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/operations/datetimerfc1123_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/operations/datetimerfc1123_operations.py
@@ -48,7 +48,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -76,6 +76,7 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/datetimerfc1123/null'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -92,7 +93,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -120,6 +121,7 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/datetimerfc1123/invalid'}
 
     def get_overflow(
             self, custom_headers=None, raw=False, **operation_config):
@@ -136,7 +138,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/overflow'
+        url = self.get_overflow.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -164,6 +166,7 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_overflow.metadata = {'url': '/datetimerfc1123/overflow'}
 
     def get_underflow(
             self, custom_headers=None, raw=False, **operation_config):
@@ -180,7 +183,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/underflow'
+        url = self.get_underflow.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -208,6 +211,7 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_underflow.metadata = {'url': '/datetimerfc1123/underflow'}
 
     def put_utc_max_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -226,7 +230,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/max'
+        url = self.put_utc_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -251,6 +255,7 @@ class Datetimerfc1123Operations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_utc_max_date_time.metadata = {'url': '/datetimerfc1123/max'}
 
     def get_utc_lowercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -267,7 +272,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/max/lowercase'
+        url = self.get_utc_lowercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -295,6 +300,7 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_utc_lowercase_max_date_time.metadata = {'url': '/datetimerfc1123/max/lowercase'}
 
     def get_utc_uppercase_max_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -311,7 +317,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/max/uppercase'
+        url = self.get_utc_uppercase_max_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -339,6 +345,7 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_utc_uppercase_max_date_time.metadata = {'url': '/datetimerfc1123/max/uppercase'}
 
     def put_utc_min_date_time(
             self, datetime_body, custom_headers=None, raw=False, **operation_config):
@@ -357,7 +364,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/min'
+        url = self.put_utc_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -382,6 +389,7 @@ class Datetimerfc1123Operations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_utc_min_date_time.metadata = {'url': '/datetimerfc1123/min'}
 
     def get_utc_min_date_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -398,7 +406,7 @@ class Datetimerfc1123Operations(object):
          :class:`ErrorException<bodydatetimerfc1123.models.ErrorException>`
         """
         # Construct URL
-        url = '/datetimerfc1123/min'
+        url = self.get_utc_min_date_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -426,3 +434,4 @@ class Datetimerfc1123Operations(object):
             return client_raw_response
 
         return deserialized
+    get_utc_min_date_time.metadata = {'url': '/datetimerfc1123/min'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/dictionary_operations.py
@@ -47,7 +47,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/dictionary/null'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/dictionary/empty'}
 
     def put_empty(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -135,7 +137,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/empty'
+        url = self.put_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -160,6 +162,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_empty.metadata = {'url': '/dictionary/empty'}
 
     def get_null_value(
             self, custom_headers=None, raw=False, **operation_config):
@@ -175,7 +178,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/nullvalue'
+        url = self.get_null_value.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -203,6 +206,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null_value.metadata = {'url': '/dictionary/nullvalue'}
 
     def get_null_key(
             self, custom_headers=None, raw=False, **operation_config):
@@ -218,7 +222,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/nullkey'
+        url = self.get_null_key.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -246,6 +250,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null_key.metadata = {'url': '/dictionary/nullkey'}
 
     def get_empty_string_key(
             self, custom_headers=None, raw=False, **operation_config):
@@ -261,7 +266,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/keyemptystring'
+        url = self.get_empty_string_key.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -289,6 +294,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty_string_key.metadata = {'url': '/dictionary/keyemptystring'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -304,7 +310,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -332,6 +338,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/dictionary/invalid'}
 
     def get_boolean_tfft(
             self, custom_headers=None, raw=False, **operation_config):
@@ -348,7 +355,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/boolean/tfft'
+        url = self.get_boolean_tfft.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -376,6 +383,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_boolean_tfft.metadata = {'url': '/dictionary/prim/boolean/tfft'}
 
     def put_boolean_tfft(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -394,7 +402,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/boolean/tfft'
+        url = self.put_boolean_tfft.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -419,6 +427,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_boolean_tfft.metadata = {'url': '/dictionary/prim/boolean/tfft'}
 
     def get_boolean_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -434,7 +443,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/boolean/true.null.false'
+        url = self.get_boolean_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -462,6 +471,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_boolean_invalid_null.metadata = {'url': '/dictionary/prim/boolean/true.null.false'}
 
     def get_boolean_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -477,7 +487,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/boolean/true.boolean.false'
+        url = self.get_boolean_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -505,6 +515,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_boolean_invalid_string.metadata = {'url': '/dictionary/prim/boolean/true.boolean.false'}
 
     def get_integer_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -520,7 +531,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/integer/1.-1.3.300'
+        url = self.get_integer_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -548,6 +559,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_integer_valid.metadata = {'url': '/dictionary/prim/integer/1.-1.3.300'}
 
     def put_integer_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -565,7 +577,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/integer/1.-1.3.300'
+        url = self.put_integer_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -590,6 +602,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_integer_valid.metadata = {'url': '/dictionary/prim/integer/1.-1.3.300'}
 
     def get_int_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -605,7 +618,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/integer/1.null.zero'
+        url = self.get_int_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -633,6 +646,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_int_invalid_null.metadata = {'url': '/dictionary/prim/integer/1.null.zero'}
 
     def get_int_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -648,7 +662,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/integer/1.integer.0'
+        url = self.get_int_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -676,6 +690,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_int_invalid_string.metadata = {'url': '/dictionary/prim/integer/1.integer.0'}
 
     def get_long_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -691,7 +706,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/long/1.-1.3.300'
+        url = self.get_long_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -719,6 +734,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long_valid.metadata = {'url': '/dictionary/prim/long/1.-1.3.300'}
 
     def put_long_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -736,7 +752,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/long/1.-1.3.300'
+        url = self.put_long_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -761,6 +777,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_long_valid.metadata = {'url': '/dictionary/prim/long/1.-1.3.300'}
 
     def get_long_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -776,7 +793,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/long/1.null.zero'
+        url = self.get_long_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -804,6 +821,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long_invalid_null.metadata = {'url': '/dictionary/prim/long/1.null.zero'}
 
     def get_long_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -819,7 +837,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/long/1.integer.0'
+        url = self.get_long_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -847,6 +865,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_long_invalid_string.metadata = {'url': '/dictionary/prim/long/1.integer.0'}
 
     def get_float_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -862,7 +881,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/float/0--0.01-1.2e20'
+        url = self.get_float_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -890,6 +909,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float_valid.metadata = {'url': '/dictionary/prim/float/0--0.01-1.2e20'}
 
     def put_float_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -907,7 +927,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/float/0--0.01-1.2e20'
+        url = self.put_float_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -932,6 +952,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_float_valid.metadata = {'url': '/dictionary/prim/float/0--0.01-1.2e20'}
 
     def get_float_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -947,7 +968,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/float/0.0-null-1.2e20'
+        url = self.get_float_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -975,6 +996,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float_invalid_null.metadata = {'url': '/dictionary/prim/float/0.0-null-1.2e20'}
 
     def get_float_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -990,7 +1012,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/float/1.number.0'
+        url = self.get_float_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1018,6 +1040,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_float_invalid_string.metadata = {'url': '/dictionary/prim/float/1.number.0'}
 
     def get_double_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1033,7 +1056,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/double/0--0.01-1.2e20'
+        url = self.get_double_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1061,6 +1084,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double_valid.metadata = {'url': '/dictionary/prim/double/0--0.01-1.2e20'}
 
     def put_double_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1078,7 +1102,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/double/0--0.01-1.2e20'
+        url = self.put_double_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1103,6 +1127,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_double_valid.metadata = {'url': '/dictionary/prim/double/0--0.01-1.2e20'}
 
     def get_double_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1118,7 +1143,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/double/0.0-null-1.2e20'
+        url = self.get_double_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1146,6 +1171,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double_invalid_null.metadata = {'url': '/dictionary/prim/double/0.0-null-1.2e20'}
 
     def get_double_invalid_string(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1161,7 +1187,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/double/1.number.0'
+        url = self.get_double_invalid_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1189,6 +1215,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_double_invalid_string.metadata = {'url': '/dictionary/prim/double/1.number.0'}
 
     def get_string_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1204,7 +1231,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/string/foo1.foo2.foo3'
+        url = self.get_string_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1232,6 +1259,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string_valid.metadata = {'url': '/dictionary/prim/string/foo1.foo2.foo3'}
 
     def put_string_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1249,7 +1277,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/string/foo1.foo2.foo3'
+        url = self.put_string_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1274,6 +1302,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_string_valid.metadata = {'url': '/dictionary/prim/string/foo1.foo2.foo3'}
 
     def get_string_with_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1289,7 +1318,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/string/foo.null.foo2'
+        url = self.get_string_with_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1317,6 +1346,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string_with_null.metadata = {'url': '/dictionary/prim/string/foo.null.foo2'}
 
     def get_string_with_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1332,7 +1362,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/string/foo.123.foo2'
+        url = self.get_string_with_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1360,6 +1390,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_string_with_invalid.metadata = {'url': '/dictionary/prim/string/foo.123.foo2'}
 
     def get_date_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1376,7 +1407,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date/valid'
+        url = self.get_date_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1404,6 +1435,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_valid.metadata = {'url': '/dictionary/prim/date/valid'}
 
     def put_date_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1422,7 +1454,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date/valid'
+        url = self.put_date_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1447,6 +1479,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_valid.metadata = {'url': '/dictionary/prim/date/valid'}
 
     def get_date_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1463,7 +1496,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date/invalidnull'
+        url = self.get_date_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1491,6 +1524,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_invalid_null.metadata = {'url': '/dictionary/prim/date/invalidnull'}
 
     def get_date_invalid_chars(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1506,7 +1540,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date/invalidchars'
+        url = self.get_date_invalid_chars.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1534,6 +1568,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_invalid_chars.metadata = {'url': '/dictionary/prim/date/invalidchars'}
 
     def get_date_time_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1550,7 +1585,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date-time/valid'
+        url = self.get_date_time_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1578,6 +1613,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_valid.metadata = {'url': '/dictionary/prim/date-time/valid'}
 
     def put_date_time_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1596,7 +1632,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date-time/valid'
+        url = self.put_date_time_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1621,6 +1657,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_time_valid.metadata = {'url': '/dictionary/prim/date-time/valid'}
 
     def get_date_time_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1636,7 +1673,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date-time/invalidnull'
+        url = self.get_date_time_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1664,6 +1701,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_invalid_null.metadata = {'url': '/dictionary/prim/date-time/invalidnull'}
 
     def get_date_time_invalid_chars(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1680,7 +1718,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date-time/invalidchars'
+        url = self.get_date_time_invalid_chars.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1708,6 +1746,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_invalid_chars.metadata = {'url': '/dictionary/prim/date-time/invalidchars'}
 
     def get_date_time_rfc1123_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1725,7 +1764,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date-time-rfc1123/valid'
+        url = self.get_date_time_rfc1123_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1753,6 +1792,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_date_time_rfc1123_valid.metadata = {'url': '/dictionary/prim/date-time-rfc1123/valid'}
 
     def put_date_time_rfc1123_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1771,7 +1811,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/date-time-rfc1123/valid'
+        url = self.put_date_time_rfc1123_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1796,6 +1836,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_date_time_rfc1123_valid.metadata = {'url': '/dictionary/prim/date-time-rfc1123/valid'}
 
     def get_duration_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1812,7 +1853,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/duration/valid'
+        url = self.get_duration_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1840,6 +1881,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_duration_valid.metadata = {'url': '/dictionary/prim/duration/valid'}
 
     def put_duration_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1857,7 +1899,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/duration/valid'
+        url = self.put_duration_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1882,6 +1924,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_duration_valid.metadata = {'url': '/dictionary/prim/duration/valid'}
 
     def get_byte_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1898,7 +1941,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/byte/valid'
+        url = self.get_byte_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1926,6 +1969,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_byte_valid.metadata = {'url': '/dictionary/prim/byte/valid'}
 
     def put_byte_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -1944,7 +1988,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/byte/valid'
+        url = self.put_byte_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1969,6 +2013,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_byte_valid.metadata = {'url': '/dictionary/prim/byte/valid'}
 
     def get_byte_invalid_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1985,7 +2030,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/byte/invalidnull'
+        url = self.get_byte_invalid_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2013,6 +2058,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_byte_invalid_null.metadata = {'url': '/dictionary/prim/byte/invalidnull'}
 
     def get_base64_url(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2029,7 +2075,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/prim/base64url/valid'
+        url = self.get_base64_url.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2057,6 +2103,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_base64_url.metadata = {'url': '/dictionary/prim/base64url/valid'}
 
     def get_complex_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2073,7 +2120,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/complex/null'
+        url = self.get_complex_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2101,6 +2148,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_null.metadata = {'url': '/dictionary/complex/null'}
 
     def get_complex_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2117,7 +2165,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/complex/empty'
+        url = self.get_complex_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2145,6 +2193,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_empty.metadata = {'url': '/dictionary/complex/empty'}
 
     def get_complex_item_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2162,7 +2211,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/complex/itemnull'
+        url = self.get_complex_item_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2190,6 +2239,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_item_null.metadata = {'url': '/dictionary/complex/itemnull'}
 
     def get_complex_item_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2207,7 +2257,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/complex/itemempty'
+        url = self.get_complex_item_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2235,6 +2285,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_item_empty.metadata = {'url': '/dictionary/complex/itemempty'}
 
     def get_complex_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2253,7 +2304,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/complex/valid'
+        url = self.get_complex_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2281,6 +2332,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_complex_valid.metadata = {'url': '/dictionary/complex/valid'}
 
     def put_complex_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -2300,7 +2352,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/complex/valid'
+        url = self.put_complex_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2325,6 +2377,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_complex_valid.metadata = {'url': '/dictionary/complex/valid'}
 
     def get_array_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2340,7 +2393,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/array/null'
+        url = self.get_array_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2368,6 +2421,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_null.metadata = {'url': '/dictionary/array/null'}
 
     def get_array_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2383,7 +2437,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/array/empty'
+        url = self.get_array_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2411,6 +2465,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_empty.metadata = {'url': '/dictionary/array/empty'}
 
     def get_array_item_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2427,7 +2482,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/array/itemnull'
+        url = self.get_array_item_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2455,6 +2510,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_item_null.metadata = {'url': '/dictionary/array/itemnull'}
 
     def get_array_item_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2471,7 +2527,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/array/itemempty'
+        url = self.get_array_item_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2499,6 +2555,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_item_empty.metadata = {'url': '/dictionary/array/itemempty'}
 
     def get_array_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2515,7 +2572,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/array/valid'
+        url = self.get_array_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2543,6 +2600,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_array_valid.metadata = {'url': '/dictionary/array/valid'}
 
     def put_array_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -2561,7 +2619,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/array/valid'
+        url = self.put_array_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2586,6 +2644,7 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_array_valid.metadata = {'url': '/dictionary/array/valid'}
 
     def get_dictionary_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2602,7 +2661,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/dictionary/null'
+        url = self.get_dictionary_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2630,6 +2689,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_null.metadata = {'url': '/dictionary/dictionary/null'}
 
     def get_dictionary_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2647,7 +2707,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/dictionary/empty'
+        url = self.get_dictionary_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2675,6 +2735,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_empty.metadata = {'url': '/dictionary/dictionary/empty'}
 
     def get_dictionary_item_null(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2693,7 +2754,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/dictionary/itemnull'
+        url = self.get_dictionary_item_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2721,6 +2782,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_item_null.metadata = {'url': '/dictionary/dictionary/itemnull'}
 
     def get_dictionary_item_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2739,7 +2801,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/dictionary/itemempty'
+        url = self.get_dictionary_item_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2767,6 +2829,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_item_empty.metadata = {'url': '/dictionary/dictionary/itemempty'}
 
     def get_dictionary_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -2785,7 +2848,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/dictionary/valid'
+        url = self.get_dictionary_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2813,6 +2876,7 @@ class DictionaryOperations(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary_valid.metadata = {'url': '/dictionary/dictionary/valid'}
 
     def put_dictionary_valid(
             self, array_body, custom_headers=None, raw=False, **operation_config):
@@ -2832,7 +2896,7 @@ class DictionaryOperations(object):
         :raises: :class:`ErrorException<bodydictionary.models.ErrorException>`
         """
         # Construct URL
-        url = '/dictionary/dictionary/valid'
+        url = self.put_dictionary_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -2857,3 +2921,4 @@ class DictionaryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_dictionary_valid.metadata = {'url': '/dictionary/dictionary/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/operations/duration_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/operations/duration_operations.py
@@ -47,7 +47,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class DurationOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/duration/null'}
 
     def put_positive_duration(
             self, duration_body, custom_headers=None, raw=False, **operation_config):
@@ -92,7 +93,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/positiveduration'
+        url = self.put_positive_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -117,6 +118,7 @@ class DurationOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_positive_duration.metadata = {'url': '/duration/positiveduration'}
 
     def get_positive_duration(
             self, custom_headers=None, raw=False, **operation_config):
@@ -132,7 +134,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/positiveduration'
+        url = self.get_positive_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -160,6 +162,7 @@ class DurationOperations(object):
             return client_raw_response
 
         return deserialized
+    get_positive_duration.metadata = {'url': '/duration/positiveduration'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -175,7 +178,7 @@ class DurationOperations(object):
         :raises: :class:`ErrorException<bodyduration.models.ErrorException>`
         """
         # Construct URL
-        url = '/duration/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -203,3 +206,4 @@ class DurationOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/duration/invalid'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/operations/files_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/operations/files_operations.py
@@ -52,7 +52,7 @@ class FilesOperations(object):
         :raises: :class:`ErrorException<bodyfile.models.ErrorException>`
         """
         # Construct URL
-        url = '/files/stream/nonempty'
+        url = self.get_file.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -80,6 +80,7 @@ class FilesOperations(object):
             return client_raw_response
 
         return deserialized
+    get_file.metadata = {'url': '/files/stream/nonempty'}
 
     def get_file_large(
             self, custom_headers=None, raw=False, callback=None, **operation_config):
@@ -100,7 +101,7 @@ class FilesOperations(object):
         :raises: :class:`ErrorException<bodyfile.models.ErrorException>`
         """
         # Construct URL
-        url = '/files/stream/verylarge'
+        url = self.get_file_large.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -128,6 +129,7 @@ class FilesOperations(object):
             return client_raw_response
 
         return deserialized
+    get_file_large.metadata = {'url': '/files/stream/verylarge'}
 
     def get_empty_file(
             self, custom_headers=None, raw=False, callback=None, **operation_config):
@@ -148,7 +150,7 @@ class FilesOperations(object):
         :raises: :class:`ErrorException<bodyfile.models.ErrorException>`
         """
         # Construct URL
-        url = '/files/stream/empty'
+        url = self.get_empty_file.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -176,3 +178,4 @@ class FilesOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty_file.metadata = {'url': '/files/stream/empty'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/operations/formdata_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/operations/formdata_operations.py
@@ -57,7 +57,7 @@ class FormdataOperations(object):
         :raises: :class:`ErrorException<bodyformdata.models.ErrorException>`
         """
         # Construct URL
-        url = '/formdata/stream/uploadfile'
+        url = self.upload_file.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -92,6 +92,7 @@ class FormdataOperations(object):
             return client_raw_response
 
         return deserialized
+    upload_file.metadata = {'url': '/formdata/stream/uploadfile'}
 
     def upload_file_via_body(
             self, file_content, custom_headers=None, raw=False, callback=None, **operation_config):
@@ -114,7 +115,7 @@ class FormdataOperations(object):
         :raises: :class:`ErrorException<bodyformdata.models.ErrorException>`
         """
         # Construct URL
-        url = '/formdata/stream/uploadfile'
+        url = self.upload_file_via_body.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -146,3 +147,4 @@ class FormdataOperations(object):
             return client_raw_response
 
         return deserialized
+    upload_file_via_body.metadata = {'url': '/formdata/stream/uploadfile'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/operations/int_model_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/operations/int_model_operations.py
@@ -47,7 +47,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/int/null'}
 
     def get_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/invalid'
+        url = self.get_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid.metadata = {'url': '/int/invalid'}
 
     def get_overflow_int32(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/overflowint32'
+        url = self.get_overflow_int32.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_overflow_int32.metadata = {'url': '/int/overflowint32'}
 
     def get_underflow_int32(
             self, custom_headers=None, raw=False, **operation_config):
@@ -176,7 +179,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/underflowint32'
+        url = self.get_underflow_int32.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_underflow_int32.metadata = {'url': '/int/underflowint32'}
 
     def get_overflow_int64(
             self, custom_headers=None, raw=False, **operation_config):
@@ -219,7 +223,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/overflowint64'
+        url = self.get_overflow_int64.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -247,6 +251,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_overflow_int64.metadata = {'url': '/int/overflowint64'}
 
     def get_underflow_int64(
             self, custom_headers=None, raw=False, **operation_config):
@@ -262,7 +267,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/underflowint64'
+        url = self.get_underflow_int64.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -290,6 +295,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_underflow_int64.metadata = {'url': '/int/underflowint64'}
 
     def put_max32(
             self, int_body, custom_headers=None, raw=False, **operation_config):
@@ -307,7 +313,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/max/32'
+        url = self.put_max32.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -332,6 +338,7 @@ class IntModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_max32.metadata = {'url': '/int/max/32'}
 
     def put_max64(
             self, int_body, custom_headers=None, raw=False, **operation_config):
@@ -349,7 +356,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/max/64'
+        url = self.put_max64.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -374,6 +381,7 @@ class IntModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_max64.metadata = {'url': '/int/max/64'}
 
     def put_min32(
             self, int_body, custom_headers=None, raw=False, **operation_config):
@@ -391,7 +399,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/min/32'
+        url = self.put_min32.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -416,6 +424,7 @@ class IntModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_min32.metadata = {'url': '/int/min/32'}
 
     def put_min64(
             self, int_body, custom_headers=None, raw=False, **operation_config):
@@ -433,7 +442,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/min/64'
+        url = self.put_min64.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -458,6 +467,7 @@ class IntModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_min64.metadata = {'url': '/int/min/64'}
 
     def get_unix_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -473,7 +483,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/unixtime'
+        url = self.get_unix_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -501,6 +511,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_unix_time.metadata = {'url': '/int/unixtime'}
 
     def put_unix_time_date(
             self, int_body, custom_headers=None, raw=False, **operation_config):
@@ -518,7 +529,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/unixtime'
+        url = self.put_unix_time_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -543,6 +554,7 @@ class IntModelOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_unix_time_date.metadata = {'url': '/int/unixtime'}
 
     def get_invalid_unix_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -558,7 +570,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/invalidunixtime'
+        url = self.get_invalid_unix_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -586,6 +598,7 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid_unix_time.metadata = {'url': '/int/invalidunixtime'}
 
     def get_null_unix_time(
             self, custom_headers=None, raw=False, **operation_config):
@@ -601,7 +614,7 @@ class IntModelOperations(object):
         :raises: :class:`ErrorException<bodyinteger.models.ErrorException>`
         """
         # Construct URL
-        url = '/int/nullunixtime'
+        url = self.get_null_unix_time.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -629,3 +642,4 @@ class IntModelOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null_unix_time.metadata = {'url': '/int/nullunixtime'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/operations/number_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/operations/number_operations.py
@@ -47,7 +47,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/number/null'}
 
     def get_invalid_float(
             self, custom_headers=None, raw=False, **operation_config):
@@ -90,7 +91,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/invalidfloat'
+        url = self.get_invalid_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -118,6 +119,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid_float.metadata = {'url': '/number/invalidfloat'}
 
     def get_invalid_double(
             self, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/invaliddouble'
+        url = self.get_invalid_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid_double.metadata = {'url': '/number/invaliddouble'}
 
     def get_invalid_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -176,7 +179,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/invaliddecimal'
+        url = self.get_invalid_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_invalid_decimal.metadata = {'url': '/number/invaliddecimal'}
 
     def put_big_float(
             self, number_body, custom_headers=None, raw=False, **operation_config):
@@ -221,7 +225,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/float/3.402823e+20'
+        url = self.put_big_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -246,6 +250,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_float.metadata = {'url': '/number/big/float/3.402823e+20'}
 
     def get_big_float(
             self, custom_headers=None, raw=False, **operation_config):
@@ -261,7 +266,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/float/3.402823e+20'
+        url = self.get_big_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -289,6 +294,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_float.metadata = {'url': '/number/big/float/3.402823e+20'}
 
     def put_big_double(
             self, number_body, custom_headers=None, raw=False, **operation_config):
@@ -306,7 +312,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/double/2.5976931e+101'
+        url = self.put_big_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -331,6 +337,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_double.metadata = {'url': '/number/big/double/2.5976931e+101'}
 
     def get_big_double(
             self, custom_headers=None, raw=False, **operation_config):
@@ -346,7 +353,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/double/2.5976931e+101'
+        url = self.get_big_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -374,6 +381,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_double.metadata = {'url': '/number/big/double/2.5976931e+101'}
 
     def put_big_double_positive_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -391,7 +399,7 @@ class NumberOperations(object):
         number_body = 99999999.99
 
         # Construct URL
-        url = '/number/big/double/99999999.99'
+        url = self.put_big_double_positive_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -416,6 +424,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_double_positive_decimal.metadata = {'url': '/number/big/double/99999999.99'}
 
     def get_big_double_positive_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -431,7 +440,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/double/99999999.99'
+        url = self.get_big_double_positive_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -459,6 +468,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_double_positive_decimal.metadata = {'url': '/number/big/double/99999999.99'}
 
     def put_big_double_negative_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -476,7 +486,7 @@ class NumberOperations(object):
         number_body = -99999999.99
 
         # Construct URL
-        url = '/number/big/double/-99999999.99'
+        url = self.put_big_double_negative_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -501,6 +511,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_double_negative_decimal.metadata = {'url': '/number/big/double/-99999999.99'}
 
     def get_big_double_negative_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -516,7 +527,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/double/-99999999.99'
+        url = self.get_big_double_negative_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -544,6 +555,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_double_negative_decimal.metadata = {'url': '/number/big/double/-99999999.99'}
 
     def put_big_decimal(
             self, number_body, custom_headers=None, raw=False, **operation_config):
@@ -561,7 +573,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/decimal/2.5976931e+101'
+        url = self.put_big_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -586,6 +598,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_decimal.metadata = {'url': '/number/big/decimal/2.5976931e+101'}
 
     def get_big_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -601,7 +614,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/decimal/2.5976931e+101'
+        url = self.get_big_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -629,6 +642,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_decimal.metadata = {'url': '/number/big/decimal/2.5976931e+101'}
 
     def put_big_decimal_positive_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -646,7 +660,7 @@ class NumberOperations(object):
         number_body = Decimal(99999999.99)
 
         # Construct URL
-        url = '/number/big/decimal/99999999.99'
+        url = self.put_big_decimal_positive_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -671,6 +685,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_decimal_positive_decimal.metadata = {'url': '/number/big/decimal/99999999.99'}
 
     def get_big_decimal_positive_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -686,7 +701,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/decimal/99999999.99'
+        url = self.get_big_decimal_positive_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -714,6 +729,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_decimal_positive_decimal.metadata = {'url': '/number/big/decimal/99999999.99'}
 
     def put_big_decimal_negative_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -731,7 +747,7 @@ class NumberOperations(object):
         number_body = Decimal(-99999999.99)
 
         # Construct URL
-        url = '/number/big/decimal/-99999999.99'
+        url = self.put_big_decimal_negative_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -756,6 +772,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_big_decimal_negative_decimal.metadata = {'url': '/number/big/decimal/-99999999.99'}
 
     def get_big_decimal_negative_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -771,7 +788,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/big/decimal/-99999999.99'
+        url = self.get_big_decimal_negative_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -799,6 +816,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_big_decimal_negative_decimal.metadata = {'url': '/number/big/decimal/-99999999.99'}
 
     def put_small_float(
             self, number_body, custom_headers=None, raw=False, **operation_config):
@@ -816,7 +834,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/small/float/3.402823e-20'
+        url = self.put_small_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -841,6 +859,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_small_float.metadata = {'url': '/number/small/float/3.402823e-20'}
 
     def get_small_float(
             self, custom_headers=None, raw=False, **operation_config):
@@ -856,7 +875,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/small/float/3.402823e-20'
+        url = self.get_small_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -884,6 +903,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_small_float.metadata = {'url': '/number/small/float/3.402823e-20'}
 
     def put_small_double(
             self, number_body, custom_headers=None, raw=False, **operation_config):
@@ -901,7 +921,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/small/double/2.5976931e-101'
+        url = self.put_small_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -926,6 +946,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_small_double.metadata = {'url': '/number/small/double/2.5976931e-101'}
 
     def get_small_double(
             self, custom_headers=None, raw=False, **operation_config):
@@ -941,7 +962,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/small/double/2.5976931e-101'
+        url = self.get_small_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -969,6 +990,7 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_small_double.metadata = {'url': '/number/small/double/2.5976931e-101'}
 
     def put_small_decimal(
             self, number_body, custom_headers=None, raw=False, **operation_config):
@@ -986,7 +1008,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/small/decimal/2.5976931e-101'
+        url = self.put_small_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1011,6 +1033,7 @@ class NumberOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_small_decimal.metadata = {'url': '/number/small/decimal/2.5976931e-101'}
 
     def get_small_decimal(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1026,7 +1049,7 @@ class NumberOperations(object):
         :raises: :class:`ErrorException<bodynumber.models.ErrorException>`
         """
         # Construct URL
-        url = '/number/small/decimal/2.5976931e-101'
+        url = self.get_small_decimal.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1054,3 +1077,4 @@ class NumberOperations(object):
             return client_raw_response
 
         return deserialized
+    get_small_decimal.metadata = {'url': '/number/small/decimal/2.5976931e-101'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/enum_operations.py
@@ -49,7 +49,7 @@ class EnumOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/enum/notExpandable'
+        url = self.get_not_expandable.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -77,6 +77,7 @@ class EnumOperations(object):
             return client_raw_response
 
         return deserialized
+    get_not_expandable.metadata = {'url': '/string/enum/notExpandable'}
 
     def put_not_expandable(
             self, string_body, custom_headers=None, raw=False, **operation_config):
@@ -96,7 +97,7 @@ class EnumOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/enum/notExpandable'
+        url = self.put_not_expandable.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -121,6 +122,7 @@ class EnumOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_not_expandable.metadata = {'url': '/string/enum/notExpandable'}
 
     def get_referenced(
             self, custom_headers=None, raw=False, **operation_config):
@@ -138,7 +140,7 @@ class EnumOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/enum/Referenced'
+        url = self.get_referenced.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -166,6 +168,7 @@ class EnumOperations(object):
             return client_raw_response
 
         return deserialized
+    get_referenced.metadata = {'url': '/string/enum/Referenced'}
 
     def put_referenced(
             self, enum_string_body, custom_headers=None, raw=False, **operation_config):
@@ -185,7 +188,7 @@ class EnumOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/enum/Referenced'
+        url = self.put_referenced.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -210,6 +213,7 @@ class EnumOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_referenced.metadata = {'url': '/string/enum/Referenced'}
 
     def get_referenced_constant(
             self, custom_headers=None, raw=False, **operation_config):
@@ -226,7 +230,7 @@ class EnumOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/enum/ReferencedConstant'
+        url = self.get_referenced_constant.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -254,6 +258,7 @@ class EnumOperations(object):
             return client_raw_response
 
         return deserialized
+    get_referenced_constant.metadata = {'url': '/string/enum/ReferencedConstant'}
 
     def put_referenced_constant(
             self, field1=None, custom_headers=None, raw=False, **operation_config):
@@ -273,7 +278,7 @@ class EnumOperations(object):
         enum_string_body = models.RefColorConstant(field1=field1)
 
         # Construct URL
-        url = '/string/enum/ReferencedConstant'
+        url = self.put_referenced_constant.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -298,3 +303,4 @@ class EnumOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_referenced_constant.metadata = {'url': '/string/enum/ReferencedConstant'}

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/string_operations.py
@@ -47,7 +47,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/null'
+        url = self.get_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -75,6 +75,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null.metadata = {'url': '/string/null'}
 
     def put_null(
             self, string_body=None, custom_headers=None, raw=False, **operation_config):
@@ -92,7 +93,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/null'
+        url = self.put_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -120,6 +121,7 @@ class StringOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_null.metadata = {'url': '/string/null'}
 
     def get_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -135,7 +137,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/empty'
+        url = self.get_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -163,6 +165,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty.metadata = {'url': '/string/empty'}
 
     def put_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -180,7 +183,7 @@ class StringOperations(object):
         string_body = ""
 
         # Construct URL
-        url = '/string/empty'
+        url = self.put_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -205,6 +208,7 @@ class StringOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_empty.metadata = {'url': '/string/empty'}
 
     def get_mbcs(
             self, custom_headers=None, raw=False, **operation_config):
@@ -221,7 +225,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/mbcs'
+        url = self.get_mbcs.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -249,6 +253,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_mbcs.metadata = {'url': '/string/mbcs'}
 
     def put_mbcs(
             self, custom_headers=None, raw=False, **operation_config):
@@ -267,7 +272,7 @@ class StringOperations(object):
         string_body = "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"
 
         # Construct URL
-        url = '/string/mbcs'
+        url = self.put_mbcs.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -292,6 +297,7 @@ class StringOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_mbcs.metadata = {'url': '/string/mbcs'}
 
     def get_whitespace(
             self, custom_headers=None, raw=False, **operation_config):
@@ -309,7 +315,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/whitespace'
+        url = self.get_whitespace.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -337,6 +343,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_whitespace.metadata = {'url': '/string/whitespace'}
 
     def put_whitespace(
             self, custom_headers=None, raw=False, **operation_config):
@@ -356,7 +363,7 @@ class StringOperations(object):
         string_body = "    Now is the time for all good men to come to the aid of their country    "
 
         # Construct URL
-        url = '/string/whitespace'
+        url = self.put_whitespace.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -381,6 +388,7 @@ class StringOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_whitespace.metadata = {'url': '/string/whitespace'}
 
     def get_not_provided(
             self, custom_headers=None, raw=False, **operation_config):
@@ -396,7 +404,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/notProvided'
+        url = self.get_not_provided.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -424,6 +432,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_not_provided.metadata = {'url': '/string/notProvided'}
 
     def get_base64_encoded(
             self, custom_headers=None, raw=False, **operation_config):
@@ -439,7 +448,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/base64Encoding'
+        url = self.get_base64_encoded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -467,6 +476,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_base64_encoded.metadata = {'url': '/string/base64Encoding'}
 
     def get_base64_url_encoded(
             self, custom_headers=None, raw=False, **operation_config):
@@ -482,7 +492,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/base64UrlEncoding'
+        url = self.get_base64_url_encoded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -510,6 +520,7 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_base64_url_encoded.metadata = {'url': '/string/base64UrlEncoding'}
 
     def put_base64_url_encoded(
             self, string_body, custom_headers=None, raw=False, **operation_config):
@@ -527,7 +538,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/base64UrlEncoding'
+        url = self.put_base64_url_encoded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -552,6 +563,7 @@ class StringOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_base64_url_encoded.metadata = {'url': '/string/base64UrlEncoding'}
 
     def get_null_base64_url_encoded(
             self, custom_headers=None, raw=False, **operation_config):
@@ -567,7 +579,7 @@ class StringOperations(object):
         :raises: :class:`ErrorException<bodystring.models.ErrorException>`
         """
         # Construct URL
-        url = '/string/nullBase64UrlEncoding'
+        url = self.get_null_base64_url_encoded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -595,3 +607,4 @@ class StringOperations(object):
             return client_raw_response
 
         return deserialized
+    get_null_base64_url_encoded.metadata = {'url': '/string/nullBase64UrlEncoding'}

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/paths_operations.py
@@ -49,7 +49,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<custombaseurl.models.ErrorException>`
         """
         # Construct URL
-        url = '/customuri'
+        url = self.get_empty.metadata['url']
         path_format_arguments = {
             'accountName': self._serialize.url("account_name", account_name, 'str', skip_quote=True),
             'host': self._serialize.url("self.config.host", self.config.host, 'str', skip_quote=True)
@@ -75,3 +75,4 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_empty.metadata = {'url': '/customuri'}

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/operations/paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/operations/paths_operations.py
@@ -56,7 +56,7 @@ class PathsOperations(object):
          :class:`ErrorException<custombaseurlmoreoptions.models.ErrorException>`
         """
         # Construct URL
-        url = '/customuri/{subscriptionId}/{keyName}'
+        url = self.get_empty.metadata['url']
         path_format_arguments = {
             'vault': self._serialize.url("vault", vault, 'str', skip_quote=True),
             'secret': self._serialize.url("secret", secret, 'str', skip_quote=True),
@@ -87,3 +87,4 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_empty.metadata = {'url': '/customuri/{subscriptionId}/{keyName}'}

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/operations/header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/operations/header_operations.py
@@ -50,7 +50,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/existingkey'
+        url = self.param_existing_key.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -72,6 +72,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_existing_key.metadata = {'url': '/header/param/existingkey'}
 
     def response_existing_key(
             self, custom_headers=None, raw=False, **operation_config):
@@ -87,7 +88,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/existingkey'
+        url = self.response_existing_key.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -111,6 +112,7 @@ class HeaderOperations(object):
                 'User-Agent': 'str',
             })
             return client_raw_response
+    response_existing_key.metadata = {'url': '/header/response/existingkey'}
 
     def param_protected_key(
             self, content_type, custom_headers=None, raw=False, **operation_config):
@@ -129,7 +131,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/protectedkey'
+        url = self.param_protected_key.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -151,6 +153,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_protected_key.metadata = {'url': '/header/param/protectedkey'}
 
     def response_protected_key(
             self, custom_headers=None, raw=False, **operation_config):
@@ -166,7 +169,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/protectedkey'
+        url = self.response_protected_key.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -190,6 +193,7 @@ class HeaderOperations(object):
                 'Content-Type': 'str',
             })
             return client_raw_response
+    response_protected_key.metadata = {'url': '/header/response/protectedkey'}
 
     def param_integer(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -211,7 +215,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/integer'
+        url = self.param_integer.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -234,6 +238,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_integer.metadata = {'url': '/header/param/prim/integer'}
 
     def response_integer(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -252,7 +257,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/integer'
+        url = self.response_integer.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -277,6 +282,7 @@ class HeaderOperations(object):
                 'value': 'int',
             })
             return client_raw_response
+    response_integer.metadata = {'url': '/header/response/prim/integer'}
 
     def param_long(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -298,7 +304,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/long'
+        url = self.param_long.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -321,6 +327,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_long.metadata = {'url': '/header/param/prim/long'}
 
     def response_long(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -339,7 +346,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/long'
+        url = self.response_long.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -364,6 +371,7 @@ class HeaderOperations(object):
                 'value': 'long',
             })
             return client_raw_response
+    response_long.metadata = {'url': '/header/response/prim/long'}
 
     def param_float(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -385,7 +393,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/float'
+        url = self.param_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -408,6 +416,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_float.metadata = {'url': '/header/param/prim/float'}
 
     def response_float(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -426,7 +435,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/float'
+        url = self.response_float.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -451,6 +460,7 @@ class HeaderOperations(object):
                 'value': 'float',
             })
             return client_raw_response
+    response_float.metadata = {'url': '/header/response/prim/float'}
 
     def param_double(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -472,7 +482,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/double'
+        url = self.param_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -495,6 +505,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_double.metadata = {'url': '/header/param/prim/double'}
 
     def response_double(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -513,7 +524,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/double'
+        url = self.response_double.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -538,6 +549,7 @@ class HeaderOperations(object):
                 'value': 'float',
             })
             return client_raw_response
+    response_double.metadata = {'url': '/header/response/prim/double'}
 
     def param_bool(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -559,7 +571,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/bool'
+        url = self.param_bool.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -582,6 +594,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_bool.metadata = {'url': '/header/param/prim/bool'}
 
     def response_bool(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -600,7 +613,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/bool'
+        url = self.response_bool.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -625,6 +638,7 @@ class HeaderOperations(object):
                 'value': 'bool',
             })
             return client_raw_response
+    response_bool.metadata = {'url': '/header/response/prim/bool'}
 
     def param_string(
             self, scenario, value=None, custom_headers=None, raw=False, **operation_config):
@@ -648,7 +662,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/string'
+        url = self.param_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -672,6 +686,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_string.metadata = {'url': '/header/param/prim/string'}
 
     def response_string(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -691,7 +706,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/string'
+        url = self.response_string.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -716,6 +731,7 @@ class HeaderOperations(object):
                 'value': 'str',
             })
             return client_raw_response
+    response_string.metadata = {'url': '/header/response/prim/string'}
 
     def param_date(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -738,7 +754,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/date'
+        url = self.param_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -761,6 +777,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_date.metadata = {'url': '/header/param/prim/date'}
 
     def response_date(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -779,7 +796,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/date'
+        url = self.response_date.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -804,6 +821,7 @@ class HeaderOperations(object):
                 'value': 'date',
             })
             return client_raw_response
+    response_date.metadata = {'url': '/header/response/prim/date'}
 
     def param_datetime(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -827,7 +845,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/datetime'
+        url = self.param_datetime.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -850,6 +868,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_datetime.metadata = {'url': '/header/param/prim/datetime'}
 
     def response_datetime(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -869,7 +888,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/datetime'
+        url = self.response_datetime.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -894,6 +913,7 @@ class HeaderOperations(object):
                 'value': 'iso-8601',
             })
             return client_raw_response
+    response_datetime.metadata = {'url': '/header/response/prim/datetime'}
 
     def param_datetime_rfc1123(
             self, scenario, value=None, custom_headers=None, raw=False, **operation_config):
@@ -917,7 +937,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/datetimerfc1123'
+        url = self.param_datetime_rfc1123.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -941,6 +961,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_datetime_rfc1123.metadata = {'url': '/header/param/prim/datetimerfc1123'}
 
     def response_datetime_rfc1123(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -960,7 +981,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/datetimerfc1123'
+        url = self.response_datetime_rfc1123.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -985,6 +1006,7 @@ class HeaderOperations(object):
                 'value': 'rfc-1123',
             })
             return client_raw_response
+    response_datetime_rfc1123.metadata = {'url': '/header/response/prim/datetimerfc1123'}
 
     def param_duration(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -1007,7 +1029,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/duration'
+        url = self.param_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1030,6 +1052,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_duration.metadata = {'url': '/header/param/prim/duration'}
 
     def response_duration(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -1048,7 +1071,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/duration'
+        url = self.response_duration.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1073,6 +1096,7 @@ class HeaderOperations(object):
                 'value': 'duration',
             })
             return client_raw_response
+    response_duration.metadata = {'url': '/header/response/prim/duration'}
 
     def param_byte(
             self, scenario, value, custom_headers=None, raw=False, **operation_config):
@@ -1094,7 +1118,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/byte'
+        url = self.param_byte.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1117,6 +1141,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_byte.metadata = {'url': '/header/param/prim/byte'}
 
     def response_byte(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -1135,7 +1160,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/byte'
+        url = self.response_byte.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1160,6 +1185,7 @@ class HeaderOperations(object):
                 'value': 'bytearray',
             })
             return client_raw_response
+    response_byte.metadata = {'url': '/header/response/prim/byte'}
 
     def param_enum(
             self, scenario, value=None, custom_headers=None, raw=False, **operation_config):
@@ -1182,7 +1208,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/param/prim/enum'
+        url = self.param_enum.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1206,6 +1232,7 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    param_enum.metadata = {'url': '/header/param/prim/enum'}
 
     def response_enum(
             self, scenario, custom_headers=None, raw=False, **operation_config):
@@ -1224,7 +1251,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/response/prim/enum'
+        url = self.response_enum.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1249,6 +1276,7 @@ class HeaderOperations(object):
                 'value': models.GreyscaleColors,
             })
             return client_raw_response
+    response_enum.metadata = {'url': '/header/response/prim/enum'}
 
     def custom_request_id(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1265,7 +1293,7 @@ class HeaderOperations(object):
         :raises: :class:`ErrorException<header.models.ErrorException>`
         """
         # Construct URL
-        url = '/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
+        url = self.custom_request_id.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1286,3 +1314,4 @@ class HeaderOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    custom_request_id.metadata = {'url': '/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_client_failure_operations.py
@@ -50,7 +50,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/400'
+        url = self.head400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -71,6 +71,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head400.metadata = {'url': '/http/failure/client/400'}
 
     def get400(
             self, custom_headers=None, raw=False, **operation_config):
@@ -89,7 +90,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/400'
+        url = self.get400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -110,6 +111,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get400.metadata = {'url': '/http/failure/client/400'}
 
     def put400(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -130,7 +132,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/400'
+        url = self.put400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -158,6 +160,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put400.metadata = {'url': '/http/failure/client/400'}
 
     def patch400(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -178,7 +181,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/400'
+        url = self.patch400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -206,6 +209,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch400.metadata = {'url': '/http/failure/client/400'}
 
     def post400(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -226,7 +230,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/400'
+        url = self.post400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -254,6 +258,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post400.metadata = {'url': '/http/failure/client/400'}
 
     def delete400(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -274,7 +279,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/400'
+        url = self.delete400.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -302,6 +307,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete400.metadata = {'url': '/http/failure/client/400'}
 
     def head401(
             self, custom_headers=None, raw=False, **operation_config):
@@ -320,7 +326,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/401'
+        url = self.head401.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -341,6 +347,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head401.metadata = {'url': '/http/failure/client/401'}
 
     def get402(
             self, custom_headers=None, raw=False, **operation_config):
@@ -359,7 +366,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/402'
+        url = self.get402.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -380,6 +387,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get402.metadata = {'url': '/http/failure/client/402'}
 
     def get403(
             self, custom_headers=None, raw=False, **operation_config):
@@ -398,7 +406,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/403'
+        url = self.get403.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -419,6 +427,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get403.metadata = {'url': '/http/failure/client/403'}
 
     def put404(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -439,7 +448,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/404'
+        url = self.put404.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -467,6 +476,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put404.metadata = {'url': '/http/failure/client/404'}
 
     def patch405(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -487,7 +497,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/405'
+        url = self.patch405.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -515,6 +525,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch405.metadata = {'url': '/http/failure/client/405'}
 
     def post406(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -535,7 +546,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/406'
+        url = self.post406.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -563,6 +574,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post406.metadata = {'url': '/http/failure/client/406'}
 
     def delete407(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -583,7 +595,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/407'
+        url = self.delete407.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -611,6 +623,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete407.metadata = {'url': '/http/failure/client/407'}
 
     def put409(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -631,7 +644,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/409'
+        url = self.put409.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -659,6 +672,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put409.metadata = {'url': '/http/failure/client/409'}
 
     def head410(
             self, custom_headers=None, raw=False, **operation_config):
@@ -677,7 +691,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/410'
+        url = self.head410.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -698,6 +712,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head410.metadata = {'url': '/http/failure/client/410'}
 
     def get411(
             self, custom_headers=None, raw=False, **operation_config):
@@ -716,7 +731,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/411'
+        url = self.get411.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -737,6 +752,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get411.metadata = {'url': '/http/failure/client/411'}
 
     def get412(
             self, custom_headers=None, raw=False, **operation_config):
@@ -755,7 +771,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/412'
+        url = self.get412.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -776,6 +792,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get412.metadata = {'url': '/http/failure/client/412'}
 
     def put413(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -796,7 +813,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/413'
+        url = self.put413.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -824,6 +841,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put413.metadata = {'url': '/http/failure/client/413'}
 
     def patch414(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -844,7 +862,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/414'
+        url = self.patch414.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -872,6 +890,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch414.metadata = {'url': '/http/failure/client/414'}
 
     def post415(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -892,7 +911,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/415'
+        url = self.post415.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -920,6 +939,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post415.metadata = {'url': '/http/failure/client/415'}
 
     def get416(
             self, custom_headers=None, raw=False, **operation_config):
@@ -938,7 +958,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/416'
+        url = self.get416.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -959,6 +979,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get416.metadata = {'url': '/http/failure/client/416'}
 
     def delete417(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -979,7 +1000,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/417'
+        url = self.delete417.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1007,6 +1028,7 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete417.metadata = {'url': '/http/failure/client/417'}
 
     def head429(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1025,7 +1047,7 @@ class HttpClientFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/client/429'
+        url = self.head429.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1046,3 +1068,4 @@ class HttpClientFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head429.metadata = {'url': '/http/failure/client/429'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_failure_operations.py
@@ -49,7 +49,7 @@ class HttpFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/emptybody/error'
+        url = self.get_empty_error.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -77,6 +77,7 @@ class HttpFailureOperations(object):
             return client_raw_response
 
         return deserialized
+    get_empty_error.metadata = {'url': '/http/failure/emptybody/error'}
 
     def get_no_model_error(
             self, custom_headers=None, raw=False, **operation_config):
@@ -93,7 +94,7 @@ class HttpFailureOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/failure/nomodel/error'
+        url = self.get_no_model_error.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -121,6 +122,7 @@ class HttpFailureOperations(object):
             return client_raw_response
 
         return deserialized
+    get_no_model_error.metadata = {'url': '/http/failure/nomodel/error'}
 
     def get_no_model_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -137,7 +139,7 @@ class HttpFailureOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/failure/nomodel/empty'
+        url = self.get_no_model_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -165,3 +167,4 @@ class HttpFailureOperations(object):
             return client_raw_response
 
         return deserialized
+    get_no_model_empty.metadata = {'url': '/http/failure/nomodel/empty'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_redirects_operations.py
@@ -48,7 +48,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/300'
+        url = self.head300.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -72,6 +72,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    head300.metadata = {'url': '/http/redirect/300'}
 
     def get300(
             self, custom_headers=None, raw=False, **operation_config):
@@ -88,7 +89,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/300'
+        url = self.get300.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -121,6 +122,7 @@ class HttpRedirectsOperations(object):
             return client_raw_response
 
         return deserialized
+    get300.metadata = {'url': '/http/redirect/300'}
 
     def head301(
             self, custom_headers=None, raw=False, **operation_config):
@@ -137,7 +139,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/301'
+        url = self.head301.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    head301.metadata = {'url': '/http/redirect/301'}
 
     def get301(
             self, custom_headers=None, raw=False, **operation_config):
@@ -177,7 +180,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/301'
+        url = self.get301.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -201,6 +204,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    get301.metadata = {'url': '/http/redirect/301'}
 
     def put301(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -221,7 +225,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/301'
+        url = self.put301.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -252,6 +256,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    put301.metadata = {'url': '/http/redirect/301'}
 
     def head302(
             self, custom_headers=None, raw=False, **operation_config):
@@ -268,7 +273,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/302'
+        url = self.head302.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -292,6 +297,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    head302.metadata = {'url': '/http/redirect/302'}
 
     def get302(
             self, custom_headers=None, raw=False, **operation_config):
@@ -308,7 +314,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/302'
+        url = self.get302.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -332,6 +338,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    get302.metadata = {'url': '/http/redirect/302'}
 
     def patch302(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -352,7 +359,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/302'
+        url = self.patch302.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -383,6 +390,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    patch302.metadata = {'url': '/http/redirect/302'}
 
     def post303(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -403,7 +411,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/303'
+        url = self.post303.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -434,6 +442,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    post303.metadata = {'url': '/http/redirect/303'}
 
     def head307(
             self, custom_headers=None, raw=False, **operation_config):
@@ -450,7 +459,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/307'
+        url = self.head307.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -474,6 +483,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    head307.metadata = {'url': '/http/redirect/307'}
 
     def get307(
             self, custom_headers=None, raw=False, **operation_config):
@@ -490,7 +500,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/307'
+        url = self.get307.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -514,6 +524,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    get307.metadata = {'url': '/http/redirect/307'}
 
     def put307(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -532,7 +543,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/307'
+        url = self.put307.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -563,6 +574,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    put307.metadata = {'url': '/http/redirect/307'}
 
     def patch307(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -581,7 +593,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/307'
+        url = self.patch307.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -612,6 +624,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    patch307.metadata = {'url': '/http/redirect/307'}
 
     def post307(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -630,7 +643,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/307'
+        url = self.post307.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -661,6 +674,7 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    post307.metadata = {'url': '/http/redirect/307'}
 
     def delete307(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -679,7 +693,7 @@ class HttpRedirectsOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/redirect/307'
+        url = self.delete307.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -710,3 +724,4 @@ class HttpRedirectsOperations(object):
                 'Location': 'str',
             })
             return client_raw_response
+    delete307.metadata = {'url': '/http/redirect/307'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_retry_operations.py
@@ -48,7 +48,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/408'
+        url = self.head408.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -69,6 +69,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head408.metadata = {'url': '/http/retry/408'}
 
     def put500(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -87,7 +88,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/500'
+        url = self.put500.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -115,6 +116,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put500.metadata = {'url': '/http/retry/500'}
 
     def patch500(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/500'
+        url = self.patch500.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -161,6 +163,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch500.metadata = {'url': '/http/retry/500'}
 
     def get502(
             self, custom_headers=None, raw=False, **operation_config):
@@ -177,7 +180,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/502'
+        url = self.get502.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -198,6 +201,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get502.metadata = {'url': '/http/retry/502'}
 
     def post503(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -216,7 +220,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/503'
+        url = self.post503.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -244,6 +248,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post503.metadata = {'url': '/http/retry/503'}
 
     def delete503(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -262,7 +267,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/503'
+        url = self.delete503.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -290,6 +295,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete503.metadata = {'url': '/http/retry/503'}
 
     def put504(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -308,7 +314,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/504'
+        url = self.put504.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -336,6 +342,7 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put504.metadata = {'url': '/http/retry/504'}
 
     def patch504(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -354,7 +361,7 @@ class HttpRetryOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/retry/504'
+        url = self.patch504.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -382,3 +389,4 @@ class HttpRetryOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch504.metadata = {'url': '/http/retry/504'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_server_failure_operations.py
@@ -50,7 +50,7 @@ class HttpServerFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/server/501'
+        url = self.head501.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -71,6 +71,7 @@ class HttpServerFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head501.metadata = {'url': '/http/failure/server/501'}
 
     def get501(
             self, custom_headers=None, raw=False, **operation_config):
@@ -89,7 +90,7 @@ class HttpServerFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/server/501'
+        url = self.get501.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -110,6 +111,7 @@ class HttpServerFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get501.metadata = {'url': '/http/failure/server/501'}
 
     def post505(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -130,7 +132,7 @@ class HttpServerFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/server/505'
+        url = self.post505.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -158,6 +160,7 @@ class HttpServerFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post505.metadata = {'url': '/http/failure/server/505'}
 
     def delete505(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -178,7 +181,7 @@ class HttpServerFailureOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/failure/server/505'
+        url = self.delete505.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -206,3 +209,4 @@ class HttpServerFailureOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete505.metadata = {'url': '/http/failure/server/505'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/http_success_operations.py
@@ -48,7 +48,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.head200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -69,6 +69,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head200.metadata = {'url': '/http/success/200'}
 
     def get200(
             self, custom_headers=None, raw=False, **operation_config):
@@ -85,7 +86,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.get200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -113,6 +114,7 @@ class HttpSuccessOperations(object):
             return client_raw_response
 
         return deserialized
+    get200.metadata = {'url': '/http/success/200'}
 
     def put200(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -131,7 +133,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.put200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -159,6 +161,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put200.metadata = {'url': '/http/success/200'}
 
     def patch200(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -177,7 +180,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.patch200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -205,6 +208,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch200.metadata = {'url': '/http/success/200'}
 
     def post200(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -223,7 +227,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.post200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -251,6 +255,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post200.metadata = {'url': '/http/success/200'}
 
     def delete200(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -269,7 +274,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/200'
+        url = self.delete200.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -297,6 +302,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete200.metadata = {'url': '/http/success/200'}
 
     def put201(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -315,7 +321,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/201'
+        url = self.put201.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -343,6 +349,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put201.metadata = {'url': '/http/success/201'}
 
     def post201(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -361,7 +368,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/201'
+        url = self.post201.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -389,6 +396,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post201.metadata = {'url': '/http/success/201'}
 
     def put202(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -407,7 +415,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/202'
+        url = self.put202.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -435,6 +443,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put202.metadata = {'url': '/http/success/202'}
 
     def patch202(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -453,7 +462,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/202'
+        url = self.patch202.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -481,6 +490,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch202.metadata = {'url': '/http/success/202'}
 
     def post202(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -499,7 +509,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/202'
+        url = self.post202.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -527,6 +537,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post202.metadata = {'url': '/http/success/202'}
 
     def delete202(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -545,7 +556,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/202'
+        url = self.delete202.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -573,6 +584,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete202.metadata = {'url': '/http/success/202'}
 
     def head204(
             self, custom_headers=None, raw=False, **operation_config):
@@ -589,7 +601,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.head204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -610,6 +622,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head204.metadata = {'url': '/http/success/204'}
 
     def put204(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -628,7 +641,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.put204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -656,6 +669,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put204.metadata = {'url': '/http/success/204'}
 
     def patch204(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -674,7 +688,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.patch204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -702,6 +716,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    patch204.metadata = {'url': '/http/success/204'}
 
     def post204(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -720,7 +735,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.post204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -748,6 +763,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post204.metadata = {'url': '/http/success/204'}
 
     def delete204(
             self, boolean_value=None, custom_headers=None, raw=False, **operation_config):
@@ -766,7 +782,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/204'
+        url = self.delete204.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -794,6 +810,7 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    delete204.metadata = {'url': '/http/success/204'}
 
     def head404(
             self, custom_headers=None, raw=False, **operation_config):
@@ -810,7 +827,7 @@ class HttpSuccessOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/success/404'
+        url = self.head404.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -831,3 +848,4 @@ class HttpSuccessOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    head404.metadata = {'url': '/http/success/404'}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/multiple_responses_operations.py
@@ -50,7 +50,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/204/none/default/Error/response/200/valid'
+        url = self.get200_model204_no_model_default_error200_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -78,6 +78,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model204_no_model_default_error200_valid.metadata = {'url': '/http/payloads/200/A/204/none/default/Error/response/200/valid'}
 
     def get200_model204_no_model_default_error204_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -95,7 +96,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/204/none/default/Error/response/204/none'
+        url = self.get200_model204_no_model_default_error204_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -123,6 +124,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model204_no_model_default_error204_valid.metadata = {'url': '/http/payloads/200/A/204/none/default/Error/response/204/none'}
 
     def get200_model204_no_model_default_error201_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -140,7 +142,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/204/none/default/Error/response/201/valid'
+        url = self.get200_model204_no_model_default_error201_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -168,6 +170,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model204_no_model_default_error201_invalid.metadata = {'url': '/http/payloads/200/A/204/none/default/Error/response/201/valid'}
 
     def get200_model204_no_model_default_error202_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -185,7 +188,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/204/none/default/Error/response/202/none'
+        url = self.get200_model204_no_model_default_error202_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -213,6 +216,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model204_no_model_default_error202_none.metadata = {'url': '/http/payloads/200/A/204/none/default/Error/response/202/none'}
 
     def get200_model204_no_model_default_error400_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -231,7 +235,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/204/none/default/Error/response/400/valid'
+        url = self.get200_model204_no_model_default_error400_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -259,6 +263,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model204_no_model_default_error400_valid.metadata = {'url': '/http/payloads/200/A/204/none/default/Error/response/400/valid'}
 
     def get200_model201_model_default_error200_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -276,7 +281,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/B/default/Error/response/200/valid'
+        url = self.get200_model201_model_default_error200_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -306,6 +311,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model201_model_default_error200_valid.metadata = {'url': '/http/payloads/200/A/201/B/default/Error/response/200/valid'}
 
     def get200_model201_model_default_error201_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -324,7 +330,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/B/default/Error/response/201/valid'
+        url = self.get200_model201_model_default_error201_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -354,6 +360,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model201_model_default_error201_valid.metadata = {'url': '/http/payloads/200/A/201/B/default/Error/response/201/valid'}
 
     def get200_model201_model_default_error400_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -372,7 +379,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/B/default/Error/response/400/valid'
+        url = self.get200_model201_model_default_error400_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -402,6 +409,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model201_model_default_error400_valid.metadata = {'url': '/http/payloads/200/A/201/B/default/Error/response/400/valid'}
 
     def get200_model_a201_model_c404_model_ddefault_error200_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -418,7 +426,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'
+        url = self.get200_model_a201_model_c404_model_ddefault_error200_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -450,6 +458,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a201_model_c404_model_ddefault_error200_valid.metadata = {'url': '/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid'}
 
     def get200_model_a201_model_c404_model_ddefault_error201_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -466,7 +475,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'
+        url = self.get200_model_a201_model_c404_model_ddefault_error201_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -498,6 +507,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a201_model_c404_model_ddefault_error201_valid.metadata = {'url': '/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid'}
 
     def get200_model_a201_model_c404_model_ddefault_error404_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -514,7 +524,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'
+        url = self.get200_model_a201_model_c404_model_ddefault_error404_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -546,6 +556,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a201_model_c404_model_ddefault_error404_valid.metadata = {'url': '/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid'}
 
     def get200_model_a201_model_c404_model_ddefault_error400_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -563,7 +574,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'
+        url = self.get200_model_a201_model_c404_model_ddefault_error400_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -595,6 +606,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a201_model_c404_model_ddefault_error400_valid.metadata = {'url': '/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid'}
 
     def get202_none204_none_default_error202_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -611,7 +623,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/Error/response/202/none'
+        url = self.get202_none204_none_default_error202_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -632,6 +644,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_error202_none.metadata = {'url': '/http/payloads/202/none/204/none/default/Error/response/202/none'}
 
     def get202_none204_none_default_error204_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -648,7 +661,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/Error/response/204/none'
+        url = self.get202_none204_none_default_error204_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -669,6 +682,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_error204_none.metadata = {'url': '/http/payloads/202/none/204/none/default/Error/response/204/none'}
 
     def get202_none204_none_default_error400_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -686,7 +700,7 @@ class MultipleResponsesOperations(object):
          :class:`ErrorException<httpinfrastructure.models.ErrorException>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/Error/response/400/valid'
+        url = self.get202_none204_none_default_error400_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -707,6 +721,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_error400_valid.metadata = {'url': '/http/payloads/202/none/204/none/default/Error/response/400/valid'}
 
     def get202_none204_none_default_none202_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -723,7 +738,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/none/response/202/invalid'
+        url = self.get202_none204_none_default_none202_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -744,6 +759,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_none202_invalid.metadata = {'url': '/http/payloads/202/none/204/none/default/none/response/202/invalid'}
 
     def get202_none204_none_default_none204_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -760,7 +776,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/none/response/204/none'
+        url = self.get202_none204_none_default_none204_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -781,6 +797,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_none204_none.metadata = {'url': '/http/payloads/202/none/204/none/default/none/response/204/none'}
 
     def get202_none204_none_default_none400_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -797,7 +814,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/none/response/400/none'
+        url = self.get202_none204_none_default_none400_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -818,6 +835,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_none400_none.metadata = {'url': '/http/payloads/202/none/204/none/default/none/response/400/none'}
 
     def get202_none204_none_default_none400_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -834,7 +852,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/202/none/204/none/default/none/response/400/invalid'
+        url = self.get202_none204_none_default_none400_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -855,6 +873,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get202_none204_none_default_none400_invalid.metadata = {'url': '/http/payloads/202/none/204/none/default/none/response/400/invalid'}
 
     def get_default_model_a200_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -871,7 +890,7 @@ class MultipleResponsesOperations(object):
         :raises: :class:`AException<httpinfrastructure.models.AException>`
         """
         # Construct URL
-        url = '/http/payloads/default/A/response/200/valid'
+        url = self.get_default_model_a200_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -892,6 +911,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_model_a200_valid.metadata = {'url': '/http/payloads/default/A/response/200/valid'}
 
     def get_default_model_a200_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -908,7 +928,7 @@ class MultipleResponsesOperations(object):
         :raises: :class:`AException<httpinfrastructure.models.AException>`
         """
         # Construct URL
-        url = '/http/payloads/default/A/response/200/none'
+        url = self.get_default_model_a200_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -929,6 +949,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_model_a200_none.metadata = {'url': '/http/payloads/default/A/response/200/none'}
 
     def get_default_model_a400_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -945,7 +966,7 @@ class MultipleResponsesOperations(object):
         :raises: :class:`AException<httpinfrastructure.models.AException>`
         """
         # Construct URL
-        url = '/http/payloads/default/A/response/400/valid'
+        url = self.get_default_model_a400_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -966,6 +987,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_model_a400_valid.metadata = {'url': '/http/payloads/default/A/response/400/valid'}
 
     def get_default_model_a400_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -982,7 +1004,7 @@ class MultipleResponsesOperations(object):
         :raises: :class:`AException<httpinfrastructure.models.AException>`
         """
         # Construct URL
-        url = '/http/payloads/default/A/response/400/none'
+        url = self.get_default_model_a400_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1003,6 +1025,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_model_a400_none.metadata = {'url': '/http/payloads/default/A/response/400/none'}
 
     def get_default_none200_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1019,7 +1042,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/default/none/response/200/invalid'
+        url = self.get_default_none200_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1040,6 +1063,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_none200_invalid.metadata = {'url': '/http/payloads/default/none/response/200/invalid'}
 
     def get_default_none200_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1056,7 +1080,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/default/none/response/200/none'
+        url = self.get_default_none200_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1077,6 +1101,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_none200_none.metadata = {'url': '/http/payloads/default/none/response/200/none'}
 
     def get_default_none400_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1093,7 +1118,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/default/none/response/400/invalid'
+        url = self.get_default_none400_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1114,6 +1139,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_none400_invalid.metadata = {'url': '/http/payloads/default/none/response/400/invalid'}
 
     def get_default_none400_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1130,7 +1156,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/default/none/response/400/none'
+        url = self.get_default_none400_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1151,6 +1177,7 @@ class MultipleResponsesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_default_none400_none.metadata = {'url': '/http/payloads/default/none/response/400/none'}
 
     def get200_model_a200_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1169,7 +1196,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/200/none'
+        url = self.get200_model_a200_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1197,6 +1224,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a200_none.metadata = {'url': '/http/payloads/200/A/response/200/none'}
 
     def get200_model_a200_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1214,7 +1242,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/200/valid'
+        url = self.get200_model_a200_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1242,6 +1270,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a200_valid.metadata = {'url': '/http/payloads/200/A/response/200/valid'}
 
     def get200_model_a200_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1259,7 +1288,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/200/invalid'
+        url = self.get200_model_a200_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1287,6 +1316,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a200_invalid.metadata = {'url': '/http/payloads/200/A/response/200/invalid'}
 
     def get200_model_a400_none(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1305,7 +1335,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/400/none'
+        url = self.get200_model_a400_none.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1333,6 +1363,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a400_none.metadata = {'url': '/http/payloads/200/A/response/400/none'}
 
     def get200_model_a400_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1350,7 +1381,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/400/valid'
+        url = self.get200_model_a400_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1378,6 +1409,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a400_valid.metadata = {'url': '/http/payloads/200/A/response/400/valid'}
 
     def get200_model_a400_invalid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1395,7 +1427,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/400/invalid'
+        url = self.get200_model_a400_invalid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1423,6 +1455,7 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a400_invalid.metadata = {'url': '/http/payloads/200/A/response/400/invalid'}
 
     def get200_model_a202_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1440,7 +1473,7 @@ class MultipleResponsesOperations(object):
          :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
         """
         # Construct URL
-        url = '/http/payloads/200/A/response/202/valid'
+        url = self.get200_model_a202_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1468,3 +1501,4 @@ class MultipleResponsesOperations(object):
             return client_raw_response
 
         return deserialized
+    get200_model_a202_valid.metadata = {'url': '/http/payloads/200/A/response/202/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/auto_rest_resource_flattening_test_service.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/auto_rest_resource_flattening_test_service.py
@@ -73,7 +73,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/array'
+        url = self.put_array.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -101,6 +101,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_array.metadata = {'url': '/model-flatten/array'}
 
     def get_array(
             self, custom_headers=None, raw=False, **operation_config):
@@ -118,7 +119,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/array'
+        url = self.get_array.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -146,6 +147,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_array.metadata = {'url': '/model-flatten/array'}
 
     def put_wrapped_array(
             self, resource_array=None, custom_headers=None, raw=False, **operation_config):
@@ -166,7 +168,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/wrappedarray'
+        url = self.put_wrapped_array.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -194,6 +196,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_wrapped_array.metadata = {'url': '/model-flatten/wrappedarray'}
 
     def get_wrapped_array(
             self, custom_headers=None, raw=False, **operation_config):
@@ -213,7 +216,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/wrappedarray'
+        url = self.get_wrapped_array.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -241,6 +244,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_wrapped_array.metadata = {'url': '/model-flatten/wrappedarray'}
 
     def put_dictionary(
             self, resource_dictionary=None, custom_headers=None, raw=False, **operation_config):
@@ -260,7 +264,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/dictionary'
+        url = self.put_dictionary.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -288,6 +292,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_dictionary.metadata = {'url': '/model-flatten/dictionary'}
 
     def get_dictionary(
             self, custom_headers=None, raw=False, **operation_config):
@@ -305,7 +310,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/dictionary'
+        url = self.get_dictionary.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -333,6 +338,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_dictionary.metadata = {'url': '/model-flatten/dictionary'}
 
     def put_resource_collection(
             self, resource_complex_object=None, custom_headers=None, raw=False, **operation_config):
@@ -353,7 +359,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/resourcecollection'
+        url = self.put_resource_collection.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -381,6 +387,7 @@ class AutoRestResourceFlatteningTestService(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_resource_collection.metadata = {'url': '/model-flatten/resourcecollection'}
 
     def get_resource_collection(
             self, custom_headers=None, raw=False, **operation_config):
@@ -398,7 +405,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/resourcecollection'
+        url = self.get_resource_collection.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -426,6 +433,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    get_resource_collection.metadata = {'url': '/model-flatten/resourcecollection'}
 
     def put_simple_product(
             self, simple_body_product=None, custom_headers=None, raw=False, **operation_config):
@@ -445,7 +453,7 @@ class AutoRestResourceFlatteningTestService(object):
          :class:`ErrorException<modelflattening.models.ErrorException>`
         """
         # Construct URL
-        url = '/model-flatten/customFlattening'
+        url = self.put_simple_product.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -480,6 +488,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    put_simple_product.metadata = {'url': '/model-flatten/customFlattening'}
 
     def post_flattened_simple_product(
             self, product_id, max_product_display_name, description=None, generic_value=None, odatavalue=None, custom_headers=None, raw=False, **operation_config):
@@ -514,7 +523,7 @@ class AutoRestResourceFlatteningTestService(object):
             simple_body_product = models.SimpleProduct(product_id=product_id, description=description, max_product_display_name=max_product_display_name, generic_value=generic_value, odatavalue=odatavalue)
 
         # Construct URL
-        url = '/model-flatten/customFlattening'
+        url = self.post_flattened_simple_product.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -549,6 +558,7 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    post_flattened_simple_product.metadata = {'url': '/model-flatten/customFlattening'}
 
     def put_simple_product_with_grouping(
             self, flatten_parameter_group, custom_headers=None, raw=False, **operation_config):
@@ -592,7 +602,7 @@ class AutoRestResourceFlatteningTestService(object):
             simple_body_product = models.SimpleProduct(product_id=product_id, description=description, max_product_display_name=max_product_display_name, generic_value=generic_value, odatavalue=odatavalue)
 
         # Construct URL
-        url = '/model-flatten/customFlattening/parametergrouping/{name}/'
+        url = self.put_simple_product_with_grouping.metadata['url']
         path_format_arguments = {
             'name': self._serialize.url("name", name, 'str')
         }
@@ -631,3 +641,4 @@ class AutoRestResourceFlatteningTestService(object):
             return client_raw_response
 
         return deserialized
+    put_simple_product_with_grouping.metadata = {'url': '/model-flatten/customFlattening/parametergrouping/{name}/'}

--- a/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/operations/availability_sets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/operations/availability_sets_operations.py
@@ -57,7 +57,7 @@ class AvailabilitySetsOperations(object):
         tags1 = models.AvailabilitySetUpdateParameters(tags=tags)
 
         # Construct URL
-        url = '/parameterFlattening/{resourceGroupName}/{availabilitySetName}'
+        url = self.update.metadata['url']
         path_format_arguments = {
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str'),
             'availabilitySetName': self._serialize.url("avset", avset, 'str', max_length=80)
@@ -87,3 +87,4 @@ class AvailabilitySetsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    update.metadata = {'url': '/parameterFlattening/{resourceGroupName}/{availabilitySetName}'}

--- a/test/vanilla/Expected/AcceptanceTests/Report/report/auto_rest_report_service.py
+++ b/test/vanilla/Expected/AcceptanceTests/Report/report/auto_rest_report_service.py
@@ -75,7 +75,7 @@ class AutoRestReportService(object):
         :raises: :class:`ErrorException<report.models.ErrorException>`
         """
         # Construct URL
-        url = '/report'
+        url = self.get_report.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -105,3 +105,4 @@ class AutoRestReportService(object):
             return client_raw_response
 
         return deserialized
+    get_report.metadata = {'url': '/report'}

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/explicit_operations.py
@@ -52,7 +52,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/integer/parameter'
+        url = self.post_required_integer_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -77,6 +77,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_integer_parameter.metadata = {'url': '/reqopt/requied/integer/parameter'}
 
     def post_optional_integer_parameter(
             self, body_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -95,7 +96,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/integer/parameter'
+        url = self.post_optional_integer_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -123,6 +124,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_integer_parameter.metadata = {'url': '/reqopt/optional/integer/parameter'}
 
     def post_required_integer_property(
             self, value, custom_headers=None, raw=False, **operation_config):
@@ -146,7 +148,7 @@ class ExplicitOperations(object):
         body_parameter = models.IntWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/requied/integer/property'
+        url = self.post_required_integer_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -171,6 +173,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_integer_property.metadata = {'url': '/reqopt/requied/integer/property'}
 
     def post_optional_integer_property(
             self, value=None, custom_headers=None, raw=False, **operation_config):
@@ -194,7 +197,7 @@ class ExplicitOperations(object):
             body_parameter = models.IntOptionalWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/optional/integer/property'
+        url = self.post_optional_integer_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -222,6 +225,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_integer_property.metadata = {'url': '/reqopt/optional/integer/property'}
 
     def post_required_integer_header(
             self, header_parameter, custom_headers=None, raw=False, **operation_config):
@@ -242,7 +246,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/integer/header'
+        url = self.post_required_integer_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -264,6 +268,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_integer_header.metadata = {'url': '/reqopt/requied/integer/header'}
 
     def post_optional_integer_header(
             self, header_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -283,7 +288,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/integer/header'
+        url = self.post_optional_integer_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -306,6 +311,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_integer_header.metadata = {'url': '/reqopt/optional/integer/header'}
 
     def post_required_string_parameter(
             self, body_parameter, custom_headers=None, raw=False, **operation_config):
@@ -326,7 +332,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/string/parameter'
+        url = self.post_required_string_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -351,6 +357,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_string_parameter.metadata = {'url': '/reqopt/requied/string/parameter'}
 
     def post_optional_string_parameter(
             self, body_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -369,7 +376,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/string/parameter'
+        url = self.post_optional_string_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -397,6 +404,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_string_parameter.metadata = {'url': '/reqopt/optional/string/parameter'}
 
     def post_required_string_property(
             self, value, custom_headers=None, raw=False, **operation_config):
@@ -420,7 +428,7 @@ class ExplicitOperations(object):
         body_parameter = models.StringWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/requied/string/property'
+        url = self.post_required_string_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -445,6 +453,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_string_property.metadata = {'url': '/reqopt/requied/string/property'}
 
     def post_optional_string_property(
             self, value=None, custom_headers=None, raw=False, **operation_config):
@@ -468,7 +477,7 @@ class ExplicitOperations(object):
             body_parameter = models.StringOptionalWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/optional/string/property'
+        url = self.post_optional_string_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -496,6 +505,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_string_property.metadata = {'url': '/reqopt/optional/string/property'}
 
     def post_required_string_header(
             self, header_parameter, custom_headers=None, raw=False, **operation_config):
@@ -516,7 +526,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/string/header'
+        url = self.post_required_string_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -538,6 +548,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_string_header.metadata = {'url': '/reqopt/requied/string/header'}
 
     def post_optional_string_header(
             self, body_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -557,7 +568,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/string/header'
+        url = self.post_optional_string_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -580,6 +591,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_string_header.metadata = {'url': '/reqopt/optional/string/header'}
 
     def post_required_class_parameter(
             self, body_parameter, custom_headers=None, raw=False, **operation_config):
@@ -600,7 +612,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/class/parameter'
+        url = self.post_required_class_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -625,6 +637,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_class_parameter.metadata = {'url': '/reqopt/requied/class/parameter'}
 
     def post_optional_class_parameter(
             self, body_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -643,7 +656,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/class/parameter'
+        url = self.post_optional_class_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -671,6 +684,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_class_parameter.metadata = {'url': '/reqopt/optional/class/parameter'}
 
     def post_required_class_property(
             self, value, custom_headers=None, raw=False, **operation_config):
@@ -694,7 +708,7 @@ class ExplicitOperations(object):
         body_parameter = models.ClassWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/requied/class/property'
+        url = self.post_required_class_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -719,6 +733,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_class_property.metadata = {'url': '/reqopt/requied/class/property'}
 
     def post_optional_class_property(
             self, value=None, custom_headers=None, raw=False, **operation_config):
@@ -742,7 +757,7 @@ class ExplicitOperations(object):
             body_parameter = models.ClassOptionalWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/optional/class/property'
+        url = self.post_optional_class_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -770,6 +785,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_class_property.metadata = {'url': '/reqopt/optional/class/property'}
 
     def post_required_array_parameter(
             self, body_parameter, custom_headers=None, raw=False, **operation_config):
@@ -790,7 +806,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/array/parameter'
+        url = self.post_required_array_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -815,6 +831,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_array_parameter.metadata = {'url': '/reqopt/requied/array/parameter'}
 
     def post_optional_array_parameter(
             self, body_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -833,7 +850,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/array/parameter'
+        url = self.post_optional_array_parameter.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -861,6 +878,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_array_parameter.metadata = {'url': '/reqopt/optional/array/parameter'}
 
     def post_required_array_property(
             self, value, custom_headers=None, raw=False, **operation_config):
@@ -884,7 +902,7 @@ class ExplicitOperations(object):
         body_parameter = models.ArrayWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/requied/array/property'
+        url = self.post_required_array_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -909,6 +927,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_array_property.metadata = {'url': '/reqopt/requied/array/property'}
 
     def post_optional_array_property(
             self, value=None, custom_headers=None, raw=False, **operation_config):
@@ -932,7 +951,7 @@ class ExplicitOperations(object):
             body_parameter = models.ArrayOptionalWrapper(value=value)
 
         # Construct URL
-        url = '/reqopt/optional/array/property'
+        url = self.post_optional_array_property.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -960,6 +979,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_array_property.metadata = {'url': '/reqopt/optional/array/property'}
 
     def post_required_array_header(
             self, header_parameter, custom_headers=None, raw=False, **operation_config):
@@ -980,7 +1000,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/requied/array/header'
+        url = self.post_required_array_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1002,6 +1022,7 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_required_array_header.metadata = {'url': '/reqopt/requied/array/header'}
 
     def post_optional_array_header(
             self, header_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -1021,7 +1042,7 @@ class ExplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/optional/array/header'
+        url = self.post_optional_array_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1044,3 +1065,4 @@ class ExplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    post_optional_array_header.metadata = {'url': '/reqopt/optional/array/header'}

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/implicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/implicit_operations.py
@@ -51,7 +51,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/implicit/required/path/{pathParameter}'
+        url = self.get_required_path.metadata['url']
         path_format_arguments = {
             'pathParameter': self._serialize.url("path_parameter", path_parameter, 'str')
         }
@@ -76,6 +76,7 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_required_path.metadata = {'url': '/reqopt/implicit/required/path/{pathParameter}'}
 
     def put_optional_query(
             self, query_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -94,7 +95,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/implicit/optional/query'
+        url = self.put_optional_query.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -117,6 +118,7 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_optional_query.metadata = {'url': '/reqopt/implicit/optional/query'}
 
     def put_optional_header(
             self, query_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -135,7 +137,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/implicit/optional/header'
+        url = self.put_optional_header.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -158,6 +160,7 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_optional_header.metadata = {'url': '/reqopt/implicit/optional/header'}
 
     def put_optional_body(
             self, body_parameter=None, custom_headers=None, raw=False, **operation_config):
@@ -176,7 +179,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/implicit/optional/body'
+        url = self.put_optional_body.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -204,6 +207,7 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    put_optional_body.metadata = {'url': '/reqopt/implicit/optional/body'}
 
     def get_required_global_path(
             self, custom_headers=None, raw=False, **operation_config):
@@ -221,7 +225,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/global/required/path/{required-global-path}'
+        url = self.get_required_global_path.metadata['url']
         path_format_arguments = {
             'required-global-path': self._serialize.url("self.config.required_global_path", self.config.required_global_path, 'str')
         }
@@ -246,6 +250,7 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_required_global_path.metadata = {'url': '/reqopt/global/required/path/{required-global-path}'}
 
     def get_required_global_query(
             self, custom_headers=None, raw=False, **operation_config):
@@ -263,7 +268,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/global/required/query'
+        url = self.get_required_global_query.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -285,6 +290,7 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_required_global_query.metadata = {'url': '/reqopt/global/required/query'}
 
     def get_optional_global_query(
             self, custom_headers=None, raw=False, **operation_config):
@@ -302,7 +308,7 @@ class ImplicitOperations(object):
          :class:`ErrorException<requiredoptional.models.ErrorException>`
         """
         # Construct URL
-        url = '/reqopt/global/optional/query'
+        url = self.get_optional_global_query.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -325,3 +331,4 @@ class ImplicitOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_optional_global_query.metadata = {'url': '/reqopt/global/optional/query'}

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/path_items_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/path_items_operations.py
@@ -62,7 +62,7 @@ class PathItemsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'
+        url = self.get_all_with_values.metadata['url']
         path_format_arguments = {
             'localStringPath': self._serialize.url("local_string_path", local_string_path, 'str'),
             'pathItemStringPath': self._serialize.url("path_item_string_path", path_item_string_path, 'str'),
@@ -95,6 +95,7 @@ class PathItemsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_all_with_values.metadata = {'url': '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery'}
 
     def get_global_query_null(
             self, local_string_path, path_item_string_path, local_string_query=None, path_item_string_query=None, custom_headers=None, raw=False, **operation_config):
@@ -124,7 +125,7 @@ class PathItemsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'
+        url = self.get_global_query_null.metadata['url']
         path_format_arguments = {
             'localStringPath': self._serialize.url("local_string_path", local_string_path, 'str'),
             'pathItemStringPath': self._serialize.url("path_item_string_path", path_item_string_path, 'str'),
@@ -157,6 +158,7 @@ class PathItemsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_global_query_null.metadata = {'url': '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery'}
 
     def get_global_and_local_query_null(
             self, local_string_path, path_item_string_path, local_string_query=None, path_item_string_query=None, custom_headers=None, raw=False, **operation_config):
@@ -185,7 +187,7 @@ class PathItemsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'
+        url = self.get_global_and_local_query_null.metadata['url']
         path_format_arguments = {
             'localStringPath': self._serialize.url("local_string_path", local_string_path, 'str'),
             'pathItemStringPath': self._serialize.url("path_item_string_path", path_item_string_path, 'str'),
@@ -218,6 +220,7 @@ class PathItemsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_global_and_local_query_null.metadata = {'url': '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null'}
 
     def get_local_path_item_query_null(
             self, local_string_path, path_item_string_path, local_string_query=None, path_item_string_query=None, custom_headers=None, raw=False, **operation_config):
@@ -246,7 +249,7 @@ class PathItemsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'
+        url = self.get_local_path_item_query_null.metadata['url']
         path_format_arguments = {
             'localStringPath': self._serialize.url("local_string_path", local_string_path, 'str'),
             'pathItemStringPath': self._serialize.url("path_item_string_path", path_item_string_path, 'str'),
@@ -279,3 +282,4 @@ class PathItemsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_local_path_item_query_null.metadata = {'url': '/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null'}

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/paths_operations.py
@@ -55,7 +55,7 @@ class PathsOperations(object):
         bool_path = True
 
         # Construct URL
-        url = '/paths/bool/true/{boolPath}'
+        url = self.get_boolean_true.metadata['url']
         path_format_arguments = {
             'boolPath': self._serialize.url("bool_path", bool_path, 'bool')
         }
@@ -80,6 +80,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_boolean_true.metadata = {'url': '/paths/bool/true/{boolPath}'}
 
     def get_boolean_false(
             self, custom_headers=None, raw=False, **operation_config):
@@ -97,7 +98,7 @@ class PathsOperations(object):
         bool_path = False
 
         # Construct URL
-        url = '/paths/bool/false/{boolPath}'
+        url = self.get_boolean_false.metadata['url']
         path_format_arguments = {
             'boolPath': self._serialize.url("bool_path", bool_path, 'bool')
         }
@@ -122,6 +123,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_boolean_false.metadata = {'url': '/paths/bool/false/{boolPath}'}
 
     def get_int_one_million(
             self, custom_headers=None, raw=False, **operation_config):
@@ -139,7 +141,7 @@ class PathsOperations(object):
         int_path = 1000000
 
         # Construct URL
-        url = '/paths/int/1000000/{intPath}'
+        url = self.get_int_one_million.metadata['url']
         path_format_arguments = {
             'intPath': self._serialize.url("int_path", int_path, 'int')
         }
@@ -164,6 +166,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_int_one_million.metadata = {'url': '/paths/int/1000000/{intPath}'}
 
     def get_int_negative_one_million(
             self, custom_headers=None, raw=False, **operation_config):
@@ -181,7 +184,7 @@ class PathsOperations(object):
         int_path = -1000000
 
         # Construct URL
-        url = '/paths/int/-1000000/{intPath}'
+        url = self.get_int_negative_one_million.metadata['url']
         path_format_arguments = {
             'intPath': self._serialize.url("int_path", int_path, 'int')
         }
@@ -206,6 +209,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_int_negative_one_million.metadata = {'url': '/paths/int/-1000000/{intPath}'}
 
     def get_ten_billion(
             self, custom_headers=None, raw=False, **operation_config):
@@ -223,7 +227,7 @@ class PathsOperations(object):
         long_path = 10000000000
 
         # Construct URL
-        url = '/paths/long/10000000000/{longPath}'
+        url = self.get_ten_billion.metadata['url']
         path_format_arguments = {
             'longPath': self._serialize.url("long_path", long_path, 'long')
         }
@@ -248,6 +252,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_ten_billion.metadata = {'url': '/paths/long/10000000000/{longPath}'}
 
     def get_negative_ten_billion(
             self, custom_headers=None, raw=False, **operation_config):
@@ -265,7 +270,7 @@ class PathsOperations(object):
         long_path = -10000000000
 
         # Construct URL
-        url = '/paths/long/-10000000000/{longPath}'
+        url = self.get_negative_ten_billion.metadata['url']
         path_format_arguments = {
             'longPath': self._serialize.url("long_path", long_path, 'long')
         }
@@ -290,6 +295,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_negative_ten_billion.metadata = {'url': '/paths/long/-10000000000/{longPath}'}
 
     def float_scientific_positive(
             self, custom_headers=None, raw=False, **operation_config):
@@ -307,7 +313,7 @@ class PathsOperations(object):
         float_path = 1.034E+20
 
         # Construct URL
-        url = '/paths/float/1.034E+20/{floatPath}'
+        url = self.float_scientific_positive.metadata['url']
         path_format_arguments = {
             'floatPath': self._serialize.url("float_path", float_path, 'float')
         }
@@ -332,6 +338,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    float_scientific_positive.metadata = {'url': '/paths/float/1.034E+20/{floatPath}'}
 
     def float_scientific_negative(
             self, custom_headers=None, raw=False, **operation_config):
@@ -349,7 +356,7 @@ class PathsOperations(object):
         float_path = -1.034E-20
 
         # Construct URL
-        url = '/paths/float/-1.034E-20/{floatPath}'
+        url = self.float_scientific_negative.metadata['url']
         path_format_arguments = {
             'floatPath': self._serialize.url("float_path", float_path, 'float')
         }
@@ -374,6 +381,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    float_scientific_negative.metadata = {'url': '/paths/float/-1.034E-20/{floatPath}'}
 
     def double_decimal_positive(
             self, custom_headers=None, raw=False, **operation_config):
@@ -391,7 +399,7 @@ class PathsOperations(object):
         double_path = 9999999.999
 
         # Construct URL
-        url = '/paths/double/9999999.999/{doublePath}'
+        url = self.double_decimal_positive.metadata['url']
         path_format_arguments = {
             'doublePath': self._serialize.url("double_path", double_path, 'float')
         }
@@ -416,6 +424,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    double_decimal_positive.metadata = {'url': '/paths/double/9999999.999/{doublePath}'}
 
     def double_decimal_negative(
             self, custom_headers=None, raw=False, **operation_config):
@@ -433,7 +442,7 @@ class PathsOperations(object):
         double_path = -9999999.999
 
         # Construct URL
-        url = '/paths/double/-9999999.999/{doublePath}'
+        url = self.double_decimal_negative.metadata['url']
         path_format_arguments = {
             'doublePath': self._serialize.url("double_path", double_path, 'float')
         }
@@ -458,6 +467,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    double_decimal_negative.metadata = {'url': '/paths/double/-9999999.999/{doublePath}'}
 
     def string_unicode(
             self, custom_headers=None, raw=False, **operation_config):
@@ -475,7 +485,7 @@ class PathsOperations(object):
         string_path = "啊齄丂狛狜隣郎隣兀﨩"
 
         # Construct URL
-        url = '/paths/string/unicode/{stringPath}'
+        url = self.string_unicode.metadata['url']
         path_format_arguments = {
             'stringPath': self._serialize.url("string_path", string_path, 'str')
         }
@@ -500,6 +510,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_unicode.metadata = {'url': '/paths/string/unicode/{stringPath}'}
 
     def string_url_encoded(
             self, custom_headers=None, raw=False, **operation_config):
@@ -517,7 +528,7 @@ class PathsOperations(object):
         string_path = "begin!*'();:@ &=+$,/?#[]end"
 
         # Construct URL
-        url = '/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'
+        url = self.string_url_encoded.metadata['url']
         path_format_arguments = {
             'stringPath': self._serialize.url("string_path", string_path, 'str')
         }
@@ -542,6 +553,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_url_encoded.metadata = {'url': '/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}'}
 
     def string_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -559,7 +571,7 @@ class PathsOperations(object):
         string_path = ""
 
         # Construct URL
-        url = '/paths/string/empty/{stringPath}'
+        url = self.string_empty.metadata['url']
         path_format_arguments = {
             'stringPath': self._serialize.url("string_path", string_path, 'str')
         }
@@ -584,6 +596,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_empty.metadata = {'url': '/paths/string/empty/{stringPath}'}
 
     def string_null(
             self, string_path, custom_headers=None, raw=False, **operation_config):
@@ -601,7 +614,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/string/null/{stringPath}'
+        url = self.string_null.metadata['url']
         path_format_arguments = {
             'stringPath': self._serialize.url("string_path", string_path, 'str')
         }
@@ -626,6 +639,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_null.metadata = {'url': '/paths/string/null/{stringPath}'}
 
     def enum_valid(
             self, enum_path, custom_headers=None, raw=False, **operation_config):
@@ -644,7 +658,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/enum/green%20color/{enumPath}'
+        url = self.enum_valid.metadata['url']
         path_format_arguments = {
             'enumPath': self._serialize.url("enum_path", enum_path, 'UriColor')
         }
@@ -669,6 +683,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    enum_valid.metadata = {'url': '/paths/enum/green%20color/{enumPath}'}
 
     def enum_null(
             self, enum_path, custom_headers=None, raw=False, **operation_config):
@@ -688,7 +703,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/string/null/{enumPath}'
+        url = self.enum_null.metadata['url']
         path_format_arguments = {
             'enumPath': self._serialize.url("enum_path", enum_path, 'UriColor')
         }
@@ -713,6 +728,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    enum_null.metadata = {'url': '/paths/string/null/{enumPath}'}
 
     def byte_multi_byte(
             self, byte_path, custom_headers=None, raw=False, **operation_config):
@@ -731,7 +747,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/byte/multibyte/{bytePath}'
+        url = self.byte_multi_byte.metadata['url']
         path_format_arguments = {
             'bytePath': self._serialize.url("byte_path", byte_path, 'bytearray')
         }
@@ -756,6 +772,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    byte_multi_byte.metadata = {'url': '/paths/byte/multibyte/{bytePath}'}
 
     def byte_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -771,7 +788,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/byte/empty/{bytePath}'
+        url = self.byte_empty.metadata['url']
         path_format_arguments = {
             'bytePath': self._serialize.url("self.byte_path", self.byte_path, 'bytearray')
         }
@@ -796,6 +813,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    byte_empty.metadata = {'url': '/paths/byte/empty/{bytePath}'}
 
     def byte_null(
             self, byte_path, custom_headers=None, raw=False, **operation_config):
@@ -813,7 +831,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/byte/null/{bytePath}'
+        url = self.byte_null.metadata['url']
         path_format_arguments = {
             'bytePath': self._serialize.url("byte_path", byte_path, 'bytearray')
         }
@@ -838,6 +856,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    byte_null.metadata = {'url': '/paths/byte/null/{bytePath}'}
 
     def date_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -853,7 +872,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/date/2012-01-01/{datePath}'
+        url = self.date_valid.metadata['url']
         path_format_arguments = {
             'datePath': self._serialize.url("self.date_path", self.date_path, 'date')
         }
@@ -878,6 +897,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_valid.metadata = {'url': '/paths/date/2012-01-01/{datePath}'}
 
     def date_null(
             self, date_path, custom_headers=None, raw=False, **operation_config):
@@ -896,7 +916,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/date/null/{datePath}'
+        url = self.date_null.metadata['url']
         path_format_arguments = {
             'datePath': self._serialize.url("date_path", date_path, 'date')
         }
@@ -921,6 +941,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_null.metadata = {'url': '/paths/date/null/{datePath}'}
 
     def date_time_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -936,7 +957,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'
+        url = self.date_time_valid.metadata['url']
         path_format_arguments = {
             'dateTimePath': self._serialize.url("self.date_time_path", self.date_time_path, 'iso-8601')
         }
@@ -961,6 +982,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_time_valid.metadata = {'url': '/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}'}
 
     def date_time_null(
             self, date_time_path, custom_headers=None, raw=False, **operation_config):
@@ -979,7 +1001,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/datetime/null/{dateTimePath}'
+        url = self.date_time_null.metadata['url']
         path_format_arguments = {
             'dateTimePath': self._serialize.url("date_time_path", date_time_path, 'iso-8601')
         }
@@ -1004,6 +1026,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_time_null.metadata = {'url': '/paths/datetime/null/{dateTimePath}'}
 
     def base64_url(
             self, base64_url_path, custom_headers=None, raw=False, **operation_config):
@@ -1021,7 +1044,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/string/bG9yZW0/{base64UrlPath}'
+        url = self.base64_url.metadata['url']
         path_format_arguments = {
             'base64UrlPath': self._serialize.url("base64_url_path", base64_url_path, 'base64')
         }
@@ -1046,6 +1069,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    base64_url.metadata = {'url': '/paths/string/bG9yZW0/{base64UrlPath}'}
 
     def array_csv_in_path(
             self, array_path, custom_headers=None, raw=False, **operation_config):
@@ -1065,7 +1089,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'
+        url = self.array_csv_in_path.metadata['url']
         path_format_arguments = {
             'arrayPath': self._serialize.url("array_path", array_path, '[str]', div=',')
         }
@@ -1090,6 +1114,7 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_csv_in_path.metadata = {'url': '/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}'}
 
     def unix_time_url(
             self, unix_time_url_path, custom_headers=None, raw=False, **operation_config):
@@ -1107,7 +1132,7 @@ class PathsOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/paths/int/1460505600/{unixTimeUrlPath}'
+        url = self.unix_time_url.metadata['url']
         path_format_arguments = {
             'unixTimeUrlPath': self._serialize.url("unix_time_url_path", unix_time_url_path, 'unix-time')
         }
@@ -1132,3 +1157,4 @@ class PathsOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    unix_time_url.metadata = {'url': '/paths/int/1460505600/{unixTimeUrlPath}'}

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/queries_operations.py
@@ -55,7 +55,7 @@ class QueriesOperations(object):
         bool_query = True
 
         # Construct URL
-        url = '/queries/bool/true'
+        url = self.get_boolean_true.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -77,6 +77,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_boolean_true.metadata = {'url': '/queries/bool/true'}
 
     def get_boolean_false(
             self, custom_headers=None, raw=False, **operation_config):
@@ -94,7 +95,7 @@ class QueriesOperations(object):
         bool_query = False
 
         # Construct URL
-        url = '/queries/bool/false'
+        url = self.get_boolean_false.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -116,6 +117,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_boolean_false.metadata = {'url': '/queries/bool/false'}
 
     def get_boolean_null(
             self, bool_query=None, custom_headers=None, raw=False, **operation_config):
@@ -133,7 +135,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/bool/null'
+        url = self.get_boolean_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -156,6 +158,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_boolean_null.metadata = {'url': '/queries/bool/null'}
 
     def get_int_one_million(
             self, custom_headers=None, raw=False, **operation_config):
@@ -173,7 +176,7 @@ class QueriesOperations(object):
         int_query = 1000000
 
         # Construct URL
-        url = '/queries/int/1000000'
+        url = self.get_int_one_million.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -195,6 +198,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_int_one_million.metadata = {'url': '/queries/int/1000000'}
 
     def get_int_negative_one_million(
             self, custom_headers=None, raw=False, **operation_config):
@@ -212,7 +216,7 @@ class QueriesOperations(object):
         int_query = -1000000
 
         # Construct URL
-        url = '/queries/int/-1000000'
+        url = self.get_int_negative_one_million.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -234,6 +238,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_int_negative_one_million.metadata = {'url': '/queries/int/-1000000'}
 
     def get_int_null(
             self, int_query=None, custom_headers=None, raw=False, **operation_config):
@@ -251,7 +256,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/int/null'
+        url = self.get_int_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -274,6 +279,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_int_null.metadata = {'url': '/queries/int/null'}
 
     def get_ten_billion(
             self, custom_headers=None, raw=False, **operation_config):
@@ -291,7 +297,7 @@ class QueriesOperations(object):
         long_query = 10000000000
 
         # Construct URL
-        url = '/queries/long/10000000000'
+        url = self.get_ten_billion.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -313,6 +319,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_ten_billion.metadata = {'url': '/queries/long/10000000000'}
 
     def get_negative_ten_billion(
             self, custom_headers=None, raw=False, **operation_config):
@@ -330,7 +337,7 @@ class QueriesOperations(object):
         long_query = -10000000000
 
         # Construct URL
-        url = '/queries/long/-10000000000'
+        url = self.get_negative_ten_billion.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -352,6 +359,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_negative_ten_billion.metadata = {'url': '/queries/long/-10000000000'}
 
     def get_long_null(
             self, long_query=None, custom_headers=None, raw=False, **operation_config):
@@ -369,7 +377,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/long/null'
+        url = self.get_long_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -392,6 +400,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_long_null.metadata = {'url': '/queries/long/null'}
 
     def float_scientific_positive(
             self, custom_headers=None, raw=False, **operation_config):
@@ -409,7 +418,7 @@ class QueriesOperations(object):
         float_query = 1.034E+20
 
         # Construct URL
-        url = '/queries/float/1.034E+20'
+        url = self.float_scientific_positive.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -431,6 +440,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    float_scientific_positive.metadata = {'url': '/queries/float/1.034E+20'}
 
     def float_scientific_negative(
             self, custom_headers=None, raw=False, **operation_config):
@@ -448,7 +458,7 @@ class QueriesOperations(object):
         float_query = -1.034E-20
 
         # Construct URL
-        url = '/queries/float/-1.034E-20'
+        url = self.float_scientific_negative.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -470,6 +480,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    float_scientific_negative.metadata = {'url': '/queries/float/-1.034E-20'}
 
     def float_null(
             self, float_query=None, custom_headers=None, raw=False, **operation_config):
@@ -487,7 +498,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/float/null'
+        url = self.float_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -510,6 +521,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    float_null.metadata = {'url': '/queries/float/null'}
 
     def double_decimal_positive(
             self, custom_headers=None, raw=False, **operation_config):
@@ -527,7 +539,7 @@ class QueriesOperations(object):
         double_query = 9999999.999
 
         # Construct URL
-        url = '/queries/double/9999999.999'
+        url = self.double_decimal_positive.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -549,6 +561,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    double_decimal_positive.metadata = {'url': '/queries/double/9999999.999'}
 
     def double_decimal_negative(
             self, custom_headers=None, raw=False, **operation_config):
@@ -566,7 +579,7 @@ class QueriesOperations(object):
         double_query = -9999999.999
 
         # Construct URL
-        url = '/queries/double/-9999999.999'
+        url = self.double_decimal_negative.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -588,6 +601,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    double_decimal_negative.metadata = {'url': '/queries/double/-9999999.999'}
 
     def double_null(
             self, double_query=None, custom_headers=None, raw=False, **operation_config):
@@ -605,7 +619,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/double/null'
+        url = self.double_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -628,6 +642,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    double_null.metadata = {'url': '/queries/double/null'}
 
     def string_unicode(
             self, custom_headers=None, raw=False, **operation_config):
@@ -645,7 +660,7 @@ class QueriesOperations(object):
         string_query = "啊齄丂狛狜隣郎隣兀﨩"
 
         # Construct URL
-        url = '/queries/string/unicode/'
+        url = self.string_unicode.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -667,6 +682,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_unicode.metadata = {'url': '/queries/string/unicode/'}
 
     def string_url_encoded(
             self, custom_headers=None, raw=False, **operation_config):
@@ -684,7 +700,7 @@ class QueriesOperations(object):
         string_query = "begin!*'();:@ &=+$,/?#[]end"
 
         # Construct URL
-        url = '/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend'
+        url = self.string_url_encoded.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -706,6 +722,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_url_encoded.metadata = {'url': '/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend'}
 
     def string_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -723,7 +740,7 @@ class QueriesOperations(object):
         string_query = ""
 
         # Construct URL
-        url = '/queries/string/empty'
+        url = self.string_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -745,6 +762,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_empty.metadata = {'url': '/queries/string/empty'}
 
     def string_null(
             self, string_query=None, custom_headers=None, raw=False, **operation_config):
@@ -762,7 +780,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/string/null'
+        url = self.string_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -785,6 +803,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    string_null.metadata = {'url': '/queries/string/null'}
 
     def enum_valid(
             self, enum_query=None, custom_headers=None, raw=False, **operation_config):
@@ -803,7 +822,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/enum/green%20color'
+        url = self.enum_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -826,6 +845,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    enum_valid.metadata = {'url': '/queries/enum/green%20color'}
 
     def enum_null(
             self, enum_query=None, custom_headers=None, raw=False, **operation_config):
@@ -844,7 +864,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/enum/null'
+        url = self.enum_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -867,6 +887,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    enum_null.metadata = {'url': '/queries/enum/null'}
 
     def byte_multi_byte(
             self, byte_query=None, custom_headers=None, raw=False, **operation_config):
@@ -885,7 +906,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/byte/multibyte'
+        url = self.byte_multi_byte.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -908,6 +929,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    byte_multi_byte.metadata = {'url': '/queries/byte/multibyte'}
 
     def byte_empty(
             self, custom_headers=None, raw=False, **operation_config):
@@ -923,7 +945,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/byte/empty'
+        url = self.byte_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -945,6 +967,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    byte_empty.metadata = {'url': '/queries/byte/empty'}
 
     def byte_null(
             self, byte_query=None, custom_headers=None, raw=False, **operation_config):
@@ -962,7 +985,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/byte/null'
+        url = self.byte_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -985,6 +1008,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    byte_null.metadata = {'url': '/queries/byte/null'}
 
     def date_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1000,7 +1024,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/date/2012-01-01'
+        url = self.date_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1022,6 +1046,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_valid.metadata = {'url': '/queries/date/2012-01-01'}
 
     def date_null(
             self, date_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1039,7 +1064,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/date/null'
+        url = self.date_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1062,6 +1087,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_null.metadata = {'url': '/queries/date/null'}
 
     def date_time_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -1077,7 +1103,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/datetime/2012-01-01T01%3A01%3A01Z'
+        url = self.date_time_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1099,6 +1125,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_time_valid.metadata = {'url': '/queries/datetime/2012-01-01T01%3A01%3A01Z'}
 
     def date_time_null(
             self, date_time_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1116,7 +1143,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/datetime/null'
+        url = self.date_time_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1139,6 +1166,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    date_time_null.metadata = {'url': '/queries/datetime/null'}
 
     def array_string_csv_valid(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1158,7 +1186,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/csv/string/valid'
+        url = self.array_string_csv_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1181,6 +1209,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_csv_valid.metadata = {'url': '/queries/array/csv/string/valid'}
 
     def array_string_csv_null(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1198,7 +1227,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/csv/string/null'
+        url = self.array_string_csv_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1221,6 +1250,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_csv_null.metadata = {'url': '/queries/array/csv/string/null'}
 
     def array_string_csv_empty(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1239,7 +1269,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/csv/string/empty'
+        url = self.array_string_csv_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1262,6 +1292,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_csv_empty.metadata = {'url': '/queries/array/csv/string/empty'}
 
     def array_string_ssv_valid(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1281,7 +1312,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/ssv/string/valid'
+        url = self.array_string_ssv_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1304,6 +1335,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_ssv_valid.metadata = {'url': '/queries/array/ssv/string/valid'}
 
     def array_string_tsv_valid(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1323,7 +1355,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/tsv/string/valid'
+        url = self.array_string_tsv_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1346,6 +1378,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_tsv_valid.metadata = {'url': '/queries/array/tsv/string/valid'}
 
     def array_string_pipes_valid(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -1365,7 +1398,7 @@ class QueriesOperations(object):
         :raises: :class:`ErrorException<url.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/pipes/string/valid'
+        url = self.array_string_pipes_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -1388,3 +1421,4 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_pipes_valid.metadata = {'url': '/queries/array/pipes/string/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/operations/queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/operations/queries_operations.py
@@ -51,7 +51,7 @@ class QueriesOperations(object):
          :class:`ErrorException<urlmulticollectionformat.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/multi/string/null'
+        url = self.array_string_multi_null.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -74,6 +74,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_multi_null.metadata = {'url': '/queries/array/multi/string/null'}
 
     def array_string_multi_empty(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -93,7 +94,7 @@ class QueriesOperations(object):
          :class:`ErrorException<urlmulticollectionformat.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/multi/string/empty'
+        url = self.array_string_multi_empty.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -116,6 +117,7 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_multi_empty.metadata = {'url': '/queries/array/multi/string/empty'}
 
     def array_string_multi_valid(
             self, array_query=None, custom_headers=None, raw=False, **operation_config):
@@ -136,7 +138,7 @@ class QueriesOperations(object):
          :class:`ErrorException<urlmulticollectionformat.models.ErrorException>`
         """
         # Construct URL
-        url = '/queries/array/multi/string/valid'
+        url = self.array_string_multi_valid.metadata['url']
 
         # Construct parameters
         query_parameters = {}
@@ -159,3 +161,4 @@ class QueriesOperations(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    array_string_multi_valid.metadata = {'url': '/queries/array/multi/string/valid'}

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/auto_rest_validation_test.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/auto_rest_validation_test.py
@@ -85,7 +85,7 @@ class AutoRestValidationTest(object):
         :raises: :class:`ErrorException<validation.models.ErrorException>`
         """
         # Construct URL
-        url = '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+        url = self.validation_of_method_parameters.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str', max_length=10, min_length=3, pattern=r'[a-zA-Z0-9]+'),
@@ -120,6 +120,7 @@ class AutoRestValidationTest(object):
             return client_raw_response
 
         return deserialized
+    validation_of_method_parameters.metadata = {'url': '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'}
 
     def validation_of_body(
             self, resource_group_name, id, body=None, custom_headers=None, raw=False, **operation_config):
@@ -143,7 +144,7 @@ class AutoRestValidationTest(object):
         :raises: :class:`ErrorException<validation.models.ErrorException>`
         """
         # Construct URL
-        url = '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'
+        url = self.validation_of_body.metadata['url']
         path_format_arguments = {
             'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
             'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str', max_length=10, min_length=3, pattern=r'[a-zA-Z0-9]+'),
@@ -185,6 +186,7 @@ class AutoRestValidationTest(object):
             return client_raw_response
 
         return deserialized
+    validation_of_body.metadata = {'url': '/fakepath/{subscriptionId}/{resourceGroupName}/{id}'}
 
     def get_with_constant_in_path(
             self, custom_headers=None, raw=False, **operation_config):
@@ -203,7 +205,7 @@ class AutoRestValidationTest(object):
         constant_param = "constant"
 
         # Construct URL
-        url = '/validation/constantsInPath/{constantParam}/value'
+        url = self.get_with_constant_in_path.metadata['url']
         path_format_arguments = {
             'constantParam': self._serialize.url("constant_param", constant_param, 'str')
         }
@@ -228,6 +230,7 @@ class AutoRestValidationTest(object):
         if raw:
             client_raw_response = ClientRawResponse(None, response)
             return client_raw_response
+    get_with_constant_in_path.metadata = {'url': '/validation/constantsInPath/{constantParam}/value'}
 
     def post_with_constant_in_body(
             self, body=None, custom_headers=None, raw=False, **operation_config):
@@ -249,7 +252,7 @@ class AutoRestValidationTest(object):
         constant_param = "constant"
 
         # Construct URL
-        url = '/validation/constantsInPath/{constantParam}/value'
+        url = self.post_with_constant_in_body.metadata['url']
         path_format_arguments = {
             'constantParam': self._serialize.url("constant_param", constant_param, 'str')
         }
@@ -288,3 +291,4 @@ class AutoRestValidationTest(object):
             return client_raw_response
 
         return deserialized
+    post_with_constant_in_body.metadata = {'url': '/validation/constantsInPath/{constantParam}/value'}


### PR DESCRIPTION
@annatisch @johanste This is exporting the URL used in Autorest outside of the operation method. This will allow Profiles matching to be done based on the Url (by looking at `method.metadata['url']`. This does not require msrest change and is 100% backward compatible (inspect will still give the same results, etc.)

This could be enhanced in the future with more metadata (return type, HTTP verb, etc.). At the end, the method itself could become an empty shell where every important information is inside metadata (not there yet :)).