### PR TITLE
Fix to support python: settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 #### Python code gen
 
 ``` yaml !$(multiapiscript)
-version: 3.0.6220
+version: 3.0.6225
 use-extension:
   "@autorest/modelerfour": "4.6.199"
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,14 @@ modelerfour:
 
 pipeline:
 
-# --- extension remodeler ---
-
-  python/m2r:
+  python:
+    # just passes content thru, 
+    # makes it so that the python: config section loads.
+    pass-thru: true 
     input: modelerfour/identity
+    
+  python/m2r:
+    input: python
 
   python/namer:
     input: python/m2r


### PR DESCRIPTION
Wait for the next build of autorest cli and autorest.core  before committing this.

The reason batch mode wasn't working (and a few other things) is because when you have settings in `python:` they are tied to the plugin `python` (and the dependent tasks get to share them)

In the new generator, you have multiple plugins, but none were named `python` 

This creates an empty `python` plugin (which just passes content straight thru), and makes `m2r` get the input from that one. 