### PR TITLE
Avoiding schema duplication using yaml ids instead of names

### DIFF
--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -151,7 +151,7 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
             ancestors.append(schema)
             while current.base_model:
                 parent = current.base_model
-                if parent.name in seen_schema_names:
+                if parent.id in seen_schema_yaml_ids:
                     break
                 ancestors.insert(0, parent)
                 seen_schema_names.add(current.name)

--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -136,22 +136,29 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
         :return: None
         :rtype: None
         """
-        seen_schemas: Set[str] = set()
+        seen_schema_names: Set[str] = set()
+        seen_schema_yaml_ids: Set[int] = set()
         sorted_schemas: List[ObjectSchema] = []
         for schema in sorted(self.schemas.values(), key=lambda x: x.name.lower()):
-            if schema.name in seen_schemas:
+            if schema.id in seen_schema_yaml_ids:
                 continue
+            if schema.name in seen_schema_names:
+                raise ValueError(
+                    f"We have already generated a schema with name {schema.name}"
+                )
             ancestors = []
             current = schema
             ancestors.append(schema)
             while current.base_model:
                 parent = current.base_model
-                if parent.name in seen_schemas:
+                if parent.name in seen_schema_names:
                     break
                 ancestors.insert(0, parent)
-                seen_schemas.add(current.name)
+                seen_schema_names.add(current.name)
+                seen_schema_yaml_ids.add(current.id)
                 current = parent
-            seen_schemas.add(current.name)
+            seen_schema_names.add(current.name)
+            seen_schema_yaml_ids.add(current.id)
             sorted_schemas += ancestors
         self.sorted_schemas = sorted_schemas
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/Azure/autorest.python/blob/master/README.md",
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "^2.10.9",
-    "@autorest/autorest": "^3.0.0"
+    "@autorest/autorest": "^3.0.0",
+    "@microsoft.azure/autorest.testserver": "^2.10.10"
   },
   "files": [
     "autorest/**/*.py",


### PR DESCRIPTION
fixes #466 

I've also ensured this fails with storage mgmt:
![image](https://user-images.githubusercontent.com/43154838/76031985-b713a700-5eed-11ea-8b76-e0f471022009.png)


I also included an update to package.json in this pr to get the addition of the media types swagger.