### PR TITLE
Fix default value enum py3

### DIFF
--- a/autorest/codegen/serializers/model_generic_serializer.py
+++ b/autorest/codegen/serializers/model_generic_serializer.py
@@ -25,6 +25,9 @@ class ModelGenericSerializer(ModelBaseSerializer):
                 discriminator_value = f"'{model.discriminator_value}'" if model.discriminator_value else None
                 init_args.append(f"self.{prop.name} = {discriminator_value}")
             elif not prop.constant:
-                default_value = prop.schema.default_value_declaration
-                init_args.append(f"self.{prop.name} = kwargs.get('{prop.name}', {default_value})")
+                if prop.required and not prop.schema.default_value:
+                    init_args.append(f"self.{prop.name} = kwargs['{prop.name}']")
+                else:
+                    default = prop.schema.default_value_declaration
+                    init_args.append(f"self.{prop.name} = kwargs.get('{prop.name}', {default})")
         return init_args

--- a/autorest/codegen/serializers/model_python3_serializer.py
+++ b/autorest/codegen/serializers/model_python3_serializer.py
@@ -20,10 +20,10 @@ class ModelPython3Serializer(ModelBaseSerializer):
         if init_line_parameters:
             init_properties_declaration.append("*")
         for param in init_line_parameters:
-            if param.required:
+            default_value = param.schema.default_value_declaration
+            if param.required and default_value == "None":
                 init_properties_declaration.append(f"{param.name}: {param.type_annotation}")
             else:
-                default_value = param.schema.default_value_declaration
                 init_properties_declaration.append(f"{param.name}: {param.type_annotation} = {default_value}")
 
         return init_properties_declaration

--- a/autorest/codegen/serializers/model_python3_serializer.py
+++ b/autorest/codegen/serializers/model_python3_serializer.py
@@ -20,11 +20,11 @@ class ModelPython3Serializer(ModelBaseSerializer):
         if init_line_parameters:
             init_properties_declaration.append("*")
         for param in init_line_parameters:
-            default_value = param.schema.default_value_declaration
-            if param.required and default_value == "None":
+            if param.required and not param.schema.default_value:
                 init_properties_declaration.append(f"{param.name}: {param.type_annotation}")
             else:
-                init_properties_declaration.append(f"{param.name}: {param.type_annotation} = {default_value}")
+                default = param.schema.default_value_declaration
+                init_properties_declaration.append(f"{param.name}: {param.type_annotation} = {default}")
 
         return init_properties_declaration
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Azure/autorest.python/blob/master/README.md",
   "devDependencies": {
     "@autorest/autorest": "^3.0.0",
-    "@microsoft.azure/autorest.testserver": "^2.10.17"
+    "@microsoft.azure/autorest.testserver": "^2.10.19"
   },
   "files": [
     "autorest/**/*.py",

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/models/_models.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/models/_models.py
@@ -136,5 +136,5 @@ class ParameterGroupingPostRequiredParameters(msrest.serialization.Model):
         super(ParameterGroupingPostRequiredParameters, self).__init__(**kwargs)
         self.custom_header = kwargs.get('custom_header', None)
         self.query = kwargs.get('query', 30)
-        self.path = kwargs.get('path', None)
-        self.body = kwargs.get('body', None)
+        self.path = kwargs['path']
+        self.body = kwargs['body']

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/models/_models.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/models/_models.py
@@ -68,7 +68,7 @@ class HeaderCustomNamedRequestIdParamGroupingParameters(msrest.serialization.Mod
         **kwargs
     ):
         super(HeaderCustomNamedRequestIdParamGroupingParameters, self).__init__(**kwargs)
-        self.foo_client_request_id = kwargs.get('foo_client_request_id', None)
+        self.foo_client_request_id = kwargs['foo_client_request_id']
 
 
 class OdataFilter(msrest.serialization.Model):

--- a/test/azure/Expected/AcceptanceTests/Paging/paging/models/_models.py
+++ b/test/azure/Expected/AcceptanceTests/Paging/paging/models/_models.py
@@ -35,8 +35,8 @@ class CustomParameterGroup(msrest.serialization.Model):
         **kwargs
     ):
         super(CustomParameterGroup, self).__init__(**kwargs)
