### PR TITLE
Declare char as a type of string

### DIFF
--- a/autorest/codegen/models/primitive_schemas.py
+++ b/autorest/codegen/models/primitive_schemas.py
@@ -270,6 +270,7 @@ def get_primitive_schema(namespace: str, yaml_data: Dict[str, Any]) -> "Primitiv
         'integer': NumberSchema,
         'number': NumberSchema,
         'string': StringSchema,
+        'char': StringSchema,
         'date-time': DatetimeSchema,
         'unixtime': UnixTimeSchema,
         'date': DateSchema,


### PR DESCRIPTION
Python will not make a difference between char type and string type

See https://github.com/Azure/autorest.testserver/issues/131 too