### PR TITLE
correct item name of paging response model

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Unreleased
+Modelerfour version: 4.13.351
+
+**Bug Fixes**
+- Corrected generation of the item name of paging response when extracting data  #648
+
 ### 2020-05-22 - 5.0.0-preview.8
 Modelerfour version: 4.13.351
 

--- a/autorest/codegen/models/paging_operation.py
+++ b/autorest/codegen/models/paging_operation.py
@@ -77,14 +77,13 @@ class PagingOperation(Operation):
             # Default value. I still check if I find it,  so I can do a nice message.
             item_name = "value"
             try:
-                self._find_python_name(item_name, "itemName")
+                return self._find_python_name(item_name, "itemName")
             except ValueError:
                 response = self._get_response()
                 raise ValueError(
                     f"While scanning x-ms-pageable, itemName was not defined and object"
                     + f" {response.schema.name} has no array called 'value'"
                 )
-            return item_name
         return self._find_python_name(self._item_name, "itemName")
 
     @property


### PR DESCRIPTION
fixes #647

search generation with fix:
![image](https://user-images.githubusercontent.com/43154838/82949885-5f2b9000-9f72-11ea-9802-657710938c0a.png)
