### PR TITLE
add content_type docstring if multiple media types to lro and paging docs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### 2020-xx-xx - 5.3.3
+Autorest core version: 3.0.6318
+
+Modelerfour version: 4.15.419
+
+**Bug fixes**
+
+- Include `content_type` docstrings for LRO and paging operations in the case of multiple media types  #778
+
 ### 2020-09-14 - 5.3.2
 Autorest core version: 3.0.6318
 

--- a/autorest/codegen/templates/lro_operation_helper.jinja2
+++ b/autorest/codegen/templates/lro_operation_helper.jinja2
@@ -20,6 +20,9 @@
 {% endfor %}
 :type {{ parameter.serialized_name }}: {{ parameter.docstring_type }}
 {% endfor %}
+{% if (operation.requests | length) > 1 %}
+{{ op_tools.content_type_docstring(operation) }}
+{% endif %}
 :keyword callable cls: A custom type or function that will be passed the direct response
 :keyword str continuation_token: A continuation token to restart a poller from a saved state.
 :keyword polling: True for ARMPolling, False for no polling, or a

--- a/autorest/codegen/templates/operation.py.jinja2
+++ b/autorest/codegen/templates/operation.py.jinja2
@@ -38,9 +38,7 @@
 :type {{ parameter.serialized_name }}: {{ parameter.docstring_type }}
 {% endfor %}
 {% if (operation.requests | length) > 1 %}
-{% set content_type_constant = operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("in_method_code") | selectattr("serialized_name", "equalto", "content_type") | first  %}
-:keyword str content_type: Media type of the body sent to the API. Default value is {{ content_type_constant.constant_declaration }}.
- Allowed values are: "{{ operation.requests | map(attribute="media_types") | sum(start = []) | unique | list | join ('", "')  }}".
+{{ op_tools.content_type_docstring(operation) }}
 {% endif %}
 :keyword callable cls: A custom type or function that will be passed the direct response
 {{ return_docstring(async_mode, return_type=return_type) }}

--- a/autorest/codegen/templates/operation_tools.jinja2
+++ b/autorest/codegen/templates/operation_tools.jinja2
@@ -31,7 +31,13 @@ else ((return_type_wrapper | join("[") + "[") if return_type_wrapper else "") ~ 
     **kwargs  # type: Any
 ):
 {% endif %}{% endmacro %}
-{# handle response headers/deserialization #}
+
+{# content type docstring #}
+{% macro content_type_docstring(operation) %}
+{% set content_type_constant = operation.parameters.constant|selectattr("implementation", "equalto", "Method")|selectattr("original_parameter", "equalto", None)|selectattr("in_method_code") | selectattr("serialized_name", "equalto", "content_type") | first  %}
+:keyword str content_type: Media type of the body sent to the API. Default value is {{ content_type_constant.constant_declaration }}.
+ Allowed values are: "{{ operation.requests | map(attribute="media_types") | sum(start = []) | unique | list | join ('", "')  }}".{% endmacro %}
+
 {# error map handling #}
 {% macro error_map(operation, code_model) %}
 {%if operation.status_code_exceptions %}

--- a/autorest/codegen/templates/paging_operation.py.jinja2
+++ b/autorest/codegen/templates/paging_operation.py.jinja2
@@ -29,6 +29,9 @@
 {% endfor %}
 :type {{ parameter.serialized_name }}: {{ parameter.docstring_type }}
 {% endfor %}
+{% if (operation.requests | length) > 1 %}
+{{ op_tools.content_type_docstring(operation) }}
+{% endif %}
 :keyword callable cls: A custom type or function that will be passed the direct response
 {{ return_docstring(async_mode) }}
 :raises: ~azure.core.exceptions.HttpResponseError


### PR DESCRIPTION
fixes #760 

Tried it with FR's lro operations with multiple media types, and it's correctly generating docstrings there