### PR TITLE
adding enum model name collision pipeline resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ modelerfour:
   group-parameters: true
   flatten-models: true
   flatten-payloads: true
+  resolve-schema-name-collisons: true
   naming:
     parameter: snakecase
     property: snakecase


### PR DESCRIPTION
Added because there was an enum-model name collision in storage 2016-12 (had a [model](https://github.com/Azure/azure-rest-api-specs/blob/884245893e9f85bd499369091650695c33835687/specification/storage/resource-manager/Microsoft.Storage/stable/2016-12-01/storage.json#L1057) and [enum](https://github.com/Azure/azure-rest-api-specs/blob/884245893e9f85bd499369091650695c33835687/specification/storage/resource-manager/Microsoft.Storage/stable/2016-12-01/storage.json#L1194) both called Resource)