-        self.api_version = kwargs.get('api_version', None)
-        self.tenant = kwargs.get('tenant', None)
+        self.api_version = kwargs['api_version']
+        self.tenant = kwargs['tenant']
 
 
 class OdataProductResult(msrest.serialization.Model):
@@ -161,7 +161,7 @@ class PagingGetMultiplePagesWithOffsetOptions(msrest.serialization.Model):
     ):
         super(PagingGetMultiplePagesWithOffsetOptions, self).__init__(**kwargs)
         self.maxresults = kwargs.get('maxresults', None)
-        self.offset = kwargs.get('offset', None)
+        self.offset = kwargs['offset']
         self.timeout = kwargs.get('timeout', 30)
 
 

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/models/_models.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/models/_models.py
@@ -179,7 +179,7 @@ class Resource(msrest.serialization.Model):
         self.id = None
         self.name = None
         self.type = None
-        self.location = kwargs.get('location', None)
+        self.location = kwargs['location']
         self.tags = kwargs.get('tags', None)
 
 
@@ -307,7 +307,7 @@ class StorageAccountCheckNameAvailabilityParameters(msrest.serialization.Model):
         **kwargs
     ):
         super(StorageAccountCheckNameAvailabilityParameters, self).__init__(**kwargs)
-        self.name = kwargs.get('name', None)
+        self.name = kwargs['name']
         self.type = kwargs.get('type', "Microsoft.Storage/storageAccounts")
 
 

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_operations_mixin.py
@@ -20,20 +20,16 @@ class MultiapiServiceClientOperationsMixin(object):
         **kwargs  # type: Any
     ):
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
-
-    :param id:
-    An int parameter.
-    :type id: int
-    :param message: An optional string parameter.
-    :type
-    message: str
-    :keyword callable cls: A custom type or function that will be passed the
-    direct response
-    :return: ModelTwo or the result of cls(response)
-    :rtype:
-    ~multiapi.v2.models.ModelTwo
-    :raises: ~azure.core.exceptions.HttpResponseError
-    """
+    
+        :param id: An int parameter.
+        :type id: int
+        :param message: An optional string parameter.
+        :type message: str
+        :keyword callable cls: A custom type or function that will be passed the direct response
+        :return: ModelTwo or the result of cls(response)
+        :rtype: ~multiapi.v2.models.ModelTwo
+        :raises: ~azure.core.exceptions.HttpResponseError
+        """
 
         api_version = self._get_api_version('test_one')
         if api_version == '1.0.0':

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/models/_models.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/models/_models.py
@@ -58,5 +58,5 @@ class ModelTwo(msrest.serialization.Model):
         **kwargs
     ):
         super(ModelTwo, self).__init__(**kwargs)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.message = kwargs.get('message', None)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_operations_mixin.py
@@ -20,21 +20,16 @@ class MultiapiServiceClientOperationsMixin(object):
         **kwargs  # type: Any
     ):
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
-
-    :param id:
-    An int parameter.
-    :type id: int
-    :param message: An optional string parameter.
-    :type
-    message: str
-    :keyword callable cls: A custom type or function that will be passed the
-    direct response
-    :return: ModelTwo or the result of cls(response)
-    :rtype:
-    ~multiapiwithsubmodule.submodule.v2.models.ModelTwo
-    :raises:
-    ~azure.core.exceptions.HttpResponseError
-    """
+    
+        :param id: An int parameter.
+        :type id: int
+        :param message: An optional string parameter.
+        :type message: str
+        :keyword callable cls: A custom type or function that will be passed the direct response
+        :return: ModelTwo or the result of cls(response)
+        :rtype: ~multiapiwithsubmodule.submodule.v2.models.ModelTwo
+        :raises: ~azure.core.exceptions.HttpResponseError
+        """
 
         api_version = self._get_api_version('test_one')
         if api_version == '1.0.0':

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/models/_models.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/models/_models.py
@@ -58,5 +58,5 @@ class ModelTwo(msrest.serialization.Model):
         **kwargs
     ):
         super(ModelTwo, self).__init__(**kwargs)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.message = kwargs.get('message', None)

