### PR TITLE
Fixing AlertsManagement generation (need to check if parent in yaml is of type object)

### DIFF
--- a/autorest/codegen/models/object_schema.py
+++ b/autorest/codegen/models/object_schema.py
@@ -94,6 +94,8 @@ class ObjectSchema(BaseSchema):  # pylint: disable=too-many-instance-attributes
         properties = []
         base_model = None
 
+        name = yaml_data["language"]["python"]["name"]
+
         # checking to see if there is a parent class and / or additional properties
         if yaml_data.get("parents"):
             immediate_parents = yaml_data["parents"]["immediate"]
@@ -113,7 +115,7 @@ class ObjectSchema(BaseSchema):  # pylint: disable=too-many-instance-attributes
                                 description="Unmatched properties from the message are deserialized to this collection."
                             )
                         )
-                    elif immediate_parent["language"]["default"]["name"] != yaml_data["language"]["default"]["name"]:
+                    elif immediate_parent["language"]["default"]["name"] != name and immediate_parent['type'] == "object":
                         base_model = id(immediate_parent)
 
         # checking to see if this is a polymorphic class
@@ -131,7 +133,7 @@ class ObjectSchema(BaseSchema):  # pylint: disable=too-many-instance-attributes
             ]
         # this is to ensure that the attribute map type and property type are generated correctly
 
-        name = yaml_data["language"]["python"]["name"]
+
 
         description = yaml_data["language"]["python"]["description"]
         is_exception = False

--- a/autorest/codegen/models/object_schema.py
+++ b/autorest/codegen/models/object_schema.py
@@ -115,7 +115,10 @@ class ObjectSchema(BaseSchema):  # pylint: disable=too-many-instance-attributes
                                 description="Unmatched properties from the message are deserialized to this collection."
                             )
                         )
-                    elif immediate_parent["language"]["default"]["name"] != name and immediate_parent['type'] == "object":
+                    elif (
+                        immediate_parent["language"]["default"]["name"] != name and
+                        immediate_parent['type'] == "object"
+                    ):
                         base_model = id(immediate_parent)
 
         # checking to see if this is a polymorphic class


### PR DESCRIPTION
fixes #527 
had to make changes to swagger, not sure if this is the route we want to go: https://github.com/Azure/azure-rest-api-specs/pull/8881
old autorest would differentiate them by calling one [ErrorResponse](https://github.com/Azure/azure-sdk-for-python/blob/c69590242bcca2a0f60521e2846b68b9ac2a9640/sdk/alertsmanagement/azure-mgmt-alertsmanagement/azure/mgmt/alertsmanagement/models/_models_py3.py#L968) and one [ErrorResponse1](https://github.com/Azure/azure-sdk-for-python/blob/c69590242bcca2a0f60521e2846b68b9ac2a9640/sdk/alertsmanagement/azure-mgmt-alertsmanagement/azure/mgmt/alertsmanagement/models/_models_py3.py#L996) 