### PR TITLE
Add run-python3.js script to fix package.json Python script runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "5.0.0-preview.6",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
-    "prepare": "python prepare.py",
-    "start": "python start.py",
-    "install": "python install.py"
+    "prepare": "node run-python3.js prepare.py",
+    "start": "node run-python3.js start.py",
+    "install": "node run-python3.js install.py"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/Azure/autorest.python/blob/autorestv3/README.md",
   "devDependencies": {
     "@autorest/autorest": "^3.0.0",
+    "@azure-tools/extension": "^3.0.249",
     "@microsoft.azure/autorest.testserver": "^2.10.37"
   },
   "files": [

--- a/run-python3.js
+++ b/run-python3.js
@@ -1,0 +1,20 @@
+// This script wraps logic in @azure-tools/extension to resolve
+// the path to Python 3 so that a Python script file can be run
+// from an npm script in package.json.  It uses the same Python 3
+// path resolution algorithm as AutoRest so that the behavior
+// is fully consistent (and also supports AUTOREST_PYTHON_EXE).
+//
+// Invoke it like so: "node run-python3.js script.py"
+
+const cp = require("child_process");
+const extension = require("@azure-tools/extension");
+
+async function runPython3(scriptName) {
+  const command = ["python"];
+  await extension.updatePythonPath(command);
+  cp.execSync(command[0] + " " + scriptName);
+}
+
+runPython3(process.argv[2]).catch(err => {
+  console.error(err);
+});


### PR DESCRIPTION
This PR adds a script that wraps logic in `@azure-tools/extension` to resolve the path to Python 3 so that a Python script file can be run from an npm script in package.json.  It uses the same Python 3 path resolution algorithm as AutoRest so that the behavior is fully consistent (and also supports AUTOREST_PYTHON_EXE).

It is invoked like so:

```
node run-python3.js script.py
```

This fixes an issue multiple users have run into where Python 3 is installed on their system with the name `python3` so we have to do some extra work to make sure we're not invoking Python 2 by accident.