--- a/test/vanilla/AcceptanceTests/asynctests/test_string_tests.py
+++ b/test/vanilla/AcceptanceTests/asynctests/test_string_tests.py
@@ -61,7 +61,7 @@ class TestString(object):
     async def test_empty(self, client):
         assert "" ==  (await client.string.get_empty())
         # changing this behavior because of this pr being merged: https://github.com/Azure/autorest.testserver/pull/145/files
-        await client.string.put_empty("")
+        await client.string.put_empty()
 
     @pytest.mark.asyncio
     async def test_mbcs(self, client):

--- a/test/vanilla/AcceptanceTests/test_string_tests.py
+++ b/test/vanilla/AcceptanceTests/test_string_tests.py
@@ -56,7 +56,7 @@ class TestString(object):
     def test_empty(self, client):
         assert "" ==  client.string.get_empty()
         # changing this behavior because of this pr being merged: https://github.com/Azure/autorest.testserver/pull/145/files
-        client.string.put_empty("")
+        client.string.put_empty()
 
     def test_mbcs(self, client):
         try:

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/models/_models.py
@@ -46,7 +46,7 @@ class PetAPTrue(msrest.serialization.Model):
     ):
         super(PetAPTrue, self).__init__(**kwargs)
         self.additional_properties = kwargs.get('additional_properties', None)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.name = kwargs.get('name', None)
         self.status = None
 
@@ -149,7 +149,7 @@ class PetAPInProperties(msrest.serialization.Model):
         **kwargs
     ):
         super(PetAPInProperties, self).__init__(**kwargs)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.name = kwargs.get('name', None)
         self.status = None
         self.additional_properties = kwargs.get('additional_properties', None)
@@ -198,10 +198,10 @@ class PetAPInPropertiesWithAPString(msrest.serialization.Model):
     ):
         super(PetAPInPropertiesWithAPString, self).__init__(**kwargs)
         self.additional_properties = kwargs.get('additional_properties', None)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.name = kwargs.get('name', None)
         self.status = None
-        self.odata_location = kwargs.get('odata_location', None)
+        self.odata_location = kwargs['odata_location']
         self.additional_properties1 = kwargs.get('additional_properties1', None)
 
 
@@ -241,7 +241,7 @@ class PetAPObject(msrest.serialization.Model):
     ):
         super(PetAPObject, self).__init__(**kwargs)
         self.additional_properties = kwargs.get('additional_properties', None)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.name = kwargs.get('name', None)
         self.status = None
 
@@ -282,6 +282,6 @@ class PetAPString(msrest.serialization.Model):
     ):
         super(PetAPString, self).__init__(**kwargs)
         self.additional_properties = kwargs.get('additional_properties', None)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.name = kwargs.get('name', None)
         self.status = None

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/models/_models.py
@@ -192,7 +192,7 @@ class Fish(msrest.serialization.Model):
         super(Fish, self).__init__(**kwargs)
         self.fishtype = None
         self.species = kwargs.get('species', None)
-        self.length = kwargs.get('length', None)
+        self.length = kwargs['length']
         self.siblings = kwargs.get('siblings', None)
 
 
@@ -244,7 +244,7 @@ class Shark(Fish):
         super(Shark, self).__init__(**kwargs)
         self.fishtype = 'shark'
         self.age = kwargs.get('age', None)
-        self.birthday = kwargs.get('birthday', None)
+        self.birthday = kwargs['birthday']
 
 
 class Cookiecuttershark(Shark):

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations_async/_string_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations_async/_string_operations_async.py
@@ -180,13 +180,10 @@ class StringOperations:
     @distributed_trace_async
     async def put_empty(
         self,
-        string_body: str,
         **kwargs
     ) -> None:
         """Set string value empty ''.
 
-        :param string_body:
-        :type string_body: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -195,6 +192,7 @@ class StringOperations:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
         content_type = kwargs.pop("content_type", "application/json")
+        string_body = ""
 
         # Construct URL
         url = self.put_empty.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
@@ -183,14 +183,11 @@ class StringOperations(object):
     @distributed_trace
     def put_empty(
         self,
-        string_body,  # type: str
         **kwargs  # type: Any
     ):
         # type: (...) -> None
         """Set string value empty ''.
 
