### PR TITLE
add type ignore for enums with name 'count'

### DIFF
--- a/autorest/codegen/templates/enum.py.jinja2
+++ b/autorest/codegen/templates/enum.py.jinja2
@@ -1,3 +1,4 @@
+{% set enums_mypy_does_not_recognize = ["count"] %}
 
 class {{ enum.name }}({{ enum.enum_type.type_annotation }}, Enum):
     {% if enum.description %}
@@ -6,5 +7,8 @@ class {{ enum.name }}({{ enum.enum_type.type_annotation }}, Enum):
     {% endif %}
 
     {% for value in enum.values %}
-    {{ value.name }} = {{ enum.enum_type.get_declaration(value.value) }}{{ "  #: " + value.description if value.description else "" }}
+    {% if value.description and value.name in enums_mypy_does_not_recognize %}
+    {{ "#: " + value.description }}
+    {% endif %}
+    {{ value.name }} = {{ enum.enum_type.get_declaration(value.value) }}{{ "  # type: ignore" if value.name in enums_mypy_does_not_recognize else ("  #: " + value.description if value.description else "") }}
     {% endfor %}

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/models/_storage_management_client_enums.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/models/_storage_management_client_enums.py
@@ -51,7 +51,7 @@ class UsageUnit(str, Enum):
     """Gets the unit of measurement.
     """
 
-    count = "Count"
+    count = "Count"  # type: ignore
     bytes = "Bytes"
     seconds = "Seconds"
     percent = "Percent"


### PR DESCRIPTION
mypy gets confused with an enum of name count: Incompatible types in assignment (expression has type "str", base class "str" defined the type as "Callable[[str, str, Optional[int], Optional[int]], int]"). FIX: Will add a type ignore if the name of an enum is count