### PR TITLE
Overriding parents' properties if same name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Modelerfour version: 4.12.301
 **Bug Fixes**
 
 - Separating out typing imports in TYPE_CHECKING block  #538
+- Overriding a property inherited from a parent if they both have the same name  #563
 
 **New Features**
 

--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -16,7 +16,6 @@ from .lro_operation import LROOperation
 from .paging_operation import PagingOperation
 from .parameter import Parameter, ParameterLocation
 from .client import Client
-from .property import Property
 from .parameter_list import ParameterList
 from .imports import FileImport, ImportType, TypingSection
 from .schema_response import SchemaResponse
@@ -257,6 +256,8 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
                 operation for operation in operation_group.operations if operation not in next_operations
             ]
 
+
+
     def _add_properties_from_inheritance(self) -> None:
         """Adds properties from base classes to schemas with parents.
 
@@ -268,13 +269,12 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
             if base_model:
                 parent = base_model
                 while parent:
-                    schema.properties = parent.properties + schema.properties
-                    seen_properties: Set[Property] = set()
-                    schema.properties = [
-                        p
-                        for p in schema.properties
-                        if p.name not in seen_properties and not seen_properties.add(p.name)  # type: ignore
+                    schema_property_names = [s.name for s in schema.properties]
+                    chosen_parent_properties = [
+                        p for p in parent.properties
+                        if p.name not in schema_property_names
                     ]
+                    schema.properties = chosen_parent_properties + schema.properties
                     parent = cast(ObjectSchema, parent.base_model)
 
     def _add_exceptions_from_inheritance(self) -> None:

--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -256,8 +256,6 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes
                 operation for operation in operation_group.operations if operation not in next_operations
             ]
 
-
-
     def _add_properties_from_inheritance(self) -> None:
         """Adds properties from base classes to schemas with parents.
 


### PR DESCRIPTION
Logic can now generate and is overriding parent's [name](https://github.com/Azure/azure-sdk-for-python/blob/a9c69c9154e94955005e478b8a6b79134eb2ec64/sdk/logic/azure-mgmt-logic/azure/mgmt/logic/models/_models.py#L5884). This is it in the [swagger](https://github.com/Azure/azure-rest-api-specs/blob/32bd4d8cb921e6c5cc856da82018a73de71bd0d1/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json#L8222)