### PR TITLE
adding content type values to docstring

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@
 ### Unreleased
 Modelerfour version: 4.13.346
 
+**New Features**
+
+- Displaying the default and possible values for content type in the docstring for operations with multiple requests  #615
+
 **Bug Fixes**
 
 - Fixing `AsyncTokenCredential` typing import and adding to service client  #591

--- a/autorest/codegen/templates/operation_tools.jinja2
+++ b/autorest/codegen/templates/operation_tools.jinja2
@@ -30,7 +30,7 @@
 {% if (operation.requests | length) > 1 %}
 {% set content_type_constant = operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("in_method_code") | selectattr("serialized_name", "equalto", "content_type") | first  %}
 :keyword str content_type: Media type of the body sent to the API. Default value is {{ content_type_constant.schema.constant_value }}.
- Possible values include: "{{ operation.requests | map(attribute="media_types") | sum(start = []) | unique | list | join ('", "')  }}".
+ Allowed values are: "{{ operation.requests | map(attribute="media_types") | sum(start = []) | unique | list | join ('", "')  }}".
 {% endif %}
 :keyword callable cls: A custom type or function that will be passed the direct response
 {{ return_docstring(operation) }}

--- a/autorest/codegen/templates/operation_tools.jinja2
+++ b/autorest/codegen/templates/operation_tools.jinja2
@@ -28,7 +28,9 @@
 :type {{ parameter.serialized_name }}: {{ parameter.docstring_type }}
 {% endfor %}
 {% if (operation.requests | length) > 1 %}
-:keyword str content_type: Media type of the body sent to the API.
+{% set content_type_constant = operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("in_method_code") | selectattr("serialized_name", "equalto", "content_type") | first  %}
+:keyword str content_type: Media type of the body sent to the API. Default value is {{ content_type_constant.schema.constant_value }}.
+ Possible values include: "{{ operation.requests | map(attribute="media_types") | sum(start = []) | unique | list | join ('", "')  }}".
 {% endif %}
 :keyword callable cls: A custom type or function that will be passed the direct response
 {{ return_docstring(operation) }}
@@ -179,21 +181,21 @@ body_content_kwargs['content'] = body_content{% endmacro %}
 # Construct and send request
 {% if operation.parameters.has_body %}
 body_content_kwargs = {}  # type: Dict[str, Any]
-{% if (operation.requests | length) == 1 %}
-{% if operation.requests[0].is_stream_request %}
+    {% if (operation.requests | length) == 1 %}
+        {% if operation.requests[0].is_stream_request %}
 {{ stream_body_params(operation) }}
-{% elif operation.requests[0].body_parameter_has_schema %}
+        {% elif operation.requests[0].body_parameter_has_schema %}
 {{ non_stream_body_params(operation, send_xml, request_as_xml) }}
-{% endif %}
-{% else %}
-{% for request in operation.requests %}
+        {% endif %}
+    {% else %}
+        {% for request in operation.requests %}
 {{ "el" if not loop.first }}if header_parameters['Content-Type'] in {{ request.media_types }}:
-{% if request.is_stream_request %}
+            {% if request.is_stream_request %}
     {{ stream_body_params(operation)|indent }}
-{% elif request.body_parameter_has_schema %}
+            {% elif request.body_parameter_has_schema %}
     {{ non_stream_body_params(request, send_xml, request_as_xml)|indent }}
-{% endif %}
-{% endfor %}
+            {% endif %}
+        {% endfor %}
 else:
     raise ValueError(
         "Content type {} is not valid for this operation".format(header_parameters['Content-Type'])

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations_async/_operation_group_two_operations_async.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations_async/_operation_group_two_operations_async.py
@@ -49,7 +49,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter.
         :type input: str, ~multiapi.v3.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations_async/_operation_group_two_operations_async.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations_async/_operation_group_two_operations_async.py
@@ -48,7 +48,8 @@ class OperationGroupTwoOperations:
 
         :param input: Input parameter.
         :type input: str, ~multiapi.v3.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -53,7 +53,8 @@ class OperationGroupTwoOperations(object):
 
         :param input: Input parameter.
         :type input: str, ~multiapi.v3.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -54,7 +54,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter.
         :type input: str, ~multiapi.v3.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -53,7 +53,8 @@ class OperationGroupTwoOperations(object):
 
         :param input: Input parameter.
         :type input: str, ~multiapinoasync.v3.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -54,7 +54,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter.
         :type input: str, ~multiapinoasync.v3.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations_async/_operation_group_two_operations_async.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations_async/_operation_group_two_operations_async.py
@@ -48,7 +48,8 @@ class OperationGroupTwoOperations:
 
         :param input: Input parameter.
         :type input: str, ~multiapiwithsubmodule.submodule.v3.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations_async/_operation_group_two_operations_async.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations_async/_operation_group_two_operations_async.py
@@ -49,7 +49,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter.
         :type input: str, ~multiapiwithsubmodule.submodule.v3.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -54,7 +54,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter.
         :type input: str, ~multiapiwithsubmodule.submodule.v3.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -53,7 +53,8 @@ class OperationGroupTwoOperations(object):
 
         :param input: Input parameter.
         :type input: str, ~multiapiwithsubmodule.submodule.v3.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
         :rtype: None

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations_async/_media_types_client_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations_async/_media_types_client_operations_async.py
@@ -30,7 +30,8 @@ class MediaTypesClientOperationsMixin:
 
         :param input: Input parameter.
         :type input: str, ~mediatypes.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
         :rtype: str

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations_async/_media_types_client_operations_async.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations_async/_media_types_client_operations_async.py
@@ -31,7 +31,7 @@ class MediaTypesClientOperationsMixin:
         :param input: Input parameter.
         :type input: str, ~mediatypes.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
         :rtype: str

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -36,7 +36,7 @@ class MediaTypesClientOperationsMixin(object):
         :param input: Input parameter.
         :type input: str, ~mediatypes.models.SourcePath
         :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
-         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
+         Allowed values are: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
         :rtype: str

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -35,7 +35,8 @@ class MediaTypesClientOperationsMixin(object):
 
         :param input: Input parameter.
         :type input: str, ~mediatypes.models.SourcePath
-        :keyword str content_type: Media type of the body sent to the API.
+        :keyword str content_type: Media type of the body sent to the API. Default value is "application/json".
+         Possible values include: "application/pdf", "image/jpeg", "image/png", "image/tiff", "application/json".
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
         :rtype: str


### PR DESCRIPTION
fixes #610 
post_broadcast with the new docstring:
![image](https://user-images.githubusercontent.com/43154838/81215746-c70c3d80-8fa7-11ea-8c43-302554edac2a.png)