-        :param string_body:
-        :type string_body: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None
@@ -199,6 +196,7 @@ class StringOperations(object):
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
         error_map = kwargs.pop('error_map', {404: ResourceNotFoundError, 409: ResourceExistsError})
         content_type = kwargs.pop("content_type", "application/json")
+        string_body = ""
 
         # Construct URL
         url = self.put_empty.metadata['url']

--- a/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/models/_models.py
@@ -40,4 +40,4 @@ class Pet(msrest.serialization.Model):
         super(Pet, self).__init__(**kwargs)
         self.name = kwargs.get('name', None)
         self.days_of_week = kwargs.get('days_of_week', "Friday")
-        self.int_enum = kwargs.get('int_enum', None)
+        self.int_enum = kwargs['int_enum']

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/models/_models.py
@@ -37,7 +37,7 @@ class BaseProduct(msrest.serialization.Model):
         **kwargs
     ):
         super(BaseProduct, self).__init__(**kwargs)
-        self.product_id = kwargs.get('product_id', None)
+        self.product_id = kwargs['product_id']
         self.description = kwargs.get('description', None)
 
 
@@ -211,9 +211,9 @@ class FlattenParameterGroup(msrest.serialization.Model):
         **kwargs
     ):
         super(FlattenParameterGroup, self).__init__(**kwargs)
-        self.name = kwargs.get('name', None)
+        self.name = kwargs['name']
         self.simple_body_product = kwargs.get('simple_body_product', None)
-        self.product_id = kwargs.get('product_id', None)
+        self.product_id = kwargs['product_id']
         self.description = kwargs.get('description', None)
         self.max_product_display_name = kwargs.get('max_product_display_name', None)
         self.generic_value = kwargs.get('generic_value', None)

--- a/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/models/_models.py
@@ -31,4 +31,4 @@ class AvailabilitySetUpdateParameters(msrest.serialization.Model):
         **kwargs
     ):
         super(AvailabilitySetUpdateParameters, self).__init__(**kwargs)
-        self.tags = kwargs.get('tags', None)
+        self.tags = kwargs['tags']

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/models/_models.py
@@ -51,7 +51,7 @@ class ArrayWrapper(msrest.serialization.Model):
         **kwargs
     ):
         super(ArrayWrapper, self).__init__(**kwargs)
-        self.value = kwargs.get('value', None)
+        self.value = kwargs['value']
 
 
 class ClassOptionalWrapper(msrest.serialization.Model):
@@ -95,7 +95,7 @@ class ClassWrapper(msrest.serialization.Model):
         **kwargs
     ):
         super(ClassWrapper, self).__init__(**kwargs)
-        self.value = kwargs.get('value', None)
+        self.value = kwargs['value']
 
 
 class Error(msrest.serialization.Model):
@@ -162,7 +162,7 @@ class IntWrapper(msrest.serialization.Model):
         **kwargs
     ):
         super(IntWrapper, self).__init__(**kwargs)
-        self.value = kwargs.get('value', None)
+        self.value = kwargs['value']
 
 
 class Product(msrest.serialization.Model):
@@ -190,7 +190,7 @@ class Product(msrest.serialization.Model):
         **kwargs
     ):
         super(Product, self).__init__(**kwargs)
-        self.id = kwargs.get('id', None)
+        self.id = kwargs['id']
         self.name = kwargs.get('name', None)
 
 
@@ -235,4 +235,4 @@ class StringWrapper(msrest.serialization.Model):
         **kwargs
     ):
         super(StringWrapper, self).__init__(**kwargs)
-        self.value = kwargs.get('value', None)
+        self.value = kwargs['value']

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/models/_models.py
@@ -161,5 +161,5 @@ class Product(msrest.serialization.Model):
         self.display_names = kwargs.get('display_names', None)
         self.capacity = kwargs.get('capacity', None)
         self.image = kwargs.get('image', None)
