### PR TITLE
Update to configuration to use modeler four

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml
 use-extension:
+  # during development, you can run `autorest-beta --reset` to force it to upgrade the modeler. 
   "@autorest/modelerfour": "~4.0.2"
 
 pipeline:

--- a/README.md
+++ b/README.md
@@ -23,26 +23,22 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml
 use-extension:
-  "@microsoft.azure/autorest.remodeler": "beta"
+  "@autorest/modelerfour": "~4.0.2"
 
 pipeline:
 
 # --- extension remodeler ---
 
   # "Shake the tree", and normalize the model
-  remodeler:
+  modelerfour:
     input: openapi-document/multi-api/identity     # the plugin where we get inputs from
 
   # allow developer to do transformations on the code model.
-  remodeler/new-transform:
-    input: remodeler
-
-  # Make some interpretations about what some things in the model mean
-  tweakcodemodel:
-    input: remodeler/new-transform
+  modelerfour/new-transform:
+    input: modelerfour
 
   mapper:
-    input: tweakcodemodel      # the plugin where we get inputs from
+    input: modelerfour/new-transform      # the plugin where we get inputs from
     output-artifact: python-files
 
   mapper/emitter:

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
-  "name": "@microsoft.azure/autorest.python",
+  "name": "@autorest/python",
   "version": "5.0.0",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
-    "autorest": "autorest",
-    "start": "python -m autorest.jsonrpc.server",
-    "build": "mvn package -Dlocal"
+    "start": "python -m autorest.jsonrpc.server"
   },
   "repository": {
     "type": "git",
@@ -24,6 +22,6 @@
   "homepage": "https://github.com/Azure/autorest.python/blob/master/README.md",
   "devDependencies": {
     "@microsoft.azure/autorest.testserver": "^2.6.6",
-    "autorest": "^2.0.4203"
+    "@autorest/autorest": "^3.0.0"
   }
 }


### PR DESCRIPTION
This should let you get the code model from the new 'modeler four' 

Note! you're going to want to make sure you have the latest autorest beta ( `npm install -g @autorest/autorest` and `autorest-beta --reset` ) as it fixes the weird glitch when python is installed from the store.