### PR TITLE
fixing default value getting in operation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Current
+
+**Bug Fixes**
+
+- Fixes parameter ordering so parameters with default values are all ordered at the end  #545
+
 ### 2020-04-01 - 5.0.0-dev.20200401.1
 Modelerfour version: 4.12.276
 

--- a/autorest/codegen/models/parameter.py
+++ b/autorest/codegen/models/parameter.py
@@ -75,7 +75,7 @@ class Parameter(BaseModel):  # pylint: disable=too-many-instance-attributes
         self.flattened = flattened
         self.grouped_by = grouped_by
         self.original_parameter = original_parameter
-        self.client_default_value = client_default_value
+        self._client_default_value = client_default_value
         self.is_kwarg: bool = False
         self.has_multiple_media_types: bool = False
         self.multiple_media_types_type_annot: Optional[str] = None
@@ -122,8 +122,8 @@ class Parameter(BaseModel):  # pylint: disable=too-many-instance-attributes
         if not self.required:
             type_annot = f"Optional[{type_annot}]"
 
-        if self.client_default_value is not None:
-            return self.client_default_value, self.schema.get_declaration(self.client_default_value), type_annot
+        if self._client_default_value is not None:
+            return self._client_default_value, self.schema.get_declaration(self._client_default_value), type_annot
 
         if self.multiple_media_types_type_annot:
             # means this parameter has multiple media types. We force default value to be None.
@@ -143,6 +143,12 @@ class Parameter(BaseModel):  # pylint: disable=too-many-instance-attributes
             )
 
         return default_value, default_value_declaration, type_annot
+
+    @property
+    def default_value(self) -> Optional[Any]:
+        # exposing default_value because client_default_value doesn't get updated with
+        # default values we bubble up from the schema
+        return self._default_value()[0]
 
     @property
     def docstring_type(self) -> str:

--- a/autorest/codegen/models/parameter_list.py
+++ b/autorest/codegen/models/parameter_list.py
@@ -108,7 +108,7 @@ class ParameterList(MutableSequence):
         )
         for parameter in parameters_of_this_implementation:
             if parameter.in_method_signature:
-                if not parameter.client_default_value and parameter.required:
+                if not parameter.default_value and parameter.required:
                     signature_parameters_no_default_value.append(parameter)
                 else:
                     signature_parameters_default_value.append(parameter)

--- a/test/unittests/test_parameter_ordering.py
+++ b/test/unittests/test_parameter_ordering.py
@@ -1,13 +1,15 @@
 import pytest
 from autorest.codegen.models import Parameter, AnySchema
+from autorest.codegen.models.primitive_schemas import StringSchema
 from autorest.codegen.models.parameter_list import ParameterList
 from autorest.codegen.models.parameter import ParameterLocation
 
-def get_parameter(name, required, default_value=None):
-    schema = AnySchema(
-        namespace="parameterordering",
-        yaml_data={}
-    )
+def get_parameter(name, required, default_value=None, schema=None):
+    if not schema:
+        schema = AnySchema(
+            namespace="parameterordering",
+            yaml_data={}
+        )
     return Parameter(
         schema=schema,
         yaml_data={},
@@ -21,6 +23,25 @@ def get_parameter(name, required, default_value=None):
         constraints=[],
         client_default_value=default_value
     )
+
+def test_sort_parameters_with_default_value_from_schema():
+    schema = StringSchema(
+        namespace="parameterordering",
+        yaml_data={"defaultValue": "this_is_the_default", "type": str}
+    )
+    parameter_with_default_schema_value_required = get_parameter(
+        name="required_param_with_schema_default",
+        required=True,
+        schema=schema
+    )
+    required_parameter = get_parameter(
+        name="required_parameter",
+        required=True
+    )
+
+    parameter_list = [parameter_with_default_schema_value_required, required_parameter]
+
+    assert [required_parameter, parameter_with_default_schema_value_required] == ParameterList(parameter_list).method
 
 def test_sort_required_parameters():
     required_default_value_parameter = get_parameter(


### PR DESCRIPTION
fixes #544 

<img width="521" alt="Screen Shot 2020-04-03 at 11 40 29 AM" src="https://user-images.githubusercontent.com/43154838/78379853-04447080-75a1-11ea-9f44-a8b2871ebde2.png">

Fix: client default value only takes in whether the parameter has a specified default value. Now also checking to see if the parameter's schema has a default value.