### PR TITLE
Various fixes on multiapi script

### DIFF
--- a/autorest/codegen/templates/metadata.json.jinja2
+++ b/autorest/codegen/templates/metadata.json.jinja2
@@ -6,7 +6,7 @@
         "name": {{ code_model.class_name | tojson }},
         "filename": {{ ("_" + code_model.module_name + ".py") | tojson }},
         "description": {{ code_model.description | tojson }},
-        "has_subscription_id": {{ ("subscription_id" in code_model.global_parameters.method | map(attribute="subscription_id") | list) | tojson }}
+        "has_subscription_id": {{ "true" if "subscription_id" in code_model.global_parameters | map(attribute="serialized_name") | list else "false" }}
     },
     "config": {
         "credential": {{ code_model.options['credential'] | tojson }},

--- a/autorest/multiapi/__init__.py
+++ b/autorest/multiapi/__init__.py
@@ -256,8 +256,8 @@ class MultiAPI:
         shutil.rmtree(str(self.output_folder / "operations"), ignore_errors=True)
         shutil.rmtree(str(self.output_folder / "models"), ignore_errors=True)
 
-        conf = self._autorestapi.read_file(Path(last_api_version) / "__init__.py")
-        self._autorestapi.write_file("__init__.py", conf)
+        init_content = self._autorestapi.read_file(Path(last_api_version) / "__init__.py")
+        self._autorestapi.write_file("__init__.py", init_content)
 
         # Detect if this client is using an operation mixin (Network)
         # Operation mixins are available since Autorest.Python 4.x
@@ -323,7 +323,6 @@ class MultiAPI:
             multiapi_serializer.serialize_multiapi_config()
         )
 
-        _LOGGER.debug(conf["default_models"])
         self._autorestapi.write_file(
             Path("models.py"),
             multiapi_serializer.serialize_multiapi_models()

--- a/autorest/multiapi/__init__.py
+++ b/autorest/multiapi/__init__.py
@@ -321,6 +321,13 @@ class MultiAPI:
             Path("_configuration.py"),
             multiapi_serializer.serialize_multiapi_config()
         )