-        self.child = kwargs.get('child', None)
-        self.const_child = kwargs.get('const_child', None)
+        self.child = kwargs['child']
+        self.const_child = kwargs['const_child']

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/models/_models.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/models/_models.py
@@ -40,9 +40,9 @@ class AccessPolicy(msrest.serialization.Model):
         **kwargs
     ):
         super(AccessPolicy, self).__init__(**kwargs)
-        self.start = kwargs.get('start', None)
-        self.expiry = kwargs.get('expiry', None)
-        self.permission = kwargs.get('permission', None)
+        self.start = kwargs['start']
+        self.expiry = kwargs['expiry']
+        self.permission = kwargs['permission']
 
 
 class AppleBarrel(msrest.serialization.Model):
@@ -138,10 +138,10 @@ class Blob(msrest.serialization.Model):
         **kwargs
     ):
         super(Blob, self).__init__(**kwargs)
-        self.name = kwargs.get('name', None)
-        self.deleted = kwargs.get('deleted', None)
-        self.snapshot = kwargs.get('snapshot', None)
-        self.properties = kwargs.get('properties', None)
+        self.name = kwargs['name']
+        self.deleted = kwargs['deleted']
+        self.snapshot = kwargs['snapshot']
+        self.properties = kwargs['properties']
         self.metadata = kwargs.get('metadata', None)
 
 
@@ -167,7 +167,7 @@ class BlobPrefix(msrest.serialization.Model):
         **kwargs
     ):
         super(BlobPrefix, self).__init__(**kwargs)
-        self.name = kwargs.get('name', None)
+        self.name = kwargs['name']
 
 
 class BlobProperties(msrest.serialization.Model):
@@ -277,8 +277,8 @@ class BlobProperties(msrest.serialization.Model):
         **kwargs
     ):
         super(BlobProperties, self).__init__(**kwargs)
-        self.last_modified = kwargs.get('last_modified', None)
-        self.etag = kwargs.get('etag', None)
+        self.last_modified = kwargs['last_modified']
+        self.etag = kwargs['etag']
         self.content_length = kwargs.get('content_length', None)
         self.content_type = kwargs.get('content_type', None)
         self.content_encoding = kwargs.get('content_encoding', None)
@@ -400,8 +400,8 @@ class Container(msrest.serialization.Model):
         **kwargs
     ):
         super(Container, self).__init__(**kwargs)
-        self.name = kwargs.get('name', None)
-        self.properties = kwargs.get('properties', None)
+        self.name = kwargs['name']
+        self.properties = kwargs['properties']
         self.metadata = kwargs.get('metadata', None)
 
 
@@ -444,8 +444,8 @@ class ContainerProperties(msrest.serialization.Model):
         **kwargs
     ):
         super(ContainerProperties, self).__init__(**kwargs)
-        self.last_modified = kwargs.get('last_modified', None)
-        self.etag = kwargs.get('etag', None)
+        self.last_modified = kwargs['last_modified']
+        self.etag = kwargs['etag']
         self.lease_status = kwargs.get('lease_status', None)
         self.lease_state = kwargs.get('lease_state', None)
         self.lease_duration = kwargs.get('lease_duration', None)
@@ -501,11 +501,11 @@ class CorsRule(msrest.serialization.Model):
         **kwargs
     ):
         super(CorsRule, self).__init__(**kwargs)
-        self.allowed_origins = kwargs.get('allowed_origins', None)
-        self.allowed_methods = kwargs.get('allowed_methods', None)
-        self.allowed_headers = kwargs.get('allowed_headers', None)
-        self.exposed_headers = kwargs.get('exposed_headers', None)
-        self.max_age_in_seconds = kwargs.get('max_age_in_seconds', None)
+        self.allowed_origins = kwargs['allowed_origins']
+        self.allowed_methods = kwargs['allowed_methods']
+        self.allowed_headers = kwargs['allowed_headers']
+        self.exposed_headers = kwargs['exposed_headers']
+        self.max_age_in_seconds = kwargs['max_age_in_seconds']
 
 
 class Error(msrest.serialization.Model):
