### PR TITLE
Optional constant params in signature

### DIFF
--- a/autorest/codegen/models/parameter.py
+++ b/autorest/codegen/models/parameter.py
@@ -82,6 +82,17 @@ class Parameter(BaseModel):  # pylint: disable=too-many-instance-attributes
         self.multiple_media_types_docstring_type: Optional[str] = None
 
     @property
+    def constant(self) -> bool:
+        """Returns whether a parameter is a constant that can't be set to None in a method.
+        If a parameter is a constant, it will not appear in a method signature
+        """
+        if not isinstance(self.schema, ConstantSchema):
+            return False
+        if self.required:
+            return True
+        return self.location == ParameterLocation.Other
+
+    @property
     def implementation(self) -> str:
         # https://github.com/Azure/autorest.modelerfour/issues/81
         if self.serialized_name == "api_version":

--- a/autorest/codegen/models/parameter.py
+++ b/autorest/codegen/models/parameter.py
@@ -83,8 +83,9 @@ class Parameter(BaseModel):  # pylint: disable=too-many-instance-attributes
 
     @property
     def constant(self) -> bool:
-        """Returns whether a parameter is a constant that can't be set to None in a method.
-        If a parameter is a constant, it will not appear in a method signature
+        """Returns whether a parameter is a constant or not.
+        Checking to see if it's required, because if not, we don't consider it
+        a constant because it can have a value of None.
         """
         if not isinstance(self.schema, ConstantSchema):
             return False

--- a/autorest/codegen/models/parameter.py
+++ b/autorest/codegen/models/parameter.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional, List, Any, Union, Tuple
 from .imports import FileImport, ImportType
 from .base_model import BaseModel
 from .base_schema import BaseSchema
+from .constant_schema import ConstantSchema
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,8 +101,12 @@ class Parameter(BaseModel):  # pylint: disable=too-many-instance-attributes
             default_value = None
             default_value_declaration = "None"
         else:
-            default_value = self.schema.default_value
-            default_value_declaration = self.schema.default_value_declaration
+            if isinstance(self.schema, ConstantSchema):
+                default_value = self.schema.constant_value
+                default_value_declaration = default_value
+            else:
+                default_value = self.schema.default_value
+                default_value_declaration = self.schema.default_value_declaration
         if default_value is not None and self.required:
             _LOGGER.warning(
                 "Parameter '%s' is required and has a default value, this combination is not recommended",

--- a/autorest/codegen/models/parameter_list.py
+++ b/autorest/codegen/models/parameter_list.py
@@ -108,7 +108,8 @@ class ParameterList(MutableSequence):
                 # Required constants are not in the signature bc they can only be that constant value.
                 (parameter.required and parameter in self.constant)
                 # Optional constants not in function don't appear in signature
-                or (not parameter.required and parameter in self.constant and parameter.location == ParameterLocation.Other)
+                or (not parameter.required and parameter in self.constant
+                and parameter.location == ParameterLocation.Other)
                 # Client level should not be on Method, etc.
                 or parameter.implementation != self.implementation
                 # If I'm grouped, my grouper will be on signature, not me

--- a/autorest/codegen/models/parameter_list.py
+++ b/autorest/codegen/models/parameter_list.py
@@ -8,7 +8,6 @@ import logging
 from typing import cast, List, Callable, Optional
 
 from .parameter import Parameter, ParameterLocation
-from .constant_schema import ConstantSchema
 from .object_schema import ObjectSchema
 
 

--- a/autorest/codegen/models/parameter_list.py
+++ b/autorest/codegen/models/parameter_list.py
@@ -105,11 +105,7 @@ class ParameterList(MutableSequence):
             """A predicate to tell if this parameter deserves to be in the signature.
             """
             return not (
-                # Required constants are not in the signature bc they can only be that constant value.
-                (parameter.required and parameter in self.constant)
-                # Optional constants not in function don't appear in signature
-                or (not parameter.required and parameter in self.constant
-                and parameter.location == ParameterLocation.Other)
+                parameter.constant
                 # Client level should not be on Method, etc.
                 or parameter.implementation != self.implementation
                 # If I'm grouped, my grouper will be on signature, not me

--- a/autorest/codegen/models/parameter_list.py
+++ b/autorest/codegen/models/parameter_list.py
@@ -105,8 +105,10 @@ class ParameterList(MutableSequence):
             """A predicate to tell if this parameter deserves to be in the signature.
             """
             return not (
-                # Constant are never on signature
-                isinstance(parameter.schema, ConstantSchema)
+                # Required constants are not in the signature bc they can only be that constant value.
+                (parameter.required and parameter in self.constant)
+                # Optional constants not in function don't appear in signature
+                or (not parameter.required and parameter in self.constant and parameter.location == ParameterLocation.Other)
                 # Client level should not be on Method, etc.
                 or parameter.implementation != self.implementation
                 # If I'm grouped, my grouper will be on signature, not me

--- a/autorest/codegen/templates/operation.py.jinja2
+++ b/autorest/codegen/templates/operation.py.jinja2
@@ -25,8 +25,8 @@
 
     {{ operation.parameters.build_flattened_object() }}
 {% endif %}
-{% if operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None) %}
-    {% for constant_parameter in operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None) %}
+{% if operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("constant") %}
+    {% for constant_parameter in operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("constant") %}
     {{ constant_parameter.serialized_name }} = {{ constant_parameter.schema.constant_value }}
     {% endfor %}
 {% endif %}

--- a/autorest/codegen/templates/operation.py.jinja2
+++ b/autorest/codegen/templates/operation.py.jinja2
@@ -25,8 +25,8 @@
 
     {{ operation.parameters.build_flattened_object() }}
 {% endif %}
-{% if operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("constant") %}
-    {% for constant_parameter in operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("constant") %}
+{% if operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("in_method_code") %}
+    {% for constant_parameter in operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("in_method_code") %}
     {{ constant_parameter.serialized_name }} = {{ constant_parameter.schema.constant_value }}
     {% endfor %}
 {% endif %}

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations_async/_string_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations_async/_string_operations_async.py
@@ -86,10 +86,13 @@ class StringOperations:
     @distributed_trace_async
     async def put_null(
         self,
+        string_body: Optional[str] = None,
         **kwargs
     ) -> None:
         """Set string value null.
 