+
+        _LOGGER.debug(conf["default_models"])
+        self._autorestapi.write_file(
+            Path("models.py"),
+            multiapi_serializer.serialize_multiapi_models()
+        )
+
         if mixin_operations:
             self._autorestapi.write_file(
                 Path("_operations_mixin.py"),

--- a/autorest/multiapi/__init__.py
+++ b/autorest/multiapi/__init__.py
@@ -256,14 +256,8 @@ class MultiAPI:
         shutil.rmtree(str(self.output_folder / "operations"), ignore_errors=True)
         shutil.rmtree(str(self.output_folder / "models"), ignore_errors=True)
 
-        shutil.copy(
-            str(self.output_folder / last_api_version / "_configuration.py"),
-            str(self.output_folder / "_configuration.py"),
-        )
-        shutil.copy(
-            str(self.output_folder / last_api_version / "__init__.py"),
-            str(self.output_folder / "__init__.py"),
-        )
+        conf = self._autorestapi.read_file(Path(last_api_version) / "__init__.py")
+        self._autorestapi.write_file("__init__.py", conf)
 
         # Detect if this client is using an operation mixin (Network)
         # Operation mixins are available since Autorest.Python 4.x

--- a/autorest/multiapi/__init__.py
+++ b/autorest/multiapi/__init__.py
@@ -297,6 +297,7 @@ class MultiAPI:
 
         conf = {
             "client_name": metadata_json["client"]["name"],
+            "package_name": self.input_package_name,
             "has_subscription_id": metadata_json["client"]["has_subscription_id"],
             "module_name": module_name,
             "operations": versioned_operations_dict,

--- a/autorest/multiapi/__init__.py
+++ b/autorest/multiapi/__init__.py
@@ -334,5 +334,11 @@ class MultiAPI:
                 multiapi_serializer.serialize_multiapi_operation_mixins()
             )
 
+        if not self._autorestapi.read_file("_version.py"):
+            self._autorestapi.write_file(
+                Path("_version.py"),
+                multiapi_serializer.serialize_multiapi_version()
+            )
+
         _LOGGER.info("Done!")
         return True

--- a/autorest/multiapi/multiapi_serializer.py
+++ b/autorest/multiapi/multiapi_serializer.py
@@ -31,6 +31,10 @@ class MultiAPISerializer:
         template = self.env.get_template("multiapi_models.py.jinja2")
         return template.render(**self.conf)
 
+    def serialize_multiapi_version(self) -> str:
+        template = self.env.get_template("multiapi_version.py.jinja2")
+        return template.render()
+
     def serialize_multiapi_operation_mixins(self) -> str:
         template = self.env.get_template("multiapi_operations_mixin.py.jinja2")
         return template.render(**self.conf)

--- a/autorest/multiapi/multiapi_serializer.py
+++ b/autorest/multiapi/multiapi_serializer.py
@@ -27,6 +27,10 @@ class MultiAPISerializer:
         template = self.env.get_template("multiapi_config.py.jinja2")
         return template.render(client_name=self.conf["client_name"], **self.conf["config"])
 
+    def serialize_multiapi_models(self) -> str:
+        template = self.env.get_template("multiapi_models.py.jinja2")
+        return template.render(**self.conf)
+
     def serialize_multiapi_operation_mixins(self) -> str:
         template = self.env.get_template("multiapi_operations_mixin.py.jinja2")
         return template.render(**self.conf)

--- a/autorest/multiapi/multiapi_serializer.py
+++ b/autorest/multiapi/multiapi_serializer.py
@@ -25,7 +25,11 @@ class MultiAPISerializer:
 
     def serialize_multiapi_config(self) -> str:
         template = self.env.get_template("multiapi_config.py.jinja2")
-        return template.render(client_name=self.conf["client_name"], **self.conf["config"])
+        return template.render(
+            client_name=self.conf["client_name"],
+            package_name=self.conf["package_name"],
+            **self.conf["config"]
+        )
 
     def serialize_multiapi_models(self) -> str:
         template = self.env.get_template("multiapi_models.py.jinja2")

--- a/autorest/multiapi/templates/multiapi_config.py.jinja2
+++ b/autorest/multiapi/templates/multiapi_config.py.jinja2
@@ -67,8 +67,8 @@ class {{ client_name }}Configuration(Configuration):
 {% if credential_scopes %}
         self.credential_scopes = {{ credential_scopes }}
 {% endif %}
+        kwargs.setdefault('sdk_moniker', '{{ package_name|lower }}/{}'.format(VERSION))
         self._configure(**kwargs)
-        self.user_agent_policy.add_user_agent('azsdk-python-{{ client_name|lower }}/{}'.format(VERSION))
 
     def _configure(
         self,

--- a/autorest/multiapi/templates/multiapi_config.py.jinja2
+++ b/autorest/multiapi/templates/multiapi_config.py.jinja2
@@ -24,12 +24,13 @@ def __init__(
 # Changes may cause incorrect behavior and will be lost if the code is
 # regenerated.
 # --------------------------------------------------------------------------
+from typing import Any
 
-{{ imports }}
+from azure.core.configuration import Configuration
+from azure.core.pipeline import policies
 
-{% if not package_version %}
-VERSION = "unknown"
-{% endif %}
+from ._version import VERSION
+
 
 class {{ client_name }}Configuration(Configuration):
     """Configuration for {{ client_name }}.

--- a/autorest/multiapi/templates/multiapi_models.py.jinja2
+++ b/autorest/multiapi/templates/multiapi_models.py.jinja2
@@ -1,0 +1,9 @@
+# coding=utf-8
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+{% for mod_api_version in default_models %}
+from .{{ mod_api_version }}.models import *
+{% endfor %}

--- a/autorest/multiapi/templates/multiapi_version.py.jinja2
+++ b/autorest/multiapi/templates/multiapi_version.py.jinja2
@@ -1,0 +1,8 @@
+# coding=utf-8
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+VERSION = "0.1.0"


### PR DESCRIPTION
- Use autorest to write, otherwise in some cases autorest quit before the Python cache wrote to disk
- "models.py" was missing
- "_version.py" should be written if there is none, so code is importable at least
- Configuration import missing
- Backport UserAgent work