@@ -622,13 +622,13 @@ class ListBlobsResponse(msrest.serialization.Model):
     ):
         super(ListBlobsResponse, self).__init__(**kwargs)
         self.service_endpoint = kwargs.get('service_endpoint', None)
-        self.container_name = kwargs.get('container_name', None)
-        self.prefix = kwargs.get('prefix', None)
-        self.marker = kwargs.get('marker', None)
-        self.max_results = kwargs.get('max_results', None)
-        self.delimiter = kwargs.get('delimiter', None)
-        self.blobs = kwargs.get('blobs', None)
-        self.next_marker = kwargs.get('next_marker', None)
+        self.container_name = kwargs['container_name']
+        self.prefix = kwargs['prefix']
+        self.marker = kwargs['marker']
+        self.max_results = kwargs['max_results']
+        self.delimiter = kwargs['delimiter']
+        self.blobs = kwargs['blobs']
+        self.next_marker = kwargs['next_marker']
 
 
 class ListContainersResponse(msrest.serialization.Model):
@@ -674,12 +674,12 @@ class ListContainersResponse(msrest.serialization.Model):
         **kwargs
     ):
         super(ListContainersResponse, self).__init__(**kwargs)
-        self.service_endpoint = kwargs.get('service_endpoint', None)
-        self.prefix = kwargs.get('prefix', None)
+        self.service_endpoint = kwargs['service_endpoint']
+        self.prefix = kwargs['prefix']
         self.marker = kwargs.get('marker', None)
-        self.max_results = kwargs.get('max_results', None)
+        self.max_results = kwargs['max_results']
         self.containers = kwargs.get('containers', None)
-        self.next_marker = kwargs.get('next_marker', None)
+        self.next_marker = kwargs['next_marker']
 
 
 class Logging(msrest.serialization.Model):
@@ -720,11 +720,11 @@ class Logging(msrest.serialization.Model):
         **kwargs
     ):
         super(Logging, self).__init__(**kwargs)
-        self.version = kwargs.get('version', None)
-        self.delete = kwargs.get('delete', None)
-        self.read = kwargs.get('read', None)
-        self.write = kwargs.get('write', None)
-        self.retention_policy = kwargs.get('retention_policy', None)
+        self.version = kwargs['version']
+        self.delete = kwargs['delete']
+        self.read = kwargs['read']
+        self.write = kwargs['write']
+        self.retention_policy = kwargs['retention_policy']
 
 
 class Metrics(msrest.serialization.Model):
@@ -760,7 +760,7 @@ class Metrics(msrest.serialization.Model):
     ):
         super(Metrics, self).__init__(**kwargs)
         self.version = kwargs.get('version', None)
-        self.enabled = kwargs.get('enabled', None)
+        self.enabled = kwargs['enabled']
         self.include_ap_is = kwargs.get('include_ap_is', None)
         self.retention_policy = kwargs.get('retention_policy', None)
 
@@ -793,7 +793,7 @@ class RetentionPolicy(msrest.serialization.Model):
         **kwargs
     ):
         super(RetentionPolicy, self).__init__(**kwargs)
-        self.enabled = kwargs.get('enabled', None)
+        self.enabled = kwargs['enabled']
         self.days = kwargs.get('days', None)
 
 
@@ -872,8 +872,8 @@ class SignedIdentifier(msrest.serialization.Model):
         **kwargs
     ):
         super(SignedIdentifier, self).__init__(**kwargs)
-        self.id = kwargs.get('id', None)
-        self.access_policy = kwargs.get('access_policy', None)
+        self.id = kwargs['id']
+        self.access_policy = kwargs['access_policy']
 
 
 class Slide(msrest.serialization.Model):


### PR DESCRIPTION
fixes #531 
rebased off of #529 
example of regeneration with mgmt storage: https://github.com/Azure/azure-sdk-for-python/blob/c1e7f03946e0304af758ee49172705d2f0bd4b60/sdk/storage/azure-mgmt-storage/azure/mgmt/storage/v2019_06_01/models/_models_py3.py#L931