### PR TITLE
checking for protocol in name_converter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Modelerfour version: 4.13.351
 **Bug Fixes**
 
 - No longer assuming that response with body from an LRO call is an ObjectSchema  #623
+- Checking whether "protocol" entry exists in yaml in name converter to remove erroneous "KeyError: 'protocol'"  #628
 
 ### 2020-05-08 - 5.0.0-preview.5
 Modelerfour version: 4.13.351

--- a/autorest/namer/name_converter.py
+++ b/autorest/namer/name_converter.py
@@ -109,6 +109,7 @@ class NameConverter:
 
         if not(
             schema_name == 'content_type' and
+            schema.get('protocol') and
             schema['protocol'].get('http') and
             schema['protocol']['http']['in'] == "header"
         ):


### PR DESCRIPTION
fixes KeyError("protocol") issue when generating msgraph

this pr needs to be merged first so we can pass CI, since we're missing coverage rn: https://github.com/Azure/autorest.python/pull/629