### PR TITLE
correct return type for head operations

### DIFF
--- a/autorest/codegen/templates/operation.py.jinja2
+++ b/autorest/codegen/templates/operation.py.jinja2
@@ -2,26 +2,24 @@
 {% import 'operation_tools.jinja2' as op_tools %}
 {% set trace_decorator = "@distributed_trace_async" if async_mode else "@distributed_trace" %}
 {% set stream_request_parameter = "stream=" ~ ("True" if operation.is_stream_response else "False") %}
-{% macro return_docstring(async_mode) %}
-{% if operation.responses | selectattr('has_body') | first %}
-:return: {{ operation.responses|selectattr('has_body')|map(attribute='schema')| map(attribute='docstring_text')|unique|join(' or ') }}, or the result of cls(response)
-:rtype: {{ operation.responses|selectattr('has_body')|map(attribute='schema')| map(attribute='docstring_type')|unique|join(' or ') }}{{ " or None" if operation.responses|selectattr('has_body', 'false') | first }}
-{%- else %}
-:return: None, or the result of cls(response)
-:rtype: None
-{%- endif -%}
-{% endmacro %}
+{# return_type is a variable that holds the return type if we already know what it is #}
+{% set return_type = "bool" if operation.method == 'head' and code_model.options['head_as_boolean'] else None %}
 {% macro param_documentation_string(parameter) %}:param {{ parameter.serialized_name }}: {{ parameter.description }}{% endmacro %}
-{% macro return_docstring(async_mode) %}
-{% if operation.responses | selectattr('has_body') | first %}
+{% macro return_docstring(async_mode, return_type=None) %}
+{%- if return_type -%}
+:return: {{ return_type }}, or the result of cls(response)
+:rtype: {{ return_type }}
+{%- else -%}
+    {% if operation.responses | selectattr('has_body') | first %}
 :return: {{ operation.responses|selectattr('has_body')|map(attribute='schema')| map(attribute='docstring_text')|unique|join(' or ') }}, or the result of cls(response)
 :rtype: {{ operation.responses|selectattr('has_body')|map(attribute='schema')| map(attribute='docstring_type')|unique|join(' or ') }}{{ " or None" if operation.has_optional_return_type }}
-{%- else %}
+    {%- else %}
 :return: None, or the result of cls(response)
 :rtype: None
+    {%- endif -%}
 {%- endif -%}
 {% endmacro %}
-{% macro operation_docstring(async_mode) %}
+{% macro operation_docstring(async_mode, return_type=None) %}
 """{{ operation.summary if operation.summary else operation.description | wordwrap(width=95, break_long_words=False, wrapstring='\n') }}
 {% if operation.summary and operation.description %}
 
@@ -45,19 +43,19 @@
  Allowed values are: "{{ operation.requests | map(attribute="media_types") | sum(start = []) | unique | list | join ('", "')  }}".
 {% endif %}
 :keyword callable cls: A custom type or function that will be passed the direct response
-{{ return_docstring(async_mode) }}
+{{ return_docstring(async_mode, return_type=return_type) }}
 :raises: ~azure.core.exceptions.HttpResponseError
 """{% endmacro %}
 {# actual template starts here #}
 {%- if code_model.options['tracing'] and operation.want_tracing -%}
 {{ trace_decorator }}
 {% endif %}
-{{ op_tools.method_signature(operation, operation.python_name, async_mode=async_mode, coroutine=async_mode, return_type_wrapper="") }}
+{{ op_tools.method_signature(operation, operation.python_name, async_mode=async_mode, coroutine=async_mode, return_type_wrapper="", return_type=return_type) }}
 {%- if not async_mode %}
-    {{ op_tools.sync_return_type_annotation(operation, "") }}
+    {{ op_tools.sync_return_type_annotation(operation, "", return_type=return_type) }}
 {% endif %}
 {% if operation.want_description_docstring %}
-    {{ operation_docstring(async_mode)|indent }}
+    {{ operation_docstring(async_mode, return_type=return_type)|indent }}
 {% endif %}
     cls = kwargs.pop('cls', None)  # type: {{ op_tools.return_type_annotation(operation, "ClsType") }}
 {% if operation.deprecated %}

--- a/autorest/codegen/templates/operation_tools.jinja2
+++ b/autorest/codegen/templates/operation_tools.jinja2
@@ -1,17 +1,20 @@
-{% macro return_type_annotation(operation, return_type_wrapper) %}
+{% macro return_type_annotation(operation, return_type_wrapper, return_type=None) %}
+{%- if return_type -%}
+{{ return_type }}
+{%- else -%}
 {{ ((return_type_wrapper + "[") if return_type_wrapper else "") ~ ("Optional[" if operation.has_optional_return_type else "" ) ~ ("Union[" if operation.responses | selectattr('has_body') | map(attribute='schema') | map(attribute='operation_type_annotation') | unique | list  | length > 1 else "") ~
 (operation.responses | selectattr('has_body') | map(attribute='schema') | map(attribute='operation_type_annotation') | unique | join(', ')) ~
 ("]" if operation.responses | selectattr('has_body') | map(attribute='schema') | map(attribute='operation_type_annotation')| unique | list | length > 1 else "") ~ ("]" if operation.has_optional_return_type else "") ~ ( "]" if return_type_wrapper else "")
 if operation.responses | selectattr('has_body') | first
-else ((return_type_wrapper + "[") if return_type_wrapper else "") ~ ("Optional[" if operation.has_optional_return_type else "" ) ~ "None" ~ ("]" if operation.has_optional_return_type else "") ~ ( "]" if return_type_wrapper else "") }}{% endmacro %}
+else ((return_type_wrapper + "[") if return_type_wrapper else "") ~ ("Optional[" if operation.has_optional_return_type else "" ) ~ "None" ~ ("]" if operation.has_optional_return_type else "") ~ ( "]" if return_type_wrapper else "") }}{%- endif -%}{% endmacro %}
 {# get async mypy typing #}
-{% macro async_return_type_annotation(operation, return_type_wrapper) %}
-{{ " -> " + return_type_annotation(operation, return_type_wrapper) }}{% endmacro %}
+{% macro async_return_type_annotation(operation, return_type_wrapper, return_type=None) %}
+{{ " -> " + return_type_annotation(operation, return_type_wrapper, return_type) }}{% endmacro %}
 {# get sync mypy typing #}
-{% macro sync_return_type_annotation(operation, return_type_wrapper) %}
-{{ "# type: (...) -> " + return_type_annotation(operation, return_type_wrapper) }}{% endmacro %}
+{% macro sync_return_type_annotation(operation, return_type_wrapper, return_type=None) %}
+{{ "# type: (...) -> " + return_type_annotation(operation, return_type_wrapper, return_type) }}{% endmacro %}
 {# get method signature #}
-{% macro method_signature(operation, operation_name, async_mode, coroutine, return_type_wrapper) %}
+{% macro method_signature(operation, operation_name, async_mode, coroutine, return_type_wrapper, return_type=None) %}
 {{ "async " if coroutine else "" }}def {{ operation_name }}(
 {% if async_mode %}
     self,
@@ -19,7 +22,7 @@ else ((return_type_wrapper + "[") if return_type_wrapper else "") ~ ("Optional["
     {{ param_signature }},
     {% endfor %}
     **kwargs
-){{ async_return_type_annotation(operation, return_type_wrapper) }}:
+){{ async_return_type_annotation(operation, return_type_wrapper, return_type) }}:
 {% else %}
     self,
     {% for param_signature in operation.parameters.sync_method_signature %}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations_async/_header_operations_async.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations_async/_header_operations_async.py
@@ -143,14 +143,14 @@ class HeaderOperations:
         self,
         foo_client_request_id: str,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
 
         :param foo_client_request_id: The fooRequestId.
         :type foo_client_request_id: str
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
@@ -150,14 +150,14 @@ class HeaderOperations(object):
         foo_client_request_id,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request.
 
         :param foo_client_request_id: The fooRequestId.
         :type foo_client_request_id: str
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]

--- a/test/azure/Expected/AcceptanceTests/Head/head/aio/operations_async/_http_success_operations_async.py
+++ b/test/azure/Expected/AcceptanceTests/Head/head/aio/operations_async/_http_success_operations_async.py
@@ -39,12 +39,12 @@ class HttpSuccessOperations:
     async def head200(
         self,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Return 200 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -78,12 +78,12 @@ class HttpSuccessOperations:
     async def head204(
         self,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Return 204 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -117,12 +117,12 @@ class HttpSuccessOperations:
     async def head404(
         self,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Return 404 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]

--- a/test/azure/Expected/AcceptanceTests/Head/head/operations/_http_success_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Head/head/operations/_http_success_operations.py
@@ -44,12 +44,12 @@ class HttpSuccessOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Return 200 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -84,12 +84,12 @@ class HttpSuccessOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Return 204 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -124,12 +124,12 @@ class HttpSuccessOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Return 404 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]

--- a/test/azure/Expected/AcceptanceTests/HeadExceptions/headexceptions/aio/operations_async/_head_exception_operations_async.py
+++ b/test/azure/Expected/AcceptanceTests/HeadExceptions/headexceptions/aio/operations_async/_head_exception_operations_async.py
@@ -39,12 +39,12 @@ class HeadExceptionOperations:
     async def head200(
         self,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Return 200 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -78,12 +78,12 @@ class HeadExceptionOperations:
     async def head204(
         self,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Return 204 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -117,12 +117,12 @@ class HeadExceptionOperations:
     async def head404(
         self,
         **kwargs
-    ) -> None:
+    ) -> bool:
         """Return 404 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]

--- a/test/azure/Expected/AcceptanceTests/HeadExceptions/headexceptions/operations/_head_exception_operations.py
+++ b/test/azure/Expected/AcceptanceTests/HeadExceptions/headexceptions/operations/_head_exception_operations.py
@@ -44,12 +44,12 @@ class HeadExceptionOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Return 200 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -84,12 +84,12 @@ class HeadExceptionOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Return 204 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -124,12 +124,12 @@ class HeadExceptionOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> None
+        # type: (...) -> bool
         """Return 404 status code if successful.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
-        :return: None, or the result of cls(response)
-        :rtype: None
+        :return: bool, or the result of cls(response)
+        :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
         """
         cls = kwargs.pop('cls', None)  # type: ClsType[None]


### PR DESCRIPTION
Typing should return bool if we are dealing with a head operation and the "head-as-bool" flag is True