### PR TITLE
Add cookie fixture to async tests

### DIFF
--- a/test/azure/AcceptanceTests/asynctests/test_lro.py
+++ b/test/azure/AcceptanceTests/asynctests/test_lro.py
@@ -45,6 +45,7 @@ from msrest.authentication import BasicTokenAuthentication
 
 from azure.core.exceptions import DecodeError
 from azure.core.polling import async_poller
+from azure.core.pipeline.policies import ContentDecodePolicy, AsyncRetryPolicy, HeadersPolicy
 
 from azure.mgmt.core.exceptions import ARMError
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
@@ -85,10 +86,16 @@ class AutorestTestARMPolling(AsyncARMPolling):
         return (await self._client._pipeline.run(request, stream=False, **self._operation_config)).http_response
 
 @pytest.fixture()
-async def client():
+async def client(cookie_policy):
     """Create a AutoRestLongRunningOperationTestService client with test server credentials."""
     cred = BasicTokenAuthentication({"access_token" :str(uuid4())})
-    async with AutoRestLongRunningOperationTestService(cred, base_url="http://localhost:3000", polling_interval=0) as client:
+    policies = [
+        HeadersPolicy(),
+        ContentDecodePolicy(),
+        AsyncRetryPolicy(),
+        cookie_policy
+    ]
+    async with AutoRestLongRunningOperationTestService(cred, base_url="http://localhost:3000", policies=policies, polling_interval=0) as client:
         yield client
 
 

--- a/test/azure/AcceptanceTests/asynctests/test_paging.py
+++ b/test/azure/AcceptanceTests/asynctests/test_paging.py
@@ -48,13 +48,20 @@ from paging.aio import AutoRestPagingTestService
 from paging.models import PagingGetMultiplePagesWithOffsetOptions
 
 from azure.core.exceptions import HttpResponseError
+from azure.core.pipeline.policies import ContentDecodePolicy, AsyncRetryPolicy, HeadersPolicy
 
 import pytest
 
 @pytest.fixture
-async def paging_client():
+async def paging_client(cookie_policy):
     cred = BasicTokenAuthentication({"access_token" :str(uuid4())})
-    async with AutoRestPagingTestService(cred, base_url="http://localhost:3000") as client:
+    policies = [
+        HeadersPolicy(),
+        ContentDecodePolicy(),
+        AsyncRetryPolicy(),
+        cookie_policy
+    ]
+    async with AutoRestPagingTestService(cred, base_url="http://localhost:3000", policies=policies) as client:
         yield client
 
 @pytest.mark.asyncio

--- a/test/azure/AcceptanceTests/test_lro.py
+++ b/test/azure/AcceptanceTests/test_lro.py
@@ -46,8 +46,6 @@ from msrest.authentication import BasicTokenAuthentication
 from azure.core.exceptions import DecodeError
 from azure.core.polling import LROPoller
 from azure.core.pipeline.policies import ContentDecodePolicy, RetryPolicy, HeadersPolicy
-from azure.core.pipeline.transport import RequestsTransport
-from azure.core.pipeline import Pipeline
 
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 from azure.mgmt.core.exceptions import ARMError

--- a/test/vanilla/AcceptanceTests/asynctests/test_http.py
+++ b/test/vanilla/AcceptanceTests/asynctests/test_http.py
@@ -43,6 +43,7 @@ tests = realpath(join(cwd, pardir, "Expected", "AcceptanceTests"))
 sys.path.append(join(tests, "Http"))
 
 from azure.core.exceptions import HttpResponseError
+from azure.core.pipeline.policies import ContentDecodePolicy, AsyncRetryPolicy, HeadersPolicy, AsyncRedirectPolicy
 from msrest.exceptions import DeserializationError
 
 from httpinfrastructure.aio import AutoRestHttpInfrastructureTestService
@@ -53,10 +54,17 @@ import pytest
 
 
 @pytest.fixture()
-def client():
+async def client(cookie_policy):
     """Create a AutoRestHttpInfrastructureTestService client with test server credentials."""
-    client = AutoRestHttpInfrastructureTestService(base_url="http://localhost:3000")
-    return client
+    policies = [
+        HeadersPolicy(),
+        ContentDecodePolicy(),
+        AsyncRedirectPolicy(),
+        AsyncRetryPolicy(),
+        cookie_policy
+    ]
+    async with AutoRestHttpInfrastructureTestService(base_url="http://localhost:3000", policies=policies) as client:
+        yield client
 
 
 class TestHttp(object):

--- a/test/vanilla/AcceptanceTests/test_http.py
+++ b/test/vanilla/AcceptanceTests/test_http.py
@@ -43,6 +43,7 @@ tests = realpath(join(cwd, pardir, "Expected", "AcceptanceTests"))
 sys.path.append(join(tests, "Http"))
 
 from azure.core.exceptions import HttpResponseError
+from azure.core.pipeline.policies import ContentDecodePolicy, RetryPolicy, HeadersPolicy, RedirectPolicy
 from msrest.exceptions import DeserializationError
 
 from httpinfrastructure import AutoRestHttpInfrastructureTestService
@@ -53,9 +54,16 @@ import pytest
 
 
 @pytest.fixture()
-def client():
+def client(cookie_policy):
     """Create a AutoRestHttpInfrastructureTestService client with test server credentials."""
-    with AutoRestHttpInfrastructureTestService(base_url="http://localhost:3000") as client:
+    policies = [
+        HeadersPolicy(),
+        ContentDecodePolicy(),
+        RedirectPolicy(),
+        RetryPolicy(),
+        cookie_policy
+    ]
+    with AutoRestHttpInfrastructureTestService(base_url="http://localhost:3000", policies=policies) as client:
         yield client
 
 


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/pull/7777 requires to enable cookie fixture in async tests