### PR TITLE
Reorder pipeline so that `python:` settings load earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,19 @@ modelerfour:
 pipeline:
 
   python:
-    # just passes content thru,
-    # makes it so that the python: config section loads.
-    pass-thru: true
-    input: modelerfour/identity
+    # makes it so that the 'python:' config section loads early.
+    null: true   # no actual plugin, just a placeholder
+    input: openapi-document/multi-api/identity
+
+  modelerfour:
+    # in order that the modelerfour/flattener/grouper/etc picks up
+    # configuration nested under python: in the user's config, 
+    # we have to make modelerfour depend on the 'python' task too.
+    input:
+      - python
 
   python/m2r:
-    input: python
+    input: modelerfour/identity
 
   python/namer:
     input: python/m2r

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ modelerfour:
 
 
 pipeline:
-  pipeline:
   python:
     # doesn't process anything, just makes it so that the 'python:' config section loads early.
     pass-thru: true

--- a/README.md
+++ b/README.md
@@ -48,21 +48,23 @@ modelerfour:
 
 
 pipeline:
-
   python:
-    # makes it so that the 'python:' config section loads early.
-    null: true   # no actual plugin, just a placeholder
-    input: openapi-document/multi-api/identity
+    # doesn't process anything, just makes it so that the 'python:' config section loads early.
+    null: true
 
   modelerfour:
     # in order that the modelerfour/flattener/grouper/etc picks up
     # configuration nested under python: in the user's config, 
-    # we have to make modelerfour depend on the 'python' task too.
+    # we have to make modeler four pull from the 'python' task.
     input:
       - python
 
   python/m2r:
-    input: modelerfour/identity
+    # make this set of tasks take python settings too. 
+    # anything that pulls this input will inherit the settings too. 
+    input: 
+      - modelerfour/identity 
+      - python
 
   python/namer:
     input: python/m2r

--- a/README.md
+++ b/README.md
@@ -48,23 +48,20 @@ modelerfour:
 
 
 pipeline:
+  pipeline:
   python:
     # doesn't process anything, just makes it so that the 'python:' config section loads early.
-    null: true
+    pass-thru: true
+    input: openapi-document/multi-api/identity
 
   modelerfour:
     # in order that the modelerfour/flattener/grouper/etc picks up
     # configuration nested under python: in the user's config, 
     # we have to make modeler four pull from the 'python' task.
-    input:
-      - python
+    input: python
 
   python/m2r:
-    # make this set of tasks take python settings too. 
-    # anything that pulls this input will inherit the settings too. 
-    input: 
-      - modelerfour/identity 
-      - python
+    input: modelerfour/identity 
 
   python/namer:
     input: python/m2r


### PR DESCRIPTION
This should fix the problem with things where you have a user configuration file that looks like this:

~~~ markdown
``` yaml $(python)
python:
  azure-arm: true
  license-header: MICROSOFT_MIT_NO_VERSION
  payload-flattening-threshold: 2
```
~~~

(ie https://github.com/Azure/autorest.modelerfour/issues/182) 

The reason this changes, is that in v2 generators, things like flattening were handled by the **common library,** and actually happened during the execution of the python generator, not in the modeler stage. Things that happened during the python generator, inherited configuration from the `python:`  settings section.  

Now, since the modelerfour/flattener handles that before the language-specific generator runs, the settings would either need to be changed to:

~~~ markdown
``` yaml $(python)
azure-arm: true
license-header: MICROSOFT_MIT_NO_VERSION
payload-flattening-threshold: 2
```
~~~

or we make the modelerfour inherit the `python` task, and cascade settings from there. 

Either way is ok (the above is still restricted to when `--python` is specified, since the guard is in place, but this patch makes it so that the user configuration files don't have to be changed. 