### PR TITLE
Add npm release pipeline

### DIFF
--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -1,0 +1,64 @@
+# This is a manual pipeline, don't trigger automatically
+trigger: none
+pr: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  NodeVersion: '12.x'
+  TestFolder: '$(Build.SourcesDirectory)/test/'
+
+steps:
+  - task: NodeTool@0
+    displayName: 'Install Node.js $(NodeVersion)'
+    inputs:
+      versionSpec: '$(NodeVersion)'
+
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.6'
+    inputs:
+      versionSpec: 3.6
+
+  - script: |
+      cd $(Build.SourcesDirectory)
+      pip install -r dev_requirements.txt
+      npm install -g autorest
+      npm install
+    displayName: 'Prepare Environment for Generation'
+
+  - script: |
+      pylint autorest
+    displayName: 'Pylint'
+
+  - script: |
+      mypy autorest
+    displayName: 'Mypy'
+
+  - script: |
+      pytest test/unittests
+    displayName: 'Unit tests'
+
+  - script: |
+      inv regenerate
+    displayName: 'Regenerate Code'
+
+  - script: |
+      pip install tox coverage==4.5.4
+    displayName: 'Install Env Specific Reqs in Target PyVersion $(PythonVersion)'
+
+  - script: |
+      cd $(TestFolder)/azure
+      tox -e ci
+    displayName: 'Execute "azure" Tests - Python $(PythonVersion)'
+
+  - script: |
+      export RELEASE_VERSION=$(node -p -e "require('./package.json').version")
+      npm pack
+      npx publish-release --token $(azuresdk-github-pat) --repo autorest.python --owner azure --name "Autorest for Python v$RELEASE_VERSION" --tag v$RELEASE_VERSION --notes='Release version of Autorest for Python v5' --prerelease --editRelease false --assets autorest-python-$RELEASE_VERSION.tgz --target_commitish $(Build.SourceBranchName)
+    displayName: 'Publish GitHub release'
+
+  - script: |
+      echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
+      npm publish --access public
+    displayName: 'Publish to npm'


### PR DESCRIPTION
Hey folks, this change adds a new Azure DevOps pipeline to automate npm and GitHub releases for AutoRest Python v5.  This is a manual pipeline and will need to be invoked here when a release is needed:

https://dev.azure.com/azure-sdk/internal/_build?definitionId=1668&_a=summary

Let me know if you think anything needs to be added or changed.  How do you feel about the test runs here?  I didn't include everything in `ci.yml` (it's equivalent to what I did in `publish-dev-release.yml` though), is that OK?