### PR TITLE
Fix stdin passthrough when running start.py through run-python3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "5.1.0-preview.1",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
-    "prepare": "python prepare.py",
-    "start": "python start.py",
-    "install": "python install.py"
+    "prepare": "node run-python3.js prepare.py",
+    "start": "node run-python3.js start.py",
+    "install": "node run-python3.js install.py"
   },
   "repository": {
     "type": "git",
@@ -22,9 +22,11 @@
     "url": "https://github.com/Azure/autorest.python/issues"
   },
   "homepage": "https://github.com/Azure/autorest.python/blob/autorestv3/README.md",
+  "dependencies": {
+    "@azure-tools/extension": "^3.0.249"
+  },
   "devDependencies": {
     "@autorest/autorest": "^3.0.0",
-    "@azure-tools/extension": "^3.0.249",
     "@microsoft.azure/autorest.testserver": "2.10.42"
   },
   "files": [

--- a/run-python3.js
+++ b/run-python3.js
@@ -12,7 +12,9 @@ const extension = require("@azure-tools/extension");
 async function runPython3(scriptName) {
   const command = ["python"];
   await extension.updatePythonPath(command);
-  cp.execSync(command[0] + " " + scriptName);
+  cp.execSync(command[0] + " " + scriptName, {
+    stdio: [0, 1, 2]
+  });
 }
 
 runPython3(process.argv[2]).catch(err => {


### PR DESCRIPTION
This change fixes the `run-python3.js` script so that it completes installation and successfully launches `start.py`. Re-created the PR from a local branch after my forked branch didn't work in PR #674.