### PR TITLE
special case for AnySchema

### DIFF
--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -20,6 +20,7 @@ from .property import Property
 from .parameter_list import ParameterList
 from .imports import FileImport, ImportType
 from .schema_response import SchemaResponse
+from .primitive_schemas import AnySchema
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -306,6 +307,8 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
             schema_obj_id = id(obj.schema)
             _LOGGER.debug("Looking for id %s for member %s", schema_obj_id, obj)
             try:
+                if schema_obj.get("type") == "any":
+                    obj.schema = AnySchema.from_yaml(namespace=self.namespace, yaml_data=schema_obj)
                 obj.schema = self.lookup_schema(schema_obj_id)
             except KeyError:
                 _LOGGER.critical("Unable to ref the object")

--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -309,7 +309,8 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
             try:
                 if schema_obj.get("type") == "any":
                     obj.schema = AnySchema.from_yaml(namespace=self.namespace, yaml_data=schema_obj)
-                obj.schema = self.lookup_schema(schema_obj_id)
+                else:
+                    obj.schema = self.lookup_schema(schema_obj_id)
             except KeyError:
                 _LOGGER.critical("Unable to ref the object")
                 raise


### PR DESCRIPTION
fixes #464 

Previously opened an [issue](https://github.com/Azure/autorest.modelerfour/issues/198) with modelerfour, determined this is not a bug and we should have a special case to deal with AnySchema.

Was causing an issue generating [this](https://github.com/Azure/azure-rest-api-specs/blob/58c68dea43b9924fedaf819bfead1bc922fe9143/specification/web/resource-manager/Microsoft.Web/stable/2016-09-01/AppServicePlans.json#L803), but now generating correctly

![image](https://user-images.githubusercontent.com/43154838/76218254-4a005a00-61ea-11ea-93d9-f487acce4a9a.png)
