### PR TITLE
Correct typo of "multi" in acceptance tests

### DIFF
--- a/test/vanilla/AcceptanceTests/test_url.py
+++ b/test/vanilla/AcceptanceTests/test_url.py
@@ -43,7 +43,7 @@ sys.path.append(join(tests, "UrlMultiCollectionFormat"))
 from msrest.exceptions import DeserializationError, ValidationError
 
 from url import AutoRestUrlTestService
-from urlmulticollectionformat import AutoRestUrlMutliCollectionFormatTestService
+from urlmulticollectionformat import AutoRestUrlMultiCollectionFormatTestService
 from url.models.auto_rest_url_test_service_enums import UriColor
 
 import pytest
@@ -55,7 +55,7 @@ def client():
 
 @pytest.fixture
 def multi_client():
-    with AutoRestUrlMutliCollectionFormatTestService("http://localhost:3000") as client:
+    with AutoRestUrlMultiCollectionFormatTestService("http://localhost:3000") as client:
         yield client
 
 class TestUrl(object):

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/__init__.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/__init__.py
@@ -9,10 +9,10 @@
 # regenerated.
 # --------------------------------------------------------------------------
 
-from .auto_rest_url_mutli_collection_format_test_service import AutoRestUrlMutliCollectionFormatTestService
+from .auto_rest_url_multi_collection_format_test_service import AutoRestUrlMultiCollectionFormatTestService
 from .version import VERSION
 
-__all__ = ['AutoRestUrlMutliCollectionFormatTestService']
+__all__ = ['AutoRestUrlMultiCollectionFormatTestService']
 
 __version__ = VERSION
 

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/auto_rest_url_multi_collection_format_test_service.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/auto_rest_url_multi_collection_format_test_service.py
@@ -16,8 +16,8 @@ from .operations.queries_operations import QueriesOperations
 from . import models
 
 
-class AutoRestUrlMutliCollectionFormatTestServiceConfiguration(Configuration):
-    """Configuration for AutoRestUrlMutliCollectionFormatTestService
+class AutoRestUrlMultiCollectionFormatTestServiceConfiguration(Configuration):
+    """Configuration for AutoRestUrlMultiCollectionFormatTestService
     Note that all parameters used to create this instance are saved as instance
     attributes.
 
@@ -30,16 +30,16 @@ class AutoRestUrlMutliCollectionFormatTestServiceConfiguration(Configuration):
         if not base_url:
             base_url = 'http://localhost:3000'
 
-        super(AutoRestUrlMutliCollectionFormatTestServiceConfiguration, self).__init__(base_url)
+        super(AutoRestUrlMultiCollectionFormatTestServiceConfiguration, self).__init__(base_url)
 
-        self.add_user_agent('autoresturlmutlicollectionformattestservice/{}'.format(VERSION))
+        self.add_user_agent('autoresturlmulticollectionformattestservice/{}'.format(VERSION))
 
 
-class AutoRestUrlMutliCollectionFormatTestService(SDKClient):
+class AutoRestUrlMultiCollectionFormatTestService(SDKClient):
     """Test Infrastructure for AutoRest
 
     :ivar config: Configuration for client.
-    :vartype config: AutoRestUrlMutliCollectionFormatTestServiceConfiguration
+    :vartype config: AutoRestUrlMultiCollectionFormatTestServiceConfiguration
 
     :ivar queries: Queries operations
     :vartype queries: urlmulticollectionformat.operations.QueriesOperations
@@ -50,8 +50,8 @@ class AutoRestUrlMutliCollectionFormatTestService(SDKClient):
     def __init__(
             self, base_url=None):
 
-        self.config = AutoRestUrlMutliCollectionFormatTestServiceConfiguration(base_url)
-        super(AutoRestUrlMutliCollectionFormatTestService, self).__init__(None, self.config)
+        self.config = AutoRestUrlMultiCollectionFormatTestServiceConfiguration(base_url)
+        super(AutoRestUrlMultiCollectionFormatTestService, self).__init__(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
         self.api_version = '1.0.0'

--- a/test/vanilla/Python.Tests.pyproj
+++ b/test/vanilla/Python.Tests.pyproj
@@ -178,9 +178,9 @@
     <Folder Include="Expected\AcceptanceTests\RequiredOptional\auto_rest_required_optional_test_service\operations\" />
     <Folder Include="Expected\AcceptanceTests\RequiredOptional\fixtures\" />
     <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\" />
-    <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\auto_rest_url_mutli_collection_format_test_service\" />
-    <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\auto_rest_url_mutli_collection_format_test_service\models\" />
-    <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\auto_rest_url_mutli_collection_format_test_service\operations\" />
+    <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\auto_rest_url_multi_collection_format_test_service\" />
+    <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\auto_rest_url_multi_collection_format_test_service\models\" />
+    <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\auto_rest_url_multi_collection_format_test_service\operations\" />
     <Folder Include="Expected\AcceptanceTests\UrlMultiCollectionFormat\fixtures\" />
     <Folder Include="Expected\AcceptanceTests\Url\" />
     <Folder Include="Expected\AcceptanceTests\Url\auto_rest_url_test_service\" />


### PR DESCRIPTION
I ran across what appears to be a typo in the acceptance tests, referring to "multi" as "mutli."

This minor PR corrects the typo (including in one filename). Tests appear to pass as expected after the change.