+        :param string_body:
+        :type string_body: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations_async/_string_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations_async/_string_operations_async.py
@@ -100,7 +100,6 @@ class StringOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        string_body = None
 
         # Construct URL
         url = self.put_null.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
@@ -102,7 +102,6 @@ class StringOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        string_body = None
 
         # Construct URL
         url = self.put_null.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
@@ -87,11 +87,14 @@ class StringOperations(object):
     @distributed_trace
     def put_null(
         self,
+        string_body=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Set string value null.
 
+        :param string_body:
+        :type string_body: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_client_failure_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_client_failure_operations_async.py
@@ -174,7 +174,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put400.metadata['url']
@@ -225,7 +224,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch400.metadata['url']
@@ -276,7 +274,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post400.metadata['url']
@@ -327,7 +324,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete400.metadata['url']
@@ -534,7 +530,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put404.metadata['url']
@@ -585,7 +580,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch405.metadata['url']
@@ -636,7 +630,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post406.metadata['url']
@@ -687,7 +680,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete407.metadata['url']
@@ -738,7 +730,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put409.metadata['url']
@@ -945,7 +936,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put413.metadata['url']
@@ -996,7 +986,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch414.metadata['url']
@@ -1047,7 +1036,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post415.metadata['url']
@@ -1137,7 +1125,6 @@ class HttpClientFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete417.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_client_failure_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_client_failure_operations_async.py
@@ -160,10 +160,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def put400(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -208,10 +211,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def patch400(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -256,10 +262,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def post400(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -304,10 +313,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def delete400(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -508,10 +520,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def put404(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 404 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -556,10 +571,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def patch405(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 405 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -604,10 +622,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def post406(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 406 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -652,10 +673,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def delete407(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 407 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -700,10 +724,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def put409(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 409 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -904,10 +931,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def put413(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 413 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -952,10 +982,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def patch414(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 414 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -1000,10 +1033,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def post415(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 415 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -1087,10 +1123,13 @@ class HttpClientFailureOperations:
     @distributed_trace_async
     async def delete417(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 417 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_redirects_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_redirects_operations_async.py
@@ -219,10 +219,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def put301(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -356,10 +359,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def patch302(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -407,10 +413,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def post303(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -588,10 +597,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def put307(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Put redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -640,10 +652,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def patch307(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Patch redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -692,10 +707,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def post307(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Post redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -744,10 +762,13 @@ class HttpRedirectsOperations:
     @distributed_trace_async
     async def delete307(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Delete redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_redirects_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_redirects_operations_async.py
@@ -233,7 +233,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put301.metadata['url']
@@ -373,7 +372,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch302.metadata['url']
@@ -427,7 +425,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post303.metadata['url']
@@ -611,7 +608,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put307.metadata['url']
@@ -666,7 +662,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch307.metadata['url']
@@ -721,7 +716,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post307.metadata['url']
@@ -776,7 +770,6 @@ class HttpRedirectsOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete307.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_retry_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_retry_operations_async.py
@@ -96,7 +96,6 @@ class HttpRetryOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put500.metadata['url']
@@ -147,7 +146,6 @@ class HttpRetryOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch500.metadata['url']
@@ -280,7 +278,6 @@ class HttpRetryOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post503.metadata['url']
@@ -331,7 +328,6 @@ class HttpRetryOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete503.metadata['url']
@@ -382,7 +378,6 @@ class HttpRetryOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put504.metadata['url']
@@ -433,7 +428,6 @@ class HttpRetryOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch504.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_retry_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_retry_operations_async.py
@@ -82,10 +82,13 @@ class HttpRetryOperations:
     @distributed_trace_async
     async def put500(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 500 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -130,10 +133,13 @@ class HttpRetryOperations:
     @distributed_trace_async
     async def patch500(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 500 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -260,10 +266,13 @@ class HttpRetryOperations:
     @distributed_trace_async
     async def post503(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 503 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -308,10 +317,13 @@ class HttpRetryOperations:
     @distributed_trace_async
     async def delete503(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 503 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -356,10 +368,13 @@ class HttpRetryOperations:
     @distributed_trace_async
     async def put504(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 504 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -404,10 +419,13 @@ class HttpRetryOperations:
     @distributed_trace_async
     async def patch504(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 504 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_server_failure_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_server_failure_operations_async.py
@@ -121,10 +121,13 @@ class HttpServerFailureOperations:
     @distributed_trace_async
     async def post505(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 505 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -169,10 +172,13 @@ class HttpServerFailureOperations:
     @distributed_trace_async
     async def delete505(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Return 505 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_server_failure_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_server_failure_operations_async.py
@@ -135,7 +135,6 @@ class HttpServerFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post505.metadata['url']
@@ -186,7 +185,6 @@ class HttpServerFailureOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete505.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_success_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_success_operations_async.py
@@ -168,10 +168,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def put200(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Put boolean value true returning 200 success.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -216,10 +219,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def patch200(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Patch true Boolean value in request returning 200.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -264,10 +270,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def post200(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Post bollean value true in request that returns a 200.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -312,10 +321,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def delete200(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Delete simple boolean value true returns 200.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -360,10 +372,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def put201(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Put true Boolean value in request returns 201.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -408,10 +423,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def post201(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Post true Boolean value in request returns 201 (Created).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -456,10 +474,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def put202(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Put true Boolean value in request returns 202 (Accepted).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -504,10 +525,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def patch202(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Patch true Boolean value in request returns 202.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -552,10 +576,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def post202(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Post true Boolean value in request returns 202 (Accepted).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -600,10 +627,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def delete202(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Delete true Boolean value in request returns 202 (accepted).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -687,10 +717,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def put204(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Put true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -735,10 +768,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def patch204(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Patch true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -783,10 +819,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def post204(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Post true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -831,10 +870,13 @@ class HttpSuccessOperations:
     @distributed_trace_async
     async def delete204(
         self,
+        boolean_value: Optional[bool] = True,
         **kwargs
     ) -> None:
         """Delete true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_success_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations_async/_http_success_operations_async.py
@@ -182,7 +182,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put200.metadata['url']
@@ -233,7 +232,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch200.metadata['url']
@@ -284,7 +282,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post200.metadata['url']
@@ -335,7 +332,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete200.metadata['url']
@@ -386,7 +382,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put201.metadata['url']
@@ -437,7 +432,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post201.metadata['url']
@@ -488,7 +482,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put202.metadata['url']
@@ -539,7 +532,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch202.metadata['url']
@@ -590,7 +582,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post202.metadata['url']
@@ -641,7 +632,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete202.metadata['url']
@@ -731,7 +721,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put204.metadata['url']
@@ -782,7 +771,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch204.metadata['url']
@@ -833,7 +821,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post204.metadata['url']
@@ -884,7 +871,6 @@ class HttpSuccessOperations:
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete204.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
@@ -178,7 +178,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put400.metadata['url']
@@ -230,7 +229,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch400.metadata['url']
@@ -282,7 +280,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post400.metadata['url']
@@ -334,7 +331,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete400.metadata['url']
@@ -546,7 +542,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put404.metadata['url']
@@ -598,7 +593,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch405.metadata['url']
@@ -650,7 +644,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post406.metadata['url']
@@ -702,7 +695,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete407.metadata['url']
@@ -754,7 +746,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put409.metadata['url']
@@ -966,7 +957,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put413.metadata['url']
@@ -1018,7 +1008,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch414.metadata['url']
@@ -1070,7 +1059,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post415.metadata['url']
@@ -1162,7 +1150,6 @@ class HttpClientFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete417.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
@@ -163,11 +163,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def put400(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -212,11 +215,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def patch400(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -261,11 +267,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def post400(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -310,11 +319,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def delete400(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 400 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -519,11 +531,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def put404(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 404 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -568,11 +583,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def patch405(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 405 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -617,11 +635,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def post406(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 406 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -666,11 +687,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def delete407(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 407 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -715,11 +739,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def put409(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 409 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -924,11 +951,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def put413(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 413 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -973,11 +1003,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def patch414(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 414 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -1022,11 +1055,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def post415(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 415 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -1111,11 +1147,14 @@ class HttpClientFailureOperations(object):
     @distributed_trace
     def delete417(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 417 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
@@ -238,7 +238,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put301.metadata['url']
@@ -381,7 +380,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch302.metadata['url']
@@ -436,7 +434,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post303.metadata['url']
@@ -624,7 +621,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put307.metadata['url']
@@ -680,7 +676,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch307.metadata['url']
@@ -736,7 +731,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post307.metadata['url']
@@ -792,7 +786,6 @@ class HttpRedirectsOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete307.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
@@ -223,11 +223,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def put301(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -363,11 +366,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def patch302(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -415,11 +421,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def post303(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -600,11 +609,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def put307(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Put redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -653,11 +665,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def patch307(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Patch redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -706,11 +721,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def post307(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Post redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -759,11 +777,14 @@ class HttpRedirectsOperations(object):
     @distributed_trace
     def delete307(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Delete redirected with 307, resulting in a 200 after redirect.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
@@ -83,11 +83,14 @@ class HttpRetryOperations(object):
     @distributed_trace
     def put500(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 500 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -132,11 +135,14 @@ class HttpRetryOperations(object):
     @distributed_trace
     def patch500(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 500 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -265,11 +271,14 @@ class HttpRetryOperations(object):
     @distributed_trace
     def post503(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 503 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -314,11 +323,14 @@ class HttpRetryOperations(object):
     @distributed_trace
     def delete503(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 503 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -363,11 +375,14 @@ class HttpRetryOperations(object):
     @distributed_trace
     def put504(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 504 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -412,11 +427,14 @@ class HttpRetryOperations(object):
     @distributed_trace
     def patch504(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 504 status code, then 200 after retry.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
@@ -98,7 +98,6 @@ class HttpRetryOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put500.metadata['url']
@@ -150,7 +149,6 @@ class HttpRetryOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch500.metadata['url']
@@ -286,7 +284,6 @@ class HttpRetryOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post503.metadata['url']
@@ -338,7 +335,6 @@ class HttpRetryOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete503.metadata['url']
@@ -390,7 +386,6 @@ class HttpRetryOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put504.metadata['url']
@@ -442,7 +437,6 @@ class HttpRetryOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch504.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
@@ -138,7 +138,6 @@ class HttpServerFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post505.metadata['url']
@@ -190,7 +189,6 @@ class HttpServerFailureOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete505.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
@@ -123,11 +123,14 @@ class HttpServerFailureOperations(object):
     @distributed_trace
     def post505(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 505 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -172,11 +175,14 @@ class HttpServerFailureOperations(object):
     @distributed_trace
     def delete505(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Return 505 status code - should be represented in the client as an error.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
@@ -186,7 +186,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put200.metadata['url']
@@ -238,7 +237,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch200.metadata['url']
@@ -290,7 +288,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post200.metadata['url']
@@ -342,7 +339,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete200.metadata['url']
@@ -394,7 +390,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put201.metadata['url']
@@ -446,7 +441,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post201.metadata['url']
@@ -498,7 +492,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put202.metadata['url']
@@ -550,7 +543,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch202.metadata['url']
@@ -602,7 +594,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post202.metadata['url']
@@ -654,7 +645,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete202.metadata['url']
@@ -746,7 +736,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.put204.metadata['url']
@@ -798,7 +787,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.patch204.metadata['url']
@@ -850,7 +838,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.post204.metadata['url']
@@ -902,7 +889,6 @@ class HttpSuccessOperations(object):
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
-        boolean_value = True
 
         # Construct URL
         url = self.delete204.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
@@ -171,11 +171,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def put200(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Put boolean value true returning 200 success.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -220,11 +223,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def patch200(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Patch true Boolean value in request returning 200.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -269,11 +275,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def post200(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Post bollean value true in request that returns a 200.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -318,11 +327,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def delete200(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Delete simple boolean value true returns 200.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -367,11 +379,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def put201(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Put true Boolean value in request returns 201.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -416,11 +431,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def post201(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Post true Boolean value in request returns 201 (Created).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -465,11 +483,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def put202(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Put true Boolean value in request returns 202 (Accepted).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -514,11 +535,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def patch202(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Patch true Boolean value in request returns 202.
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -563,11 +587,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def post202(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Post true Boolean value in request returns 202 (Accepted).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -612,11 +639,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def delete202(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Delete true Boolean value in request returns 202 (accepted).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -701,11 +731,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def put204(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Put true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -750,11 +783,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def patch204(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Patch true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -799,11 +835,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def post204(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Post true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -848,11 +887,14 @@ class HttpSuccessOperations(object):
     @distributed_trace
     def delete204(
         self,
+        boolean_value=True,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Delete true Boolean value in request returns 204 (no content).
 
+        :param boolean_value: Simple boolean value true.
+        :type boolean_value: bool
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None


### PR DESCRIPTION
fixes #447 

Adds optional constant params to signature if they will appear in function. Also ensure that the default value for these optional constants is their constant value.

![image](https://user-images.githubusercontent.com/43154838/76441122-4e1cab00-6395-11ea-97c4-d4e00dd9f421.png)
