### PR TITLE
access error model from operation group's model property

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### 2020-xx-xx - 5.4.3
+Autorest core version: 3.0.6320
+
+Modelerfour version: 4.15.421
+
+**Bug Fixes**
+
+- Fix conflict for model deserialization when operation has input param with name `models`  #819
+
 ### 2020-11-09 - 5.4.2
 Autorest core version: 3.0.6320
 

--- a/autorest/codegen/models/enum_schema.py
+++ b/autorest/codegen/models/enum_schema.py
@@ -96,7 +96,7 @@ class EnumSchema(BaseSchema):
         :return: The type annotation for this schema
         :rtype: str
         """
-        return f'Union[{self.enum_type.type_annotation}, "models.{self.name}"]'
+        return f'Union[{self.enum_type.type_annotation}, "_models.{self.name}"]'
 
     def get_declaration(self, value: Any) -> str:
         return f'"{value}"'

--- a/autorest/codegen/models/imports.py
+++ b/autorest/codegen/models/imports.py
@@ -50,11 +50,14 @@ class FileImport:
         from_section: str,
         name_import: str,
         import_type: ImportType,
-        typing_section: TypingSection = TypingSection.REGULAR
+        typing_section: TypingSection = TypingSection.REGULAR,
+        alias: Optional[str] = None,
     ) -> None:
         """Add an import to this import block.
         """
-        self._add_import(from_section, import_type, name_import, typing_section)
+        self._add_import(
+            from_section, import_type, name_import + f" as {alias}" if alias else name_import, typing_section
+        )
 
     def add_import(
         self,

--- a/autorest/codegen/models/imports.py
+++ b/autorest/codegen/models/imports.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from enum import Enum
-from typing import Dict, Optional, Set
+from typing import Dict, Optional, Set, Tuple, Union
 
 
 class ImportType(str, Enum):
@@ -21,20 +21,27 @@ class TypingSection(str, Enum):
 
 class FileImport:
     def __init__(
-        self, imports: Dict[TypingSection, Dict[ImportType, Dict[str, Set[Optional[str]]]]] = None
+        self,
+        imports: Dict[
+            TypingSection,
+            Dict[ImportType, Dict[str, Set[Optional[Union[str, Tuple[str, str]]]]]]
+        ] = None
     ) -> None:
         # Basic implementation
         # First level dict: TypingSection
         # Second level dict: ImportType
         # Third level dict: the package name.
         # Fourth level set: None if this import is a "import", the name to import if it's a "from"
-        self._imports: Dict[TypingSection, Dict[ImportType, Dict[str, Set[Optional[str]]]]] = imports or dict()
+        self._imports: Dict[
+            TypingSection,
+            Dict[ImportType, Dict[str, Set[Optional[Union[str, Tuple[str, str]]]]]]
+        ] = imports or dict()
 
     def _add_import(
         self,
         from_section: str,
         import_type: ImportType,
-        name_import: Optional[str] = None,
+        name_import: Optional[Union[str, Tuple[str, str]]] = None,
         typing_section: TypingSection = TypingSection.REGULAR
     ) -> None:
         self._imports.setdefault(
@@ -56,7 +63,7 @@ class FileImport:
         """Add an import to this import block.
         """
         self._add_import(
-            from_section, import_type, name_import + f" as {alias}" if alias else name_import, typing_section
+            from_section, import_type, (name_import, alias) if alias else name_import, typing_section
         )
 
     def add_import(
@@ -69,7 +76,10 @@ class FileImport:
         self._add_import(name_import, import_type, None, typing_section)
 
     @property
-    def imports(self) -> Dict[TypingSection, Dict[ImportType, Dict[str, Set[Optional[str]]]]]:
+    def imports(self) -> Dict[
+            TypingSection,
+            Dict[ImportType, Dict[str, Set[Optional[Union[str, Tuple[str, str]]]]]]
+        ]:
         return self._imports
 
     def merge(self, file_import: "FileImport") -> None:

--- a/autorest/codegen/models/object_schema.py
+++ b/autorest/codegen/models/object_schema.py
@@ -44,7 +44,7 @@ class ObjectSchema(BaseSchema):  # pylint: disable=too-many-instance-attributes
 
     @property
     def operation_type_annotation(self) -> str:
-        return f'"models.{self.name}"'
+        return f'"_models.{self.name}"'
 
     @property
     def docstring_type(self) -> str:

--- a/autorest/codegen/models/operation.py
+++ b/autorest/codegen/models/operation.py
@@ -231,7 +231,7 @@ class Operation(BaseModel):  # pylint: disable=too-many-public-methods, too-many
             return None
         excep_schema = default_excp[0].schema
         if isinstance(excep_schema, ObjectSchema):
-            return f"models.{excep_schema.name}"
+            return f"self.models.{excep_schema.name}"
         # in this case, it's just an AnySchema
         return "\'object\'"
 

--- a/autorest/codegen/models/operation.py
+++ b/autorest/codegen/models/operation.py
@@ -231,7 +231,7 @@ class Operation(BaseModel):  # pylint: disable=too-many-public-methods, too-many
             return None
         excep_schema = default_excp[0].schema
         if isinstance(excep_schema, ObjectSchema):
-            return f"self.models.{excep_schema.name}"
+            return f"_models.{excep_schema.name}"
         # in this case, it's just an AnySchema
         return "\'object\'"
 

--- a/autorest/codegen/models/operation_group.py
+++ b/autorest/codegen/models/operation_group.py
@@ -55,9 +55,9 @@ class OperationGroup(BaseModel):
                 )
         if has_schemas:
             if async_mode:
-                file_import.add_from_import("...", "models", ImportType.LOCAL)
+                file_import.add_from_import("...", "models", ImportType.LOCAL, alias="_models")
             else:
-                file_import.add_from_import("..", "models", ImportType.LOCAL)
+                file_import.add_from_import("..", "models", ImportType.LOCAL, alias="_models")
         return file_import
 
     @property

--- a/autorest/codegen/models/parameter_list.py
+++ b/autorest/codegen/models/parameter_list.py
@@ -141,4 +141,4 @@ class ParameterList(MutableSequence):
             ]
         )
         object_schema = cast(ObjectSchema, self.body[0].schema)
-        return f"{self.body[0].serialized_name} = models.{object_schema.name}({parameter_string})"
+        return f"{self.body[0].serialized_name} = _models.{object_schema.name}({parameter_string})"

--- a/autorest/codegen/serializers/import_serializer.py
+++ b/autorest/codegen/serializers/import_serializer.py
@@ -4,22 +4,26 @@
 # license information.
 # --------------------------------------------------------------------------
 from copy import deepcopy
-from typing import Dict, Set, Optional, List
+from typing import Dict, Set, Optional, List, Tuple, Union
 from ..models.imports import ImportType, FileImport, TypingSection
 
-def _serialize_package(package_name: str, module_list: Set[Optional[str]], delimiter: str) -> str:
+def _serialize_package(
+    package_name: str, module_list: Set[Optional[Union[str, Tuple[str, str]]]], delimiter: str
+) -> str:
     buffer = []
     if None in module_list:
         buffer.append(f"import {package_name}")
     if module_list != {None}:
         buffer.append(
             "from {} import {}".format(
-                package_name, ", ".join(sorted([mod for mod in module_list if mod is not None]))
+                package_name, ", ".join(sorted([
+                    mod if isinstance(mod, str) else f"{mod[0]} as {mod[1]}" for mod in module_list if mod is not None
+                ]))
             )
         )
     return delimiter.join(buffer)
 
-def _serialize_type(import_type_dict: Dict[str, Set[Optional[str]]], delimiter: str) -> str:
+def _serialize_type(import_type_dict: Dict[str, Set[Optional[Union[str, Tuple[str, str]]]]], delimiter: str) -> str:
     """Serialize a given import type."""
     import_list = []
     for package_name in sorted(list(import_type_dict.keys())):
@@ -27,7 +31,9 @@ def _serialize_type(import_type_dict: Dict[str, Set[Optional[str]]], delimiter: 
         import_list.append(_serialize_package(package_name, module_list, delimiter))
     return delimiter.join(import_list)
 
-def _get_import_clauses(imports: Dict[ImportType, Dict[str, Set[Optional[str]]]], delimiter: str) -> List[str]:
+def _get_import_clauses(
+    imports: Dict[ImportType, Dict[str, Set[Optional[Union[str, Tuple[str, str]]]]]], delimiter: str
+) -> List[str]:
     import_clause = []
     for import_type in ImportType:
         if import_type in imports:

--- a/autorest/codegen/serializers/metadata_serializer.py
+++ b/autorest/codegen/serializers/metadata_serializer.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 import copy
 import json
-from typing import List, Optional, Set, Tuple, Dict
+from typing import List, Optional, Set, Tuple, Dict, Union
 from jinja2 import Environment
 from ..models import (
     CodeModel,
@@ -26,7 +26,10 @@ def _correct_credential_parameter(global_parameters: ParameterList, async_mode: 
     credential_param.schema = TokenCredentialSchema(async_mode=async_mode)
 
 def _json_serialize_imports(
-    imports: Dict[TypingSection, Dict[ImportType, Dict[str, Set[Optional[str]]]]]
+    imports: Dict[
+        TypingSection,
+        Dict[ImportType, Dict[str, Set[Optional[Union[str, Tuple[str, str]]]]]]
+    ]
 ):
     if not imports:
         return None

--- a/autorest/codegen/templates/operation_tools.jinja2
+++ b/autorest/codegen/templates/operation_tools.jinja2
@@ -53,7 +53,7 @@ error_map = {
     {% endif %}
 {% for excep in operation.status_code_exceptions %}
     {% for status_code in excep.status_codes %}
-    {% set error_model = ", model=self._deserialize(self.models." + excep.serialization_type + ", response)" if excep.is_exception else "" %}
+    {% set error_model = ", model=self._deserialize(_models." + excep.serialization_type + ", response)" if excep.is_exception else "" %}
     {% set error_format = ", error_format=ARMErrorFormat" if code_model.options['azure_arm'] else "" %}
     {% if status_code == 401 %}
     401: lambda response: ClientAuthenticationError(response=response{{ error_model }}{{ error_format }}),

--- a/autorest/codegen/templates/operation_tools.jinja2
+++ b/autorest/codegen/templates/operation_tools.jinja2
@@ -53,7 +53,7 @@ error_map = {
     {% endif %}
 {% for excep in operation.status_code_exceptions %}
     {% for status_code in excep.status_codes %}
-    {% set error_model = ", model=self._deserialize(models." + excep.serialization_type + ", response)" if excep.is_exception else "" %}
+    {% set error_model = ", model=self._deserialize(self.models." + excep.serialization_type + ", response)" if excep.is_exception else "" %}
     {% set error_format = ", error_format=ARMErrorFormat" if code_model.options['azure_arm'] else "" %}
     {% if status_code == 401 %}
     401: lambda response: ClientAuthenticationError(response=response{{ error_model }}{{ error_format }}),

--- a/autorest/codegen/templates/operations_container.py.jinja2
+++ b/autorest/codegen/templates/operations_container.py.jinja2
@@ -25,7 +25,7 @@ class {{ operation_group.class_name }}{{ object_base_class }}:
     """
 
 {% if code_model.schemas %}
-    models = models
+    models = _models
 
 {% endif %}
     def __init__(self, client, config, serializer, deserializer){{ return_none_type_annotation }}:

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/aio/operations/_duration_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/aio/operations/_duration_operations.py
@@ -76,7 +76,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -130,7 +130,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -173,7 +173,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -219,7 +219,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/aio/operations/_duration_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/aio/operations/_duration_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class DurationOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -130,7 +130,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -173,7 +173,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -219,7 +219,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/operations/_duration_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/operations/_duration_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class DurationOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -136,7 +136,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -180,7 +180,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -227,7 +227,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/operations/_duration_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/operations/_duration_operations.py
@@ -81,7 +81,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -136,7 +136,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -180,7 +180,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -227,7 +227,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/aio/operations/_parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/aio/operations/_parameter_grouping_operations.py
@@ -43,7 +43,7 @@ class ParameterGroupingOperations:
     @distributed_trace_async
     async def post_required(
         self,
-        parameter_grouping_post_required_parameters: "models.ParameterGroupingPostRequiredParameters",
+        parameter_grouping_post_required_parameters: "_models.ParameterGroupingPostRequiredParameters",
         **kwargs
     ) -> None:
         """Post a bunch of required parameters grouped.
@@ -112,7 +112,7 @@ class ParameterGroupingOperations:
     @distributed_trace_async
     async def post_optional(
         self,
-        parameter_grouping_post_optional_parameters: Optional["models.ParameterGroupingPostOptionalParameters"] = None,
+        parameter_grouping_post_optional_parameters: Optional["_models.ParameterGroupingPostOptionalParameters"] = None,
         **kwargs
     ) -> None:
         """Post a bunch of optional parameters grouped.
@@ -168,8 +168,8 @@ class ParameterGroupingOperations:
     @distributed_trace_async
     async def post_multi_param_groups(
         self,
-        first_parameter_group: Optional["models.FirstParameterGroup"] = None,
-        parameter_grouping_post_multi_param_groups_second_param_group: Optional["models.ParameterGroupingPostMultiParamGroupsSecondParamGroup"] = None,
+        first_parameter_group: Optional["_models.FirstParameterGroup"] = None,
+        parameter_grouping_post_multi_param_groups_second_param_group: Optional["_models.ParameterGroupingPostMultiParamGroupsSecondParamGroup"] = None,
         **kwargs
     ) -> None:
         """Post parameters from multiple different parameter groups.
@@ -236,7 +236,7 @@ class ParameterGroupingOperations:
     @distributed_trace_async
     async def post_shared_parameter_group_object(
         self,
-        first_parameter_group: Optional["models.FirstParameterGroup"] = None,
+        first_parameter_group: Optional["_models.FirstParameterGroup"] = None,
         **kwargs
     ) -> None:
         """Post parameters with a shared parameter group object.

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/aio/operations/_parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/aio/operations/_parameter_grouping_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ParameterGroupingOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -101,7 +101,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -157,7 +157,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -225,7 +225,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -281,7 +281,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/aio/operations/_parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/aio/operations/_parameter_grouping_operations.py
@@ -101,7 +101,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -157,7 +157,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -225,7 +225,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -281,7 +281,7 @@ class ParameterGroupingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/_parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/_parameter_grouping_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ParameterGroupingOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -106,7 +106,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -163,7 +163,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -232,7 +232,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -289,7 +289,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/_parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/_parameter_grouping_operations.py
@@ -47,7 +47,7 @@ class ParameterGroupingOperations(object):
     @distributed_trace
     def post_required(
         self,
-        parameter_grouping_post_required_parameters,  # type: "models.ParameterGroupingPostRequiredParameters"
+        parameter_grouping_post_required_parameters,  # type: "_models.ParameterGroupingPostRequiredParameters"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -117,7 +117,7 @@ class ParameterGroupingOperations(object):
     @distributed_trace
     def post_optional(
         self,
-        parameter_grouping_post_optional_parameters=None,  # type: Optional["models.ParameterGroupingPostOptionalParameters"]
+        parameter_grouping_post_optional_parameters=None,  # type: Optional["_models.ParameterGroupingPostOptionalParameters"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -174,8 +174,8 @@ class ParameterGroupingOperations(object):
     @distributed_trace
     def post_multi_param_groups(
         self,
-        first_parameter_group=None,  # type: Optional["models.FirstParameterGroup"]
-        parameter_grouping_post_multi_param_groups_second_param_group=None,  # type: Optional["models.ParameterGroupingPostMultiParamGroupsSecondParamGroup"]
+        first_parameter_group=None,  # type: Optional["_models.FirstParameterGroup"]
+        parameter_grouping_post_multi_param_groups_second_param_group=None,  # type: Optional["_models.ParameterGroupingPostMultiParamGroupsSecondParamGroup"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -243,7 +243,7 @@ class ParameterGroupingOperations(object):
     @distributed_trace
     def post_shared_parameter_group_object(
         self,
-        first_parameter_group=None,  # type: Optional["models.FirstParameterGroup"]
+        first_parameter_group=None,  # type: Optional["_models.FirstParameterGroup"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/_parameter_grouping_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/azureparametergrouping/operations/_parameter_grouping_operations.py
@@ -106,7 +106,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -163,7 +163,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -232,7 +232,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -289,7 +289,7 @@ class ParameterGroupingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/aio/operations/_auto_rest_report_service_for_azure_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/aio/operations/_auto_rest_report_service_for_azure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -62,7 +62,7 @@ class AutoRestReportServiceForAzureOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/aio/operations/_auto_rest_report_service_for_azure_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/aio/operations/_auto_rest_report_service_for_azure_operations.py
@@ -62,7 +62,7 @@ class AutoRestReportServiceForAzureOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/operations/_auto_rest_report_service_for_azure_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/operations/_auto_rest_report_service_for_azure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -67,7 +67,7 @@ class AutoRestReportServiceForAzureOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/operations/_auto_rest_report_service_for_azure_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureReport/azurereport/operations/_auto_rest_report_service_for_azure_operations.py
@@ -67,7 +67,7 @@ class AutoRestReportServiceForAzureOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_default_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_default_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class ApiVersionDefaultOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -78,7 +78,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -123,7 +123,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -168,7 +168,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -213,7 +213,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_default_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_default_operations.py
@@ -78,7 +78,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -123,7 +123,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -168,7 +168,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -213,7 +213,7 @@ class ApiVersionDefaultOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_local_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_local_operations.py
@@ -78,7 +78,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -127,7 +127,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -172,7 +172,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -217,7 +217,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_local_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_api_version_local_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class ApiVersionLocalOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -78,7 +78,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -127,7 +127,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -172,7 +172,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -217,7 +217,7 @@ class ApiVersionLocalOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_header_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class HeaderOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -80,7 +80,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -135,7 +135,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -185,7 +185,7 @@ class HeaderOperations:
 
         if response.status_code not in [200, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_header_operations.py
@@ -94,7 +94,7 @@ class HeaderOperations:
     @distributed_trace_async
     async def custom_named_request_id_param_grouping(
         self,
-        header_custom_named_request_id_param_grouping_parameters: "models.HeaderCustomNamedRequestIdParamGroupingParameters",
+        header_custom_named_request_id_param_grouping_parameters: "_models.HeaderCustomNamedRequestIdParamGroupingParameters",
         **kwargs
     ) -> None:
         """Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request,

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_header_operations.py
@@ -80,7 +80,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -135,7 +135,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -185,7 +185,7 @@ class HeaderOperations:
 
         if response.status_code not in [200, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_odata_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_odata_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class OdataOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -91,7 +91,7 @@ class OdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_odata_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_odata_operations.py
@@ -91,7 +91,7 @@ class OdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_skip_url_encoding_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_skip_url_encoding_operations.py
@@ -83,7 +83,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -133,7 +133,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -181,7 +181,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -228,7 +228,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -276,7 +276,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -323,7 +323,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -368,7 +368,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_skip_url_encoding_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_skip_url_encoding_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class SkipUrlEncodingOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -83,7 +83,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -133,7 +133,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -181,7 +181,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -228,7 +228,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -276,7 +276,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -323,7 +323,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -368,7 +368,7 @@ class SkipUrlEncodingOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_credentials_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_credentials_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class SubscriptionInCredentialsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -81,7 +81,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -129,7 +129,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -179,7 +179,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -227,7 +227,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -275,7 +275,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_credentials_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_credentials_operations.py
@@ -81,7 +81,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -129,7 +129,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -179,7 +179,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -227,7 +227,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -275,7 +275,7 @@ class SubscriptionInCredentialsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_method_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_method_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class SubscriptionInMethodOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -85,7 +85,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -137,7 +137,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -188,7 +188,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -240,7 +240,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_method_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_subscription_in_method_operations.py
@@ -85,7 +85,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -137,7 +137,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -188,7 +188,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -240,7 +240,7 @@ class SubscriptionInMethodOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_xms_client_request_id_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_xms_client_request_id_operations.py
@@ -123,7 +123,7 @@ class XMsClientRequestIdOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_xms_client_request_id_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/aio/operations/_xms_client_request_id_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class XMsClientRequestIdOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -123,7 +123,7 @@ class XMsClientRequestIdOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_default_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_default_operations.py
@@ -83,7 +83,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -129,7 +129,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -175,7 +175,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -221,7 +221,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_default_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_default_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class ApiVersionDefaultOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -83,7 +83,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -129,7 +129,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -175,7 +175,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -221,7 +221,7 @@ class ApiVersionDefaultOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_local_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_local_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class ApiVersionLocalOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -83,7 +83,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -133,7 +133,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -179,7 +179,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -225,7 +225,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_local_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_api_version_local_operations.py
@@ -83,7 +83,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -133,7 +133,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -179,7 +179,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -225,7 +225,7 @@ class ApiVersionLocalOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class HeaderOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -141,7 +141,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -192,7 +192,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
@@ -99,7 +99,7 @@ class HeaderOperations(object):
     @distributed_trace
     def custom_named_request_id_param_grouping(
         self,
-        header_custom_named_request_id_param_grouping_parameters,  # type: "models.HeaderCustomNamedRequestIdParamGroupingParameters"
+        header_custom_named_request_id_param_grouping_parameters,  # type: "_models.HeaderCustomNamedRequestIdParamGroupingParameters"
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_header_operations.py
@@ -85,7 +85,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -141,7 +141,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}
@@ -192,7 +192,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_odata_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_odata_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class OdataOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -96,7 +96,7 @@ class OdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_odata_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_odata_operations.py
@@ -96,7 +96,7 @@ class OdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_skip_url_encoding_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_skip_url_encoding_operations.py
@@ -88,7 +88,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -139,7 +139,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -188,7 +188,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -236,7 +236,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -285,7 +285,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -333,7 +333,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -379,7 +379,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_skip_url_encoding_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_skip_url_encoding_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class SkipUrlEncodingOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -88,7 +88,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -139,7 +139,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -188,7 +188,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -236,7 +236,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -285,7 +285,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -333,7 +333,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -379,7 +379,7 @@ class SkipUrlEncodingOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_credentials_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_credentials_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class SubscriptionInCredentialsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -86,7 +86,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -135,7 +135,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -186,7 +186,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -235,7 +235,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -284,7 +284,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_credentials_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_credentials_operations.py
@@ -86,7 +86,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -135,7 +135,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -186,7 +186,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -235,7 +235,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -284,7 +284,7 @@ class SubscriptionInCredentialsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_method_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_method_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class SubscriptionInMethodOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -90,7 +90,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -143,7 +143,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -195,7 +195,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -248,7 +248,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_method_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_subscription_in_method_operations.py
@@ -90,7 +90,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -143,7 +143,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -195,7 +195,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -248,7 +248,7 @@ class SubscriptionInMethodOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_xms_client_request_id_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_xms_client_request_id_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class XMsClientRequestIdOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -129,7 +129,7 @@ class XMsClientRequestIdOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_xms_client_request_id_operations.py
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/azurespecialproperties/operations/_xms_client_request_id_operations.py
@@ -129,7 +129,7 @@ class XMsClientRequestIdOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
@@ -83,7 +83,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PathsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -83,7 +83,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PathsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -88,7 +88,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
@@ -88,7 +88,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/aio/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/aio/operations/_paging_operations.py
@@ -48,7 +48,7 @@ class PagingOperations:
         self,
         account_name: str,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that combines custom url, paging and partial URL and expect to concat after
         host.
 
@@ -59,7 +59,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~custombaseurlpaging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -123,7 +123,7 @@ class PagingOperations:
         self,
         account_name: str,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that combines custom url, paging and partial URL with next operation.
 
         :param account_name: Account Name.
@@ -133,7 +133,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~custombaseurlpaging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/aio/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/aio/operations/_paging_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -35,7 +35,7 @@ class PagingOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/operations/_paging_operations.py
@@ -52,7 +52,7 @@ class PagingOperations(object):
         account_name,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that combines custom url, paging and partial URL and expect to concat after
         host.
 
@@ -63,7 +63,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~custombaseurlpaging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -128,7 +128,7 @@ class PagingOperations(object):
         account_name,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that combines custom url, paging and partial URL with next operation.
 
         :param account_name: Account Name.
@@ -138,7 +138,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~custombaseurlpaging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/operations/_paging_operations.py
@@ -15,7 +15,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -38,7 +38,7 @@ class PagingOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lr_os_custom_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lr_os_custom_header_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -35,7 +35,7 @@ class LROsCustomHeaderOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lr_os_custom_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lr_os_custom_header_operations.py
@@ -45,10 +45,10 @@ class LROsCustomHeaderOperations:
 
     async def _put_async_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -96,9 +96,9 @@ class LROsCustomHeaderOperations:
     @distributed_trace_async
     async def begin_put_async_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
         all requests. Long running put request, service returns a 200 to the initial request, with an
         entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-
@@ -117,7 +117,7 @@ class LROsCustomHeaderOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -161,10 +161,10 @@ class LROsCustomHeaderOperations:
 
     async def _put201_creating_succeeded200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -212,9 +212,9 @@ class LROsCustomHeaderOperations:
     @distributed_trace_async
     async def begin_put201_creating_succeeded200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
         all requests. Long running put request, service returns a 201 to the initial request, with an
         entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
@@ -233,7 +233,7 @@ class LROsCustomHeaderOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -272,7 +272,7 @@ class LROsCustomHeaderOperations:
 
     async def _post202_retry200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -320,7 +320,7 @@ class LROsCustomHeaderOperations:
     @distributed_trace_async
     async def begin_post202_retry200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
@@ -376,7 +376,7 @@ class LROsCustomHeaderOperations:
 
     async def _post_async_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -425,7 +425,7 @@ class LROsCustomHeaderOperations:
     @distributed_trace_async
     async def begin_post_async_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lro_retrys_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lro_retrys_operations.py
@@ -45,10 +45,10 @@ class LRORetrysOperations:
 
     async def _put201_creating_succeeded200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -96,9 +96,9 @@ class LRORetrysOperations:
     @distributed_trace_async
     async def begin_put201_creating_succeeded200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 500, then a 201 to the initial request, with an
         entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
         returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -116,7 +116,7 @@ class LRORetrysOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -155,10 +155,10 @@ class LRORetrysOperations:
 
     async def _put_async_relative_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -206,9 +206,9 @@ class LRORetrysOperations:
     @distributed_trace_async
     async def begin_put_async_relative_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 500, then a 200 to the initial request, with an
         entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-
         AsyncOperation header for operation status.
@@ -226,7 +226,7 @@ class LRORetrysOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -271,8 +271,8 @@ class LRORetrysOperations:
     async def _delete_provisioning202_accepted200_succeeded_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -316,7 +316,7 @@ class LRORetrysOperations:
     async def begin_delete_provisioning202_accepted200_succeeded(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running delete request, service returns a 500, then a  202 to the initial request, with an
         entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll
         returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -332,7 +332,7 @@ class LRORetrysOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -555,7 +555,7 @@ class LRORetrysOperations:
 
     async def _post202_retry200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -603,7 +603,7 @@ class LRORetrysOperations:
     @distributed_trace_async
     async def begin_post202_retry200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 500, then a 202 to the initial request, with
@@ -658,7 +658,7 @@ class LRORetrysOperations:
 
     async def _post_async_relative_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -707,7 +707,7 @@ class LRORetrysOperations:
     @distributed_trace_async
     async def begin_post_async_relative_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 500, then a 202 to the initial request, with an

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lro_retrys_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lro_retrys_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -35,7 +35,7 @@ class LRORetrysOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lros_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lros_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -35,7 +35,7 @@ class LROsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lros_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lros_operations.py
@@ -45,10 +45,10 @@ class LROsOperations:
 
     async def _put200_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -94,9 +94,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put200_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Succeeded’.
 
@@ -113,7 +113,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -152,10 +152,10 @@ class LROsOperations:
 
     async def _put201_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -199,9 +199,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put201_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Succeeded’.
 
@@ -218,7 +218,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -258,8 +258,8 @@ class LROsOperations:
     async def _post202_list_initial(
         self,
         **kwargs
-    ) -> Optional[List["models.Product"]]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[List["models.Product"]]]
+    ) -> Optional[List["_models.Product"]]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[List["_models.Product"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -303,7 +303,7 @@ class LROsOperations:
     async def begin_post202_list(
         self,
         **kwargs
-    ) -> AsyncLROPoller[List["models.Product"]]:
+    ) -> AsyncLROPoller[List["_models.Product"]]:
         """Long running put request, service returns a 202 with empty body to first request, returns a 200
         with body [{ 'id': '100', 'name': 'foo' }].
 
@@ -318,7 +318,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -356,10 +356,10 @@ class LROsOperations:
 
     async def _put200_succeeded_no_state_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -403,9 +403,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put200_succeeded_no_state(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         does not contain ProvisioningState=’Succeeded’.
 
@@ -422,7 +422,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -461,10 +461,10 @@ class LROsOperations:
 
     async def _put202_retry200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -508,9 +508,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put202_retry200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 202 to the initial request, with a location header
         that points to a polling URL that returns a 200 and an entity that doesn't contains
         ProvisioningState.
@@ -528,7 +528,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -567,10 +567,10 @@ class LROsOperations:
 
     async def _put201_creating_succeeded200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -618,9 +618,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put201_creating_succeeded200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Succeeded’.
@@ -638,7 +638,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -677,10 +677,10 @@ class LROsOperations:
 
     async def _put200_updating_succeeded204_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -724,9 +724,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put200_updating_succeeded204(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Succeeded’.
@@ -744,7 +744,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -783,10 +783,10 @@ class LROsOperations:
 
     async def _put201_creating_failed200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -834,9 +834,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put201_creating_failed200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Failed’.
@@ -854,7 +854,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -893,10 +893,10 @@ class LROsOperations:
 
     async def _put200_acceptedcanceled200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -940,9 +940,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put200_acceptedcanceled200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Canceled’.
@@ -960,7 +960,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -999,10 +999,10 @@ class LROsOperations:
 
     async def _put_no_header_in_retry_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1048,9 +1048,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_no_header_in_retry(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 202 to the initial request with location header.
         Subsequent calls to operation status do not contain location header.
 
@@ -1067,7 +1067,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1109,10 +1109,10 @@ class LROsOperations:
 
     async def _put_async_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1160,9 +1160,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_async_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1180,7 +1180,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1224,10 +1224,10 @@ class LROsOperations:
 
     async def _put_async_no_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1274,9 +1274,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_async_no_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1294,7 +1294,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1337,10 +1337,10 @@ class LROsOperations:
 
     async def _put_async_retry_failed_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1388,9 +1388,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_async_retry_failed(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1408,7 +1408,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1452,10 +1452,10 @@ class LROsOperations:
 
     async def _put_async_no_retrycanceled_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1502,9 +1502,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_async_no_retrycanceled(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1522,7 +1522,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1565,10 +1565,10 @@ class LROsOperations:
 
     async def _put_async_no_header_in_retry_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1614,9 +1614,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_async_no_header_in_retry(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 202 to the initial request with Azure-
         AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation
         header.
@@ -1634,7 +1634,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1676,10 +1676,10 @@ class LROsOperations:
 
     async def _put_non_resource_initial(
         self,
-        sku: Optional["models.Sku"] = None,
+        sku: Optional["_models.Sku"] = None,
         **kwargs
-    ) -> "models.Sku":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+    ) -> "_models.Sku":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1723,9 +1723,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_non_resource(
         self,
-        sku: Optional["models.Sku"] = None,
+        sku: Optional["_models.Sku"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Sku"]:
+    ) -> AsyncLROPoller["_models.Sku"]:
         """Long running put request with non resource.
 
         :param sku: sku to put.
@@ -1741,7 +1741,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1780,10 +1780,10 @@ class LROsOperations:
 
     async def _put_async_non_resource_initial(
         self,
-        sku: Optional["models.Sku"] = None,
+        sku: Optional["_models.Sku"] = None,
         **kwargs
-    ) -> "models.Sku":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+    ) -> "_models.Sku":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1827,9 +1827,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_put_async_non_resource(
         self,
-        sku: Optional["models.Sku"] = None,
+        sku: Optional["_models.Sku"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Sku"]:
+    ) -> AsyncLROPoller["_models.Sku"]:
         """Long running put request with non resource.
 
         :param sku: Sku to put.
@@ -1845,7 +1845,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1886,14 +1886,14 @@ class LROsOperations:
         self,
         provisioning_state: Optional[str] = None,
         **kwargs
-    ) -> "models.SubProduct":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+    ) -> "_models.SubProduct":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _product = models.SubProduct(provisioning_state=provisioning_state)
+        _product = _models.SubProduct(provisioning_state=provisioning_state)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1935,7 +1935,7 @@ class LROsOperations:
         self,
         provisioning_state: Optional[str] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.SubProduct"]:
+    ) -> AsyncLROPoller["_models.SubProduct"]:
         """Long running put request with sub resource.
 
         :param provisioning_state:
@@ -1951,7 +1951,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1992,14 +1992,14 @@ class LROsOperations:
         self,
         provisioning_state: Optional[str] = None,
         **kwargs
-    ) -> "models.SubProduct":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+    ) -> "_models.SubProduct":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _product = models.SubProduct(provisioning_state=provisioning_state)
+        _product = _models.SubProduct(provisioning_state=provisioning_state)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -2041,7 +2041,7 @@ class LROsOperations:
         self,
         provisioning_state: Optional[str] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.SubProduct"]:
+    ) -> AsyncLROPoller["_models.SubProduct"]:
         """Long running put request with sub resource.
 
         :param provisioning_state:
@@ -2057,7 +2057,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2097,8 +2097,8 @@ class LROsOperations:
     async def _delete_provisioning202_accepted200_succeeded_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2142,7 +2142,7 @@ class LROsOperations:
     async def begin_delete_provisioning202_accepted200_succeeded(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running delete request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Succeeded’.
@@ -2158,7 +2158,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2201,8 +2201,8 @@ class LROsOperations:
     async def _delete_provisioning202_deleting_failed200_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2246,7 +2246,7 @@ class LROsOperations:
     async def begin_delete_provisioning202_deleting_failed200(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running delete request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Failed’.
@@ -2262,7 +2262,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2305,8 +2305,8 @@ class LROsOperations:
     async def _delete_provisioning202_deletingcanceled200_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2350,7 +2350,7 @@ class LROsOperations:
     async def begin_delete_provisioning202_deletingcanceled200(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running delete request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Canceled’.
@@ -2366,7 +2366,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2494,8 +2494,8 @@ class LROsOperations:
     async def _delete202_retry200_initial(
         self,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2539,7 +2539,7 @@ class LROsOperations:
     async def begin_delete202_retry200(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running delete request, service returns a 202 to the initial request. Polls return this
         value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
 
@@ -2554,7 +2554,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2593,8 +2593,8 @@ class LROsOperations:
     async def _delete202_no_retry204_initial(
         self,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2638,7 +2638,7 @@ class LROsOperations:
     async def begin_delete202_no_retry204(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running delete request, service returns a 202 to the initial request. Polls return this
         value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
 
@@ -2653,7 +2653,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3236,8 +3236,8 @@ class LROsOperations:
     async def _post200_with_payload_initial(
         self,
         **kwargs
-    ) -> "models.Sku":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+    ) -> "_models.Sku":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3278,7 +3278,7 @@ class LROsOperations:
     async def begin_post200_with_payload(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Sku"]:
+    ) -> AsyncLROPoller["_models.Sku"]:
         """Long running post request, service returns a 202 to the initial request, with 'Location'
         header. Poll returns a 200 with a response body after success.
 
@@ -3293,7 +3293,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3331,7 +3331,7 @@ class LROsOperations:
 
     async def _post202_retry200_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -3379,7 +3379,7 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_post202_retry200(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with 'Location' and
@@ -3434,10 +3434,10 @@ class LROsOperations:
 
     async def _post202_no_retry204_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3484,9 +3484,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_post202_no_retry204(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running post request, service returns a 202 to the initial request, with 'Location'
         header, 204 with noresponse body after success.
 
@@ -3503,7 +3503,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3547,8 +3547,8 @@ class LROsOperations:
     async def _post_double_headers_final_location_get_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3585,7 +3585,7 @@ class LROsOperations:
     async def begin_post_double_headers_final_location_get(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running post request, service returns a 202 to the initial request with both Location and
         Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final
         object.
@@ -3601,7 +3601,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3640,8 +3640,8 @@ class LROsOperations:
     async def _post_double_headers_final_azure_header_get_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3678,7 +3678,7 @@ class LROsOperations:
     async def begin_post_double_headers_final_azure_header_get(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running post request, service returns a 202 to the initial request with both Location and
         Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the
         final object.
@@ -3694,7 +3694,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3733,8 +3733,8 @@ class LROsOperations:
     async def _post_double_headers_final_azure_header_get_default_initial(
         self,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3771,7 +3771,7 @@ class LROsOperations:
     async def begin_post_double_headers_final_azure_header_get_default(
         self,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running post request, service returns a 202 to the initial request with both Location and
         Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the
         final object if you support initial Autorest behavior.
@@ -3787,7 +3787,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3825,10 +3825,10 @@ class LROsOperations:
 
     async def _post_async_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3880,9 +3880,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_post_async_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running post request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -3900,7 +3900,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3939,10 +3939,10 @@ class LROsOperations:
 
     async def _post_async_no_retry_succeeded_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3994,9 +3994,9 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_post_async_no_retry_succeeded(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running post request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -4014,7 +4014,7 @@ class LROsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -4053,7 +4053,7 @@ class LROsOperations:
 
     async def _post_async_retry_failed_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -4102,7 +4102,7 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_post_async_retry_failed(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with an entity that
@@ -4158,7 +4158,7 @@ class LROsOperations:
 
     async def _post_async_retrycanceled_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -4207,7 +4207,7 @@ class LROsOperations:
     @distributed_trace_async
     async def begin_post_async_retrycanceled(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with an entity that

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lrosads_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lrosads_operations.py
@@ -45,10 +45,10 @@ class LROSADsOperations:
 
     async def _put_non_retry400_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -96,9 +96,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_non_retry400(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 400 to the initial request.
 
         :param product: Product to put.
@@ -114,7 +114,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -153,10 +153,10 @@ class LROSADsOperations:
 
     async def _put_non_retry201_creating400_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -204,9 +204,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_non_retry201_creating400(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
         201 response code.
 
@@ -223,7 +223,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -262,10 +262,10 @@ class LROSADsOperations:
 
     async def _put_non_retry201_creating400_invalid_json_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -313,9 +313,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_non_retry201_creating400_invalid_json(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
         201 response code.
 
@@ -332,7 +332,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -371,10 +371,10 @@ class LROSADsOperations:
 
     async def _put_async_relative_retry400_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -422,9 +422,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_async_relative_retry400(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
         endpoint indicated in the Azure-AsyncOperation header for operation status.
 
@@ -441,7 +441,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -754,7 +754,7 @@ class LROSADsOperations:
 
     async def _post_non_retry400_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -802,7 +802,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post_non_retry400(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 400 with no error body.
@@ -856,7 +856,7 @@ class LROSADsOperations:
 
     async def _post202_non_retry400_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -904,7 +904,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post202_non_retry400(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 with a location header.
@@ -958,7 +958,7 @@ class LROSADsOperations:
 
     async def _post_async_relative_retry400_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -1007,7 +1007,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post_async_relative_retry400(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request Poll the endpoint
@@ -1062,10 +1062,10 @@ class LROSADsOperations:
 
     async def _put_error201_no_provisioning_state_payload_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1113,9 +1113,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_error201_no_provisioning_state_payload(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 201 to the initial request with no payload.
 
         :param product: Product to put.
@@ -1131,7 +1131,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1170,10 +1170,10 @@ class LROSADsOperations:
 
     async def _put_async_relative_retry_no_status_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1221,9 +1221,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_async_relative_retry_no_status(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1241,7 +1241,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1285,10 +1285,10 @@ class LROSADsOperations:
 
     async def _put_async_relative_retry_no_status_payload_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1336,9 +1336,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_async_relative_retry_no_status_payload(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1356,7 +1356,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1576,7 +1576,7 @@ class LROSADsOperations:
 
     async def _post202_no_location_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -1624,7 +1624,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post202_no_location(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, without a location
@@ -1679,7 +1679,7 @@ class LROSADsOperations:
 
     async def _post_async_relative_retry_no_payload_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -1728,7 +1728,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post_async_relative_retry_no_payload(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with an entity that
@@ -1784,10 +1784,10 @@ class LROSADsOperations:
 
     async def _put200_invalid_json_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1833,9 +1833,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put200_invalid_json(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that is
         not a valid json.
 
@@ -1852,7 +1852,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1891,10 +1891,10 @@ class LROSADsOperations:
 
     async def _put_async_relative_retry_invalid_header_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1942,9 +1942,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_async_relative_retry_invalid_header(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation
         header is invalid.
@@ -1962,7 +1962,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2006,10 +2006,10 @@ class LROSADsOperations:
 
     async def _put_async_relative_retry_invalid_json_polling_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+    ) -> "_models.Product":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2057,9 +2057,9 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_put_async_relative_retry_invalid_json_polling(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -2077,7 +2077,7 @@ class LROSADsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2393,7 +2393,7 @@ class LROSADsOperations:
 
     async def _post202_retry_invalid_header_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -2441,7 +2441,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post202_retry_invalid_header(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with invalid
@@ -2496,7 +2496,7 @@ class LROSADsOperations:
 
     async def _post_async_relative_retry_invalid_header_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -2545,7 +2545,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post_async_relative_retry_invalid_header(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with an entity that
@@ -2601,7 +2601,7 @@ class LROSADsOperations:
 
     async def _post_async_relative_retry_invalid_json_polling_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         cls = kwargs.pop('cls', None)  # type: ClsType[None]
@@ -2650,7 +2650,7 @@ class LROSADsOperations:
     @distributed_trace_async
     async def begin_post_async_relative_retry_invalid_json_polling(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
     ) -> AsyncLROPoller[None]:
         """Long running post request, service returns a 202 to the initial request, with an entity that

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lrosads_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/aio/operations/_lrosads_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -35,7 +35,7 @@ class LROSADsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lr_os_custom_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lr_os_custom_header_operations.py
@@ -49,11 +49,11 @@ class LROsCustomHeaderOperations(object):
 
     def _put_async_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -101,10 +101,10 @@ class LROsCustomHeaderOperations(object):
     @distributed_trace
     def begin_put_async_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
         all requests. Long running put request, service returns a 200 to the initial request, with an
         entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-
@@ -123,7 +123,7 @@ class LROsCustomHeaderOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -167,11 +167,11 @@ class LROsCustomHeaderOperations(object):
 
     def _put201_creating_succeeded200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -219,10 +219,10 @@ class LROsCustomHeaderOperations(object):
     @distributed_trace
     def begin_put201_creating_succeeded200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
         all requests. Long running put request, service returns a 201 to the initial request, with an
         entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
@@ -241,7 +241,7 @@ class LROsCustomHeaderOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -280,7 +280,7 @@ class LROsCustomHeaderOperations(object):
 
     def _post202_retry200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -329,7 +329,7 @@ class LROsCustomHeaderOperations(object):
     @distributed_trace
     def begin_post202_retry200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -386,7 +386,7 @@ class LROsCustomHeaderOperations(object):
 
     def _post_async_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -436,7 +436,7 @@ class LROsCustomHeaderOperations(object):
     @distributed_trace
     def begin_post_async_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lr_os_custom_header_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lr_os_custom_header_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -39,7 +39,7 @@ class LROsCustomHeaderOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lro_retrys_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lro_retrys_operations.py
@@ -49,11 +49,11 @@ class LRORetrysOperations(object):
 
     def _put201_creating_succeeded200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -101,10 +101,10 @@ class LRORetrysOperations(object):
     @distributed_trace
     def begin_put201_creating_succeeded200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 500, then a 201 to the initial request, with an
         entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
         returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -122,7 +122,7 @@ class LRORetrysOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -161,11 +161,11 @@ class LRORetrysOperations(object):
 
     def _put_async_relative_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -213,10 +213,10 @@ class LRORetrysOperations(object):
     @distributed_trace
     def begin_put_async_relative_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 500, then a 200 to the initial request, with an
         entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-
         AsyncOperation header for operation status.
@@ -234,7 +234,7 @@ class LRORetrysOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -280,8 +280,8 @@ class LRORetrysOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -326,7 +326,7 @@ class LRORetrysOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running delete request, service returns a 500, then a  202 to the initial request, with an
         entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll
         returns a ‘200’ with ProvisioningState=’Succeeded’.
@@ -342,7 +342,7 @@ class LRORetrysOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -569,7 +569,7 @@ class LRORetrysOperations(object):
 
     def _post202_retry200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -618,7 +618,7 @@ class LRORetrysOperations(object):
     @distributed_trace
     def begin_post202_retry200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -674,7 +674,7 @@ class LRORetrysOperations(object):
 
     def _post_async_relative_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -724,7 +724,7 @@ class LRORetrysOperations(object):
     @distributed_trace
     def begin_post_async_relative_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lro_retrys_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lro_retrys_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -39,7 +39,7 @@ class LRORetrysOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lros_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lros_operations.py
@@ -49,11 +49,11 @@ class LROsOperations(object):
 
     def _put200_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -99,10 +99,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put200_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Succeeded’.
 
@@ -119,7 +119,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -158,11 +158,11 @@ class LROsOperations(object):
 
     def _put201_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -206,10 +206,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put201_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Succeeded’.
 
@@ -226,7 +226,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -267,8 +267,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional[List["models.Product"]]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[List["models.Product"]]]
+        # type: (...) -> Optional[List["_models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[List["_models.Product"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -313,7 +313,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[List["models.Product"]]
+        # type: (...) -> LROPoller[List["_models.Product"]]
         """Long running put request, service returns a 202 with empty body to first request, returns a 200
         with body [{ 'id': '100', 'name': 'foo' }].
 
@@ -328,7 +328,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -366,11 +366,11 @@ class LROsOperations(object):
 
     def _put200_succeeded_no_state_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -414,10 +414,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put200_succeeded_no_state(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         does not contain ProvisioningState=’Succeeded’.
 
@@ -434,7 +434,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -473,11 +473,11 @@ class LROsOperations(object):
 
     def _put202_retry200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -521,10 +521,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put202_retry200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 202 to the initial request, with a location header
         that points to a polling URL that returns a 200 and an entity that doesn't contains
         ProvisioningState.
@@ -542,7 +542,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -581,11 +581,11 @@ class LROsOperations(object):
 
     def _put201_creating_succeeded200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -633,10 +633,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put201_creating_succeeded200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Succeeded’.
@@ -654,7 +654,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -693,11 +693,11 @@ class LROsOperations(object):
 
     def _put200_updating_succeeded204_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -741,10 +741,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put200_updating_succeeded204(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Succeeded’.
@@ -762,7 +762,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -801,11 +801,11 @@ class LROsOperations(object):
 
     def _put201_creating_failed200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -853,10 +853,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put201_creating_failed200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Failed’.
@@ -874,7 +874,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -913,11 +913,11 @@ class LROsOperations(object):
 
     def _put200_acceptedcanceled200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -961,10 +961,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put200_acceptedcanceled200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 201 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Canceled’.
@@ -982,7 +982,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1021,11 +1021,11 @@ class LROsOperations(object):
 
     def _put_no_header_in_retry_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1071,10 +1071,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_no_header_in_retry(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 202 to the initial request with location header.
         Subsequent calls to operation status do not contain location header.
 
@@ -1091,7 +1091,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1133,11 +1133,11 @@ class LROsOperations(object):
 
     def _put_async_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1185,10 +1185,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_async_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1206,7 +1206,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1250,11 +1250,11 @@ class LROsOperations(object):
 
     def _put_async_no_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1301,10 +1301,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_async_no_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1322,7 +1322,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1365,11 +1365,11 @@ class LROsOperations(object):
 
     def _put_async_retry_failed_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1417,10 +1417,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_async_retry_failed(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1438,7 +1438,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1482,11 +1482,11 @@ class LROsOperations(object):
 
     def _put_async_no_retrycanceled_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1533,10 +1533,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_async_no_retrycanceled(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1554,7 +1554,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1597,11 +1597,11 @@ class LROsOperations(object):
 
     def _put_async_no_header_in_retry_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1647,10 +1647,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_async_no_header_in_retry(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 202 to the initial request with Azure-
         AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation
         header.
@@ -1668,7 +1668,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1710,11 +1710,11 @@ class LROsOperations(object):
 
     def _put_non_resource_initial(
         self,
-        sku=None,  # type: Optional["models.Sku"]
+        sku=None,  # type: Optional["_models.Sku"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Sku"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        # type: (...) -> "_models.Sku"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1758,10 +1758,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_non_resource(
         self,
-        sku=None,  # type: Optional["models.Sku"]
+        sku=None,  # type: Optional["_models.Sku"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Sku"]
+        # type: (...) -> LROPoller["_models.Sku"]
         """Long running put request with non resource.
 
         :param sku: sku to put.
@@ -1777,7 +1777,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1816,11 +1816,11 @@ class LROsOperations(object):
 
     def _put_async_non_resource_initial(
         self,
-        sku=None,  # type: Optional["models.Sku"]
+        sku=None,  # type: Optional["_models.Sku"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Sku"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        # type: (...) -> "_models.Sku"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1864,10 +1864,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_put_async_non_resource(
         self,
-        sku=None,  # type: Optional["models.Sku"]
+        sku=None,  # type: Optional["_models.Sku"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Sku"]
+        # type: (...) -> LROPoller["_models.Sku"]
         """Long running put request with non resource.
 
         :param sku: Sku to put.
@@ -1883,7 +1883,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1925,14 +1925,14 @@ class LROsOperations(object):
         provisioning_state=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.SubProduct"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+        # type: (...) -> "_models.SubProduct"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _product = models.SubProduct(provisioning_state=provisioning_state)
+        _product = _models.SubProduct(provisioning_state=provisioning_state)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1975,7 +1975,7 @@ class LROsOperations(object):
         provisioning_state=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.SubProduct"]
+        # type: (...) -> LROPoller["_models.SubProduct"]
         """Long running put request with sub resource.
 
         :param provisioning_state:
@@ -1991,7 +1991,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2033,14 +2033,14 @@ class LROsOperations(object):
         provisioning_state=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.SubProduct"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+        # type: (...) -> "_models.SubProduct"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _product = models.SubProduct(provisioning_state=provisioning_state)
+        _product = _models.SubProduct(provisioning_state=provisioning_state)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -2083,7 +2083,7 @@ class LROsOperations(object):
         provisioning_state=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.SubProduct"]
+        # type: (...) -> LROPoller["_models.SubProduct"]
         """Long running put request with sub resource.
 
         :param provisioning_state:
@@ -2099,7 +2099,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SubProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SubProduct"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2140,8 +2140,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2186,7 +2186,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running delete request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Succeeded’.
@@ -2202,7 +2202,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2246,8 +2246,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2292,7 +2292,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running delete request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Failed’.
@@ -2308,7 +2308,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2352,8 +2352,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2398,7 +2398,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running delete request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
         ‘200’ with ProvisioningState=’Canceled’.
@@ -2414,7 +2414,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2545,8 +2545,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2591,7 +2591,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running delete request, service returns a 202 to the initial request. Polls return this
         value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
 
@@ -2606,7 +2606,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2646,8 +2646,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2692,7 +2692,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running delete request, service returns a 202 to the initial request. Polls return this
         value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’.
 
@@ -2707,7 +2707,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3303,8 +3303,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Sku"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        # type: (...) -> "_models.Sku"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3346,7 +3346,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Sku"]
+        # type: (...) -> LROPoller["_models.Sku"]
         """Long running post request, service returns a 202 to the initial request, with 'Location'
         header. Poll returns a 200 with a response body after success.
 
@@ -3361,7 +3361,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Sku"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Sku"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3399,7 +3399,7 @@ class LROsOperations(object):
 
     def _post202_retry200_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -3448,7 +3448,7 @@ class LROsOperations(object):
     @distributed_trace
     def begin_post202_retry200(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -3504,11 +3504,11 @@ class LROsOperations(object):
 
     def _post202_no_retry204_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3555,10 +3555,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_post202_no_retry204(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running post request, service returns a 202 to the initial request, with 'Location'
         header, 204 with noresponse body after success.
 
@@ -3575,7 +3575,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3620,8 +3620,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3659,7 +3659,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running post request, service returns a 202 to the initial request with both Location and
         Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final
         object.
@@ -3675,7 +3675,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3715,8 +3715,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3754,7 +3754,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running post request, service returns a 202 to the initial request with both Location and
         Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the
         final object.
@@ -3770,7 +3770,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3810,8 +3810,8 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3849,7 +3849,7 @@ class LROsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running post request, service returns a 202 to the initial request with both Location and
         Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the
         final object if you support initial Autorest behavior.
@@ -3865,7 +3865,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -3903,11 +3903,11 @@ class LROsOperations(object):
 
     def _post_async_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -3959,10 +3959,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_post_async_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running post request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -3980,7 +3980,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -4019,11 +4019,11 @@ class LROsOperations(object):
 
     def _post_async_no_retry_succeeded_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -4075,10 +4075,10 @@ class LROsOperations(object):
     @distributed_trace
     def begin_post_async_no_retry_succeeded(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running post request, service returns a 202 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -4096,7 +4096,7 @@ class LROsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -4135,7 +4135,7 @@ class LROsOperations(object):
 
     def _post_async_retry_failed_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -4185,7 +4185,7 @@ class LROsOperations(object):
     @distributed_trace
     def begin_post_async_retry_failed(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -4242,7 +4242,7 @@ class LROsOperations(object):
 
     def _post_async_retrycanceled_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -4292,7 +4292,7 @@ class LROsOperations(object):
     @distributed_trace
     def begin_post_async_retrycanceled(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lros_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lros_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -39,7 +39,7 @@ class LROsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lrosads_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lrosads_operations.py
@@ -49,11 +49,11 @@ class LROSADsOperations(object):
 
     def _put_non_retry400_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -101,10 +101,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_non_retry400(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 400 to the initial request.
 
         :param product: Product to put.
@@ -120,7 +120,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -159,11 +159,11 @@ class LROSADsOperations(object):
 
     def _put_non_retry201_creating400_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -211,10 +211,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_non_retry201_creating400(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
         201 response code.
 
@@ -231,7 +231,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -270,11 +270,11 @@ class LROSADsOperations(object):
 
     def _put_non_retry201_creating400_invalid_json_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -322,10 +322,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_non_retry201_creating400_invalid_json(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
         201 response code.
 
@@ -342,7 +342,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -381,11 +381,11 @@ class LROSADsOperations(object):
 
     def _put_async_relative_retry400_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -433,10 +433,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_async_relative_retry400(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
         endpoint indicated in the Azure-AsyncOperation header for operation status.
 
@@ -453,7 +453,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -772,7 +772,7 @@ class LROSADsOperations(object):
 
     def _post_non_retry400_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -821,7 +821,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post_non_retry400(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -876,7 +876,7 @@ class LROSADsOperations(object):
 
     def _post202_non_retry400_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -925,7 +925,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post202_non_retry400(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -980,7 +980,7 @@ class LROSADsOperations(object):
 
     def _post_async_relative_retry400_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1030,7 +1030,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post_async_relative_retry400(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -1086,11 +1086,11 @@ class LROSADsOperations(object):
 
     def _put_error201_no_provisioning_state_payload_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1138,10 +1138,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_error201_no_provisioning_state_payload(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 201 to the initial request with no payload.
 
         :param product: Product to put.
@@ -1157,7 +1157,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1196,11 +1196,11 @@ class LROSADsOperations(object):
 
     def _put_async_relative_retry_no_status_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1248,10 +1248,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_async_relative_retry_no_status(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1269,7 +1269,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1313,11 +1313,11 @@ class LROSADsOperations(object):
 
     def _put_async_relative_retry_no_status_payload_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1365,10 +1365,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_async_relative_retry_no_status_payload(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -1386,7 +1386,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1610,7 +1610,7 @@ class LROSADsOperations(object):
 
     def _post202_no_location_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1659,7 +1659,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post202_no_location(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -1715,7 +1715,7 @@ class LROSADsOperations(object):
 
     def _post_async_relative_retry_no_payload_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1765,7 +1765,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post_async_relative_retry_no_payload(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -1822,11 +1822,11 @@ class LROSADsOperations(object):
 
     def _put200_invalid_json_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1872,10 +1872,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put200_invalid_json(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that is
         not a valid json.
 
@@ -1892,7 +1892,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1931,11 +1931,11 @@ class LROSADsOperations(object):
 
     def _put_async_relative_retry_invalid_header_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1983,10 +1983,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_async_relative_retry_invalid_header(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation
         header is invalid.
@@ -2004,7 +2004,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2048,11 +2048,11 @@ class LROSADsOperations(object):
 
     def _put_async_relative_retry_invalid_json_polling_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        # type: (...) -> "_models.Product"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2100,10 +2100,10 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_put_async_relative_retry_invalid_json_polling(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Long running put request, service returns a 200 to the initial request, with an entity that
         contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
         header for operation status.
@@ -2121,7 +2121,7 @@ class LROSADsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -2443,7 +2443,7 @@ class LROSADsOperations(object):
 
     def _post202_retry_invalid_header_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -2492,7 +2492,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post202_retry_invalid_header(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -2548,7 +2548,7 @@ class LROSADsOperations(object):
 
     def _post_async_relative_retry_invalid_header_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -2598,7 +2598,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post_async_relative_retry_invalid_header(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]
@@ -2655,7 +2655,7 @@ class LROSADsOperations(object):
 
     def _post_async_relative_retry_invalid_json_polling_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -2705,7 +2705,7 @@ class LROSADsOperations(object):
     @distributed_trace
     def begin_post_async_relative_retry_invalid_json_polling(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> LROPoller[None]

--- a/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lrosads_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Lro/lro/operations/_lrosads_operations.py
@@ -16,7 +16,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -39,7 +39,7 @@ class LROSADsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/aio/operations/_lro_with_paramaterized_endpoints_operations.py
+++ b/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/aio/operations/_lro_with_paramaterized_endpoints_operations.py
@@ -55,7 +55,7 @@ class LROWithParamaterizedEndpointsOperationsMixin:
 
         if response.status_code not in [200, 202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/aio/operations/_lro_with_paramaterized_endpoints_operations.py
+++ b/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/aio/operations/_lro_with_paramaterized_endpoints_operations.py
@@ -15,7 +15,7 @@ from azure.core.polling import AsyncLROPoller, AsyncNoPolling, AsyncPollingMetho
 from azure.core.polling.async_base_polling import AsyncLROBasePolling
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -55,7 +55,7 @@ class LROWithParamaterizedEndpointsOperationsMixin:
 
         if response.status_code not in [200, 202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/operations/_lro_with_paramaterized_endpoints_operations.py
+++ b/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/operations/_lro_with_paramaterized_endpoints_operations.py
@@ -60,7 +60,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(object):
 
         if response.status_code not in [200, 202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/operations/_lro_with_paramaterized_endpoints_operations.py
+++ b/test/azure/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/operations/_lro_with_paramaterized_endpoints_operations.py
@@ -15,7 +15,7 @@ from azure.core.polling import LROPoller, NoPolling, PollingMethod
 from azure.core.polling.base_polling import LROBasePolling
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -60,7 +60,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(object):
 
         if response.status_code not in [200, 202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/azure/Expected/AcceptanceTests/Paging/paging/aio/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Paging/paging/aio/operations/_paging_operations.py
@@ -49,7 +49,7 @@ class PagingOperations:
     def get_no_item_name_pages(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResultValue"]:
+    ) -> AsyncIterable["_models.ProductResultValue"]:
         """A paging operation that must return result of the default 'value' node.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResultValue]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResultValue"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResultValue"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -110,7 +110,7 @@ class PagingOperations:
     def get_null_next_link_name_pages(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that must ignore any kind of nextLink, and stop after page 1.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -118,7 +118,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -171,7 +171,7 @@ class PagingOperations:
     def get_single_pages(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that finishes on the first call without a nextlink.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -179,7 +179,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -232,9 +232,9 @@ class PagingOperations:
     def get_multiple_pages(
         self,
         client_request_id: Optional[str] = None,
-        paging_get_multiple_pages_options: Optional["models.PagingGetMultiplePagesOptions"] = None,
+        paging_get_multiple_pages_options: Optional["_models.PagingGetMultiplePagesOptions"] = None,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -246,7 +246,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -312,7 +312,7 @@ class PagingOperations:
         self,
         required_query_parameter: int,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that includes a next operation. It has a different query parameter from it's
         next operation nextOperationWithQueryParams. Returns a ProductResult.
 
@@ -324,7 +324,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -383,9 +383,9 @@ class PagingOperations:
     def get_odata_multiple_pages(
         self,
         client_request_id: Optional[str] = None,
-        paging_get_odata_multiple_pages_options: Optional["models.PagingGetOdataMultiplePagesOptions"] = None,
+        paging_get_odata_multiple_pages_options: Optional["_models.PagingGetOdataMultiplePagesOptions"] = None,
         **kwargs
-    ) -> AsyncIterable["models.OdataProductResult"]:
+    ) -> AsyncIterable["_models.OdataProductResult"]:
         """A paging operation that includes a nextLink in odata format that has 10 pages.
 
         :param client_request_id:
@@ -397,7 +397,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.OdataProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.OdataProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.OdataProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -461,10 +461,10 @@ class PagingOperations:
     @distributed_trace
     def get_multiple_pages_with_offset(
         self,
-        paging_get_multiple_pages_with_offset_options: "models.PagingGetMultiplePagesWithOffsetOptions",
+        paging_get_multiple_pages_with_offset_options: "_models.PagingGetMultiplePagesWithOffsetOptions",
         client_request_id: Optional[str] = None,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that includes a nextLink that has 10 pages.
 
         :param paging_get_multiple_pages_with_offset_options: Parameter group.
@@ -476,7 +476,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -547,7 +547,7 @@ class PagingOperations:
     def get_multiple_pages_retry_first(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that fails on the first call with 500 and then retries and then get a
         response including a nextLink that has 10 pages.
 
@@ -556,7 +556,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -609,7 +609,7 @@ class PagingOperations:
     def get_multiple_pages_retry_second(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails
         first with 500. The client should retry and finish all 10 pages eventually.
 
@@ -618,7 +618,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -671,7 +671,7 @@ class PagingOperations:
     def get_single_pages_failure(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that receives a 400 on the first call.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -679,7 +679,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -732,7 +732,7 @@ class PagingOperations:
     def get_multiple_pages_failure(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that receives a 400 on the second call.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -740,7 +740,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -793,7 +793,7 @@ class PagingOperations:
     def get_multiple_pages_failure_uri(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResult"]:
+    ) -> AsyncIterable["_models.ProductResult"]:
         """A paging operation that receives an invalid nextLink.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -801,7 +801,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -856,7 +856,7 @@ class PagingOperations:
         api_version: str,
         tenant: str,
         **kwargs
-    ) -> AsyncIterable["models.OdataProductResult"]:
+    ) -> AsyncIterable["_models.OdataProductResult"]:
         """A paging operation that doesn't return a full URL, just a fragment.
 
         :param api_version: Sets the api version to use.
@@ -868,7 +868,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.OdataProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.OdataProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.OdataProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -933,9 +933,9 @@ class PagingOperations:
     @distributed_trace
     def get_multiple_pages_fragment_with_grouping_next_link(
         self,
-        custom_parameter_group: "models.CustomParameterGroup",
+        custom_parameter_group: "_models.CustomParameterGroup",
         **kwargs
-    ) -> AsyncIterable["models.OdataProductResult"]:
+    ) -> AsyncIterable["_models.OdataProductResult"]:
         """A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
 
         :param custom_parameter_group: Parameter group.
@@ -945,7 +945,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.OdataProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.OdataProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.OdataProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1016,10 +1016,10 @@ class PagingOperations:
     async def _get_multiple_pages_lro_initial(
         self,
         client_request_id: Optional[str] = None,
-        paging_get_multiple_pages_lro_options: Optional["models.PagingGetMultiplePagesLroOptions"] = None,
+        paging_get_multiple_pages_lro_options: Optional["_models.PagingGetMultiplePagesLroOptions"] = None,
         **kwargs
-    ) -> "models.ProductResult":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+    ) -> "_models.ProductResult":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1068,9 +1068,9 @@ class PagingOperations:
     async def begin_get_multiple_pages_lro(
         self,
         client_request_id: Optional[str] = None,
-        paging_get_multiple_pages_lro_options: Optional["models.PagingGetMultiplePagesLroOptions"] = None,
+        paging_get_multiple_pages_lro_options: Optional["_models.PagingGetMultiplePagesLroOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.ProductResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.ProductResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -1087,7 +1087,7 @@ class PagingOperations:
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1144,7 +1144,7 @@ class PagingOperations:
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1188,7 +1188,7 @@ class PagingOperations:
     def get_paging_model_with_item_name_with_xms_client_name(
         self,
         **kwargs
-    ) -> AsyncIterable["models.ProductResultValueWithXMSClientName"]:
+    ) -> AsyncIterable["_models.ProductResultValueWithXMSClientName"]:
         """A paging operation that returns a paging model whose item name is is overriden by x-ms-client-
         name 'indexes'.
 
@@ -1197,7 +1197,7 @@ class PagingOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~paging.models.ProductResultValueWithXMSClientName]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResultValueWithXMSClientName"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResultValueWithXMSClientName"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/Paging/paging/aio/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Paging/paging/aio/operations/_paging_operations.py
@@ -18,7 +18,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -37,7 +37,7 @@ class PagingOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/Paging/paging/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Paging/paging/operations/_paging_operations.py
@@ -53,7 +53,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResultValue"]
+        # type: (...) -> Iterable["_models.ProductResultValue"]
         """A paging operation that must return result of the default 'value' node.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -61,7 +61,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResultValue]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResultValue"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResultValue"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -115,7 +115,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that must ignore any kind of nextLink, and stop after page 1.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -123,7 +123,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -177,7 +177,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that finishes on the first call without a nextlink.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -185,7 +185,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -238,10 +238,10 @@ class PagingOperations(object):
     def get_multiple_pages(
         self,
         client_request_id=None,  # type: Optional[str]
-        paging_get_multiple_pages_options=None,  # type: Optional["models.PagingGetMultiplePagesOptions"]
+        paging_get_multiple_pages_options=None,  # type: Optional["_models.PagingGetMultiplePagesOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -253,7 +253,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -320,7 +320,7 @@ class PagingOperations(object):
         required_query_parameter,  # type: int
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that includes a next operation. It has a different query parameter from it's
         next operation nextOperationWithQueryParams. Returns a ProductResult.
 
@@ -332,7 +332,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -391,10 +391,10 @@ class PagingOperations(object):
     def get_odata_multiple_pages(
         self,
         client_request_id=None,  # type: Optional[str]
-        paging_get_odata_multiple_pages_options=None,  # type: Optional["models.PagingGetOdataMultiplePagesOptions"]
+        paging_get_odata_multiple_pages_options=None,  # type: Optional["_models.PagingGetOdataMultiplePagesOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.OdataProductResult"]
+        # type: (...) -> Iterable["_models.OdataProductResult"]
         """A paging operation that includes a nextLink in odata format that has 10 pages.
 
         :param client_request_id:
@@ -406,7 +406,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.OdataProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.OdataProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.OdataProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -470,11 +470,11 @@ class PagingOperations(object):
     @distributed_trace
     def get_multiple_pages_with_offset(
         self,
-        paging_get_multiple_pages_with_offset_options,  # type: "models.PagingGetMultiplePagesWithOffsetOptions"
+        paging_get_multiple_pages_with_offset_options,  # type: "_models.PagingGetMultiplePagesWithOffsetOptions"
         client_request_id=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that includes a nextLink that has 10 pages.
 
         :param paging_get_multiple_pages_with_offset_options: Parameter group.
@@ -486,7 +486,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -558,7 +558,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that fails on the first call with 500 and then retries and then get a
         response including a nextLink that has 10 pages.
 
@@ -567,7 +567,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -621,7 +621,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails
         first with 500. The client should retry and finish all 10 pages eventually.
 
@@ -630,7 +630,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -684,7 +684,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that receives a 400 on the first call.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -692,7 +692,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -746,7 +746,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that receives a 400 on the second call.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -754,7 +754,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -808,7 +808,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResult"]
+        # type: (...) -> Iterable["_models.ProductResult"]
         """A paging operation that receives an invalid nextLink.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -816,7 +816,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -872,7 +872,7 @@ class PagingOperations(object):
         tenant,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.OdataProductResult"]
+        # type: (...) -> Iterable["_models.OdataProductResult"]
         """A paging operation that doesn't return a full URL, just a fragment.
 
         :param api_version: Sets the api version to use.
@@ -884,7 +884,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.OdataProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.OdataProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.OdataProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -949,10 +949,10 @@ class PagingOperations(object):
     @distributed_trace
     def get_multiple_pages_fragment_with_grouping_next_link(
         self,
-        custom_parameter_group,  # type: "models.CustomParameterGroup"
+        custom_parameter_group,  # type: "_models.CustomParameterGroup"
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.OdataProductResult"]
+        # type: (...) -> Iterable["_models.OdataProductResult"]
         """A paging operation that doesn't return a full URL, just a fragment with parameters grouped.
 
         :param custom_parameter_group: Parameter group.
@@ -962,7 +962,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.OdataProductResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.OdataProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.OdataProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1033,11 +1033,11 @@ class PagingOperations(object):
     def _get_multiple_pages_lro_initial(
         self,
         client_request_id=None,  # type: Optional[str]
-        paging_get_multiple_pages_lro_options=None,  # type: Optional["models.PagingGetMultiplePagesLroOptions"]
+        paging_get_multiple_pages_lro_options=None,  # type: Optional["_models.PagingGetMultiplePagesLroOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ProductResult"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        # type: (...) -> "_models.ProductResult"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1086,10 +1086,10 @@ class PagingOperations(object):
     def begin_get_multiple_pages_lro(
         self,
         client_request_id=None,  # type: Optional[str]
-        paging_get_multiple_pages_lro_options=None,  # type: Optional["models.PagingGetMultiplePagesLroOptions"]
+        paging_get_multiple_pages_lro_options=None,  # type: Optional["_models.PagingGetMultiplePagesLroOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[ItemPaged["models.ProductResult"]]
+        # type: (...) -> LROPoller[ItemPaged["_models.ProductResult"]]
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -1106,7 +1106,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~paging.models.ProductResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1163,7 +1163,7 @@ class PagingOperations(object):
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -1208,7 +1208,7 @@ class PagingOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.ProductResultValueWithXMSClientName"]
+        # type: (...) -> Iterable["_models.ProductResultValueWithXMSClientName"]
         """A paging operation that returns a paging model whose item name is is overriden by x-ms-client-
         name 'indexes'.
 
@@ -1217,7 +1217,7 @@ class PagingOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~paging.models.ProductResultValueWithXMSClientName]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ProductResultValueWithXMSClientName"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ProductResultValueWithXMSClientName"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/Paging/paging/operations/_paging_operations.py
+++ b/test/azure/Expected/AcceptanceTests/Paging/paging/operations/_paging_operations.py
@@ -17,7 +17,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -40,7 +40,7 @@ class PagingOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
@@ -18,7 +18,7 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -37,7 +37,7 @@ class StorageAccountsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
@@ -48,9 +48,9 @@ class StorageAccountsOperations:
     @distributed_trace_async
     async def check_name_availability(
         self,
-        account_name: "models.StorageAccountCheckNameAvailabilityParameters",
+        account_name: "_models.StorageAccountCheckNameAvailabilityParameters",
         **kwargs
-    ) -> "models.CheckNameAvailabilityResult":
+    ) -> "_models.CheckNameAvailabilityResult":
         """Checks that account name is valid and is not in use.
 
         :param account_name: The name of the storage account within the specified resource group.
@@ -62,7 +62,7 @@ class StorageAccountsOperations:
         :rtype: ~storage.models.CheckNameAvailabilityResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.CheckNameAvailabilityResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.CheckNameAvailabilityResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -110,10 +110,10 @@ class StorageAccountsOperations:
         self,
         resource_group_name: str,
         account_name: str,
-        parameters: "models.StorageAccountCreateParameters",
+        parameters: "_models.StorageAccountCreateParameters",
         **kwargs
-    ) -> Optional["models.StorageAccount"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.StorageAccount"]]
+    ) -> Optional["_models.StorageAccount"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.StorageAccount"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -166,9 +166,9 @@ class StorageAccountsOperations:
         self,
         resource_group_name: str,
         account_name: str,
-        parameters: "models.StorageAccountCreateParameters",
+        parameters: "_models.StorageAccountCreateParameters",
         **kwargs
-    ) -> AsyncLROPoller["models.StorageAccount"]:
+    ) -> AsyncLROPoller["_models.StorageAccount"]:
         """Asynchronously creates a new storage account with the specified parameters. Existing accounts
         cannot be updated with this API and should instead use the Update Storage Account API. If an
         account is already created and subsequent PUT request is issued with exact same set of
@@ -193,7 +193,7 @@ class StorageAccountsOperations:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccount"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -300,7 +300,7 @@ class StorageAccountsOperations:
         resource_group_name: str,
         account_name: str,
         **kwargs
-    ) -> "models.StorageAccount":
+    ) -> "_models.StorageAccount":
         """Returns the properties for the specified storage account including but not limited to name,
         account type, location, and account status. The ListKeys operation should be used to retrieve
         storage keys.
@@ -316,7 +316,7 @@ class StorageAccountsOperations:
         :rtype: ~storage.models.StorageAccount
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccount"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -362,9 +362,9 @@ class StorageAccountsOperations:
         self,
         resource_group_name: str,
         account_name: str,
-        parameters: "models.StorageAccountUpdateParameters",
+        parameters: "_models.StorageAccountUpdateParameters",
         **kwargs
-    ) -> "models.StorageAccount":
+    ) -> "_models.StorageAccount":
         """Updates the account type or tags for a storage account. It can also be used to add a custom
         domain (note that custom domains cannot be added via the Create operation). Only one custom
         domain is supported per storage account. This API can only be used to update one of tags,
@@ -387,7 +387,7 @@ class StorageAccountsOperations:
         :rtype: ~storage.models.StorageAccount
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccount"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -439,7 +439,7 @@ class StorageAccountsOperations:
         resource_group_name: str,
         account_name: str,
         **kwargs
-    ) -> "models.StorageAccountKeys":
+    ) -> "_models.StorageAccountKeys":
         """Lists the access keys for the specified storage account.
 
         :param resource_group_name: The name of the resource group within the user’s subscription.
@@ -451,7 +451,7 @@ class StorageAccountsOperations:
         :rtype: ~storage.models.StorageAccountKeys
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountKeys"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountKeys"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -496,7 +496,7 @@ class StorageAccountsOperations:
     def list(
         self,
         **kwargs
-    ) -> AsyncIterable["models.StorageAccountListResult"]:
+    ) -> AsyncIterable["_models.StorageAccountListResult"]:
         """Lists all the storage accounts available under the subscription. Note that storage keys are not
         returned; use the ListKeys operation for this.
 
@@ -505,7 +505,7 @@ class StorageAccountsOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~storage.models.StorageAccountListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountListResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountListResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -565,7 +565,7 @@ class StorageAccountsOperations:
         self,
         resource_group_name: str,
         **kwargs
-    ) -> AsyncIterable["models.StorageAccountListResult"]:
+    ) -> AsyncIterable["_models.StorageAccountListResult"]:
         """Lists all the storage accounts available under the given resource group. Note that storage keys
         are not returned; use the ListKeys operation for this.
 
@@ -576,7 +576,7 @@ class StorageAccountsOperations:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~storage.models.StorageAccountListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountListResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountListResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -637,9 +637,9 @@ class StorageAccountsOperations:
         self,
         resource_group_name: str,
         account_name: str,
-        key_name: Optional[Union[str, "models.KeyName"]] = None,
+        key_name: Optional[Union[str, "_models.KeyName"]] = None,
         **kwargs
-    ) -> "models.StorageAccountKeys":
+    ) -> "_models.StorageAccountKeys":
         """Regenerates the access keys for the specified storage account.
 
         :param resource_group_name: The name of the resource group within the user’s subscription.
@@ -655,13 +655,13 @@ class StorageAccountsOperations:
         :rtype: ~storage.models.StorageAccountKeys
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountKeys"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountKeys"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _regenerate_key = models.StorageAccountRegenerateKeyParameters(key_name=key_name)
+        _regenerate_key = _models.StorageAccountRegenerateKeyParameters(key_name=key_name)
         api_version = "2015-05-01-preview"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json, text/json"

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_usage_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_usage_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class UsageOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_usage_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_usage_operations.py
@@ -45,7 +45,7 @@ class UsageOperations:
     async def list(
         self,
         **kwargs
-    ) -> "models.UsageListResult":
+    ) -> "_models.UsageListResult":
         """Gets the current usage count and the limit for the resources under the subscription.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -53,7 +53,7 @@ class UsageOperations:
         :rtype: ~storage.models.UsageListResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.UsageListResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.UsageListResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
@@ -51,10 +51,10 @@ class StorageAccountsOperations(object):
     @distributed_trace
     def check_name_availability(
         self,
-        account_name,  # type: "models.StorageAccountCheckNameAvailabilityParameters"
+        account_name,  # type: "_models.StorageAccountCheckNameAvailabilityParameters"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.CheckNameAvailabilityResult"
+        # type: (...) -> "_models.CheckNameAvailabilityResult"
         """Checks that account name is valid and is not in use.
 
         :param account_name: The name of the storage account within the specified resource group.
@@ -66,7 +66,7 @@ class StorageAccountsOperations(object):
         :rtype: ~storage.models.CheckNameAvailabilityResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.CheckNameAvailabilityResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.CheckNameAvailabilityResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -114,11 +114,11 @@ class StorageAccountsOperations(object):
         self,
         resource_group_name,  # type: str
         account_name,  # type: str
-        parameters,  # type: "models.StorageAccountCreateParameters"
+        parameters,  # type: "_models.StorageAccountCreateParameters"
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.StorageAccount"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.StorageAccount"]]
+        # type: (...) -> Optional["_models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.StorageAccount"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -171,10 +171,10 @@ class StorageAccountsOperations(object):
         self,
         resource_group_name,  # type: str
         account_name,  # type: str
-        parameters,  # type: "models.StorageAccountCreateParameters"
+        parameters,  # type: "_models.StorageAccountCreateParameters"
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.StorageAccount"]
+        # type: (...) -> LROPoller["_models.StorageAccount"]
         """Asynchronously creates a new storage account with the specified parameters. Existing accounts
         cannot be updated with this API and should instead use the Update Storage Account API. If an
         account is already created and subsequent PUT request is issued with exact same set of
@@ -199,7 +199,7 @@ class StorageAccountsOperations(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccount"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -308,7 +308,7 @@ class StorageAccountsOperations(object):
         account_name,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.StorageAccount"
+        # type: (...) -> "_models.StorageAccount"
         """Returns the properties for the specified storage account including but not limited to name,
         account type, location, and account status. The ListKeys operation should be used to retrieve
         storage keys.
@@ -324,7 +324,7 @@ class StorageAccountsOperations(object):
         :rtype: ~storage.models.StorageAccount
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccount"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -370,10 +370,10 @@ class StorageAccountsOperations(object):
         self,
         resource_group_name,  # type: str
         account_name,  # type: str
-        parameters,  # type: "models.StorageAccountUpdateParameters"
+        parameters,  # type: "_models.StorageAccountUpdateParameters"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.StorageAccount"
+        # type: (...) -> "_models.StorageAccount"
         """Updates the account type or tags for a storage account. It can also be used to add a custom
         domain (note that custom domains cannot be added via the Create operation). Only one custom
         domain is supported per storage account. This API can only be used to update one of tags,
@@ -396,7 +396,7 @@ class StorageAccountsOperations(object):
         :rtype: ~storage.models.StorageAccount
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccount"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccount"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -449,7 +449,7 @@ class StorageAccountsOperations(object):
         account_name,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.StorageAccountKeys"
+        # type: (...) -> "_models.StorageAccountKeys"
         """Lists the access keys for the specified storage account.
 
         :param resource_group_name: The name of the resource group within the user’s subscription.
@@ -461,7 +461,7 @@ class StorageAccountsOperations(object):
         :rtype: ~storage.models.StorageAccountKeys
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountKeys"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountKeys"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -507,7 +507,7 @@ class StorageAccountsOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.StorageAccountListResult"]
+        # type: (...) -> Iterable["_models.StorageAccountListResult"]
         """Lists all the storage accounts available under the subscription. Note that storage keys are not
         returned; use the ListKeys operation for this.
 
@@ -516,7 +516,7 @@ class StorageAccountsOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~storage.models.StorageAccountListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountListResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountListResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -577,7 +577,7 @@ class StorageAccountsOperations(object):
         resource_group_name,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.StorageAccountListResult"]
+        # type: (...) -> Iterable["_models.StorageAccountListResult"]
         """Lists all the storage accounts available under the given resource group. Note that storage keys
         are not returned; use the ListKeys operation for this.
 
@@ -588,7 +588,7 @@ class StorageAccountsOperations(object):
         :rtype: ~azure.core.paging.ItemPaged[~storage.models.StorageAccountListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountListResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountListResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -649,10 +649,10 @@ class StorageAccountsOperations(object):
         self,
         resource_group_name,  # type: str
         account_name,  # type: str
-        key_name=None,  # type: Optional[Union[str, "models.KeyName"]]
+        key_name=None,  # type: Optional[Union[str, "_models.KeyName"]]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.StorageAccountKeys"
+        # type: (...) -> "_models.StorageAccountKeys"
         """Regenerates the access keys for the specified storage account.
 
         :param resource_group_name: The name of the resource group within the user’s subscription.
@@ -668,13 +668,13 @@ class StorageAccountsOperations(object):
         :rtype: ~storage.models.StorageAccountKeys
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageAccountKeys"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageAccountKeys"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _regenerate_key = models.StorageAccountRegenerateKeyParameters(key_name=key_name)
+        _regenerate_key = _models.StorageAccountRegenerateKeyParameters(key_name=key_name)
         api_version = "2015-05-01-preview"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json, text/json"

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
@@ -17,7 +17,7 @@ from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -40,7 +40,7 @@ class StorageAccountsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_usage_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_usage_operations.py
@@ -50,7 +50,7 @@ class UsageOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.UsageListResult"
+        # type: (...) -> "_models.UsageListResult"
         """Gets the current usage count and the limit for the resources under the subscription.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -58,7 +58,7 @@ class UsageOperations(object):
         :rtype: ~storage.models.UsageListResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.UsageListResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.UsageListResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_usage_operations.py
+++ b/test/azure/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_usage_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class UsageOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/aio/operations/_group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/aio/operations/_group_operations.py
@@ -86,7 +86,7 @@ class GroupOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('SampleResourceGroup', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/aio/operations/_group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/aio/operations/_group_operations.py
@@ -46,7 +46,7 @@ class GroupOperations:
         self,
         resource_group_name: str,
         **kwargs
-    ) -> "models.SampleResourceGroup":
+    ) -> "_models.SampleResourceGroup":
         """Provides a resouce group with name 'testgroup101' and location 'West US'.
 
         :param resource_group_name: Resource Group name 'testgroup101'.
@@ -56,7 +56,7 @@ class GroupOperations:
         :rtype: ~subscriptionidapiversion.models.SampleResourceGroup
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SampleResourceGroup"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SampleResourceGroup"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/aio/operations/_group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/aio/operations/_group_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class GroupOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -86,7 +86,7 @@ class GroupOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('SampleResourceGroup', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/_group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/_group_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class GroupOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -91,7 +91,7 @@ class GroupOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('SampleResourceGroup', pipeline_response)

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/_group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/_group_operations.py
@@ -51,7 +51,7 @@ class GroupOperations(object):
         resource_group_name,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.SampleResourceGroup"
+        # type: (...) -> "_models.SampleResourceGroup"
         """Provides a resouce group with name 'testgroup101' and location 'West US'.
 
         :param resource_group_name: Resource Group name 'testgroup101'.
@@ -61,7 +61,7 @@ class GroupOperations(object):
         :rtype: ~subscriptionidapiversion.models.SampleResourceGroup
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SampleResourceGroup"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SampleResourceGroup"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/_group_operations.py
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/operations/_group_operations.py
@@ -91,7 +91,7 @@ class GroupOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('SampleResourceGroup', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_operations_mixin.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
@@ -62,7 +62,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
         """A long-running paging operation that includes a nextLink that has 10 pages.

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/aio/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/aio/_operations_mixin.py
@@ -25,9 +25,9 @@ class MultiapiServiceClientOperationsMixin(object):
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -58,9 +58,9 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -125,7 +125,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncItemPaged["models.PagingResult"]:
+    ) -> AsyncItemPaged["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/_metadata.json
@@ -57,48 +57,48 @@
         },
         "_test_lro_initial" : {
             "sync": {
-                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapi.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapi.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"models.Product\"]:\n",
+                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"_models.Product\"]:\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapi.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapi.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "product"
         },
         "begin_test_lro" : {
             "sync": {
-                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapi.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~multiapi.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"models.Product\"]:\n",
+                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"_models.Product\"]:\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapi.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~multiapi.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "product"
         },
         "_test_lro_and_paging_initial" : {
             "sync": {
-                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapi.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapi.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"models.PagingResult\":\n",
+                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"_models.PagingResult\":\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapi.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapi.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"
         },
         "begin_test_lro_and_paging" : {
             "sync": {
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapi.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapi.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": false,
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"models.PagingResult\"]]:\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"_models.PagingResult\"]]:\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapi.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapi.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import AsyncLROPoller, AsyncNoPolling, AsyncPollingMetho
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -68,7 +68,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -112,7 +112,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
@@ -68,7 +68,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -112,7 +112,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
@@ -78,10 +78,10 @@ class MultiapiServiceClientOperationsMixin:
 
     async def _test_lro_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -127,9 +127,9 @@ class MultiapiServiceClientOperationsMixin:
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -145,7 +145,7 @@ class MultiapiServiceClientOperationsMixin:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -185,10 +185,10 @@ class MultiapiServiceClientOperationsMixin:
     async def _test_lro_and_paging_initial(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> "models.PagingResult":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+    ) -> "_models.PagingResult":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -236,9 +236,9 @@ class MultiapiServiceClientOperationsMixin:
     async def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -255,7 +255,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapi.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -312,7 +312,7 @@ class MultiapiServiceClientOperationsMixin:
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_operation_group_one_operations.py
@@ -76,7 +76,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import LROPoller, NoPolling, PollingMethod
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
@@ -83,11 +83,11 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def _test_lro_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -133,10 +133,10 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -152,7 +152,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -192,11 +192,11 @@ class MultiapiServiceClientOperationsMixin(object):
     def _test_lro_and_paging_initial(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PagingResult"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        # type: (...) -> "_models.PagingResult"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -244,10 +244,10 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[ItemPaged["models.PagingResult"]]
+        # type: (...) -> LROPoller[ItemPaged["_models.PagingResult"]]
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -264,7 +264,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapi.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -321,7 +321,7 @@ class MultiapiServiceClientOperationsMixin(object):
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_operation_group_one_operations.py
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"models.ModelTwo\":\n",
+                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"_models.ModelTwo\":\n",
                 "doc": "\"\"\"TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.\n\n:param id: An int parameter.\n:type id: int\n:param message: An optional string parameter.\n:type message: str\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: ModelTwo, or the result of cls(response)\n:rtype: ~multiapi.v2.models.ModelTwo\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "id, message"

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_multiapi_service_client_operations.py
@@ -25,7 +25,7 @@ class MultiapiServiceClientOperationsMixin:
         id: int,
         message: Optional[str] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~multiapi.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_multiapi_service_client_operations.py
@@ -65,7 +65,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -65,7 +65,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_one_operations.py
@@ -42,9 +42,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelTwo"] = None,
+        parameter_one: Optional["_models.ModelTwo"] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -54,7 +54,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapi.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_one_operations.py
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -134,7 +134,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -134,7 +134,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -80,7 +80,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/aio/operations/_operation_group_two_operations.py
@@ -80,7 +80,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_multiapi_service_client_operations.py
@@ -30,7 +30,7 @@ class MultiapiServiceClientOperationsMixin(object):
         message=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -42,7 +42,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~multiapi.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_multiapi_service_client_operations.py
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelTwo"]
+        parameter_one=None,  # type: Optional["_models.ModelTwo"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapi.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_two_operations.py
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": false,
-                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"models.PagingResult\"]:\n",
+                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"_models.PagingResult\"]:\n",
                 "doc": "\"\"\"Returns ModelThree with optionalProperty \u0027paged\u0027.\n\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: An iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapi.v3.models.PagingResult]\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": ""

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_multiapi_service_client_operations.py
@@ -24,7 +24,7 @@ class MultiapiServiceClientOperationsMixin:
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncIterable["models.PagingResult"]:
+    ) -> AsyncIterable["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -32,7 +32,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapi.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_one_operations.py
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_one_operations.py
@@ -42,9 +42,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelThree"] = None,
+        parameter_one: Optional["_models.ModelThree"] = None,
         **kwargs
-    ) -> "models.ModelThree":
+    ) -> "_models.ModelThree":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -54,7 +54,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapi.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
@@ -97,7 +97,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
@@ -42,7 +42,7 @@ class OperationGroupTwoOperations:
 
     async def test_four(
         self,
-        input: Optional[Union[IO, "models.SourcePath"]] = None,
+        input: Optional[Union[IO, "_models.SourcePath"]] = None,
         **kwargs
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -97,7 +97,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_multiapi_service_client_operations.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.PagingResult"]
+        # type: (...) -> Iterable["_models.PagingResult"]
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~multiapi.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelThree"]
+        parameter_one=None,  # type: Optional["_models.ModelThree"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelThree"
+        # type: (...) -> "_models.ModelThree"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapi.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -46,7 +46,7 @@ class OperationGroupTwoOperations(object):
 
     def test_four(
         self,
-        input=None,  # type: Optional[Union[IO, "models.SourcePath"]]
+        input=None,  # type: Optional[Union[IO, "_models.SourcePath"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/_operations_mixin.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
@@ -62,7 +62,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
         """A long-running paging operation that includes a nextLink that has 10 pages.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/aio/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/aio/_operations_mixin.py
@@ -25,9 +25,9 @@ class MultiapiServiceClientOperationsMixin(object):
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -58,9 +58,9 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -125,7 +125,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncItemPaged["models.PagingResult"]:
+    ) -> AsyncItemPaged["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/_metadata.json
@@ -57,48 +57,48 @@
         },
         "_test_lro_initial" : {
             "sync": {
-                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapicredentialdefaultpolicy.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapicredentialdefaultpolicy.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"models.Product\"]:\n",
+                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"_models.Product\"]:\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapicredentialdefaultpolicy.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapicredentialdefaultpolicy.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "product"
         },
         "begin_test_lro" : {
             "sync": {
-                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapicredentialdefaultpolicy.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~multiapicredentialdefaultpolicy.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"models.Product\"]:\n",
+                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"_models.Product\"]:\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapicredentialdefaultpolicy.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~multiapicredentialdefaultpolicy.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "product"
         },
         "_test_lro_and_paging_initial" : {
             "sync": {
-                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapicredentialdefaultpolicy.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapicredentialdefaultpolicy.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"models.PagingResult\":\n",
+                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"_models.PagingResult\":\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapicredentialdefaultpolicy.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapicredentialdefaultpolicy.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"
         },
         "begin_test_lro_and_paging" : {
             "sync": {
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapicredentialdefaultpolicy.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapicredentialdefaultpolicy.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": false,
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"models.PagingResult\"]]:\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"_models.PagingResult\"]]:\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapicredentialdefaultpolicy.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapicredentialdefaultpolicy.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import AsyncLROPoller, AsyncNoPolling, AsyncPollingMetho
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -68,7 +68,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -112,7 +112,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
@@ -68,7 +68,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -112,7 +112,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
@@ -78,10 +78,10 @@ class MultiapiServiceClientOperationsMixin:
 
     async def _test_lro_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -127,9 +127,9 @@ class MultiapiServiceClientOperationsMixin:
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -145,7 +145,7 @@ class MultiapiServiceClientOperationsMixin:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -185,10 +185,10 @@ class MultiapiServiceClientOperationsMixin:
     async def _test_lro_and_paging_initial(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> "models.PagingResult":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+    ) -> "_models.PagingResult":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -236,9 +236,9 @@ class MultiapiServiceClientOperationsMixin:
     async def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -255,7 +255,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapicredentialdefaultpolicy.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -312,7 +312,7 @@ class MultiapiServiceClientOperationsMixin:
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_operation_group_one_operations.py
@@ -76,7 +76,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
@@ -83,11 +83,11 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def _test_lro_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -133,10 +133,10 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -152,7 +152,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -192,11 +192,11 @@ class MultiapiServiceClientOperationsMixin(object):
     def _test_lro_and_paging_initial(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PagingResult"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        # type: (...) -> "_models.PagingResult"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -244,10 +244,10 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[ItemPaged["models.PagingResult"]]
+        # type: (...) -> LROPoller[ItemPaged["_models.PagingResult"]]
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -264,7 +264,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapicredentialdefaultpolicy.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -321,7 +321,7 @@ class MultiapiServiceClientOperationsMixin(object):
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import LROPoller, NoPolling, PollingMethod
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_operation_group_one_operations.py
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"models.ModelTwo\":\n",
+                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"_models.ModelTwo\":\n",
                 "doc": "\"\"\"TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.\n\n:param id: An int parameter.\n:type id: int\n:param message: An optional string parameter.\n:type message: str\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: ModelTwo, or the result of cls(response)\n:rtype: ~multiapicredentialdefaultpolicy.v2.models.ModelTwo\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "id, message"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_multiapi_service_client_operations.py
@@ -65,7 +65,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -65,7 +65,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_multiapi_service_client_operations.py
@@ -25,7 +25,7 @@ class MultiapiServiceClientOperationsMixin:
         id: int,
         message: Optional[str] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~multiapicredentialdefaultpolicy.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_one_operations.py
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -134,7 +134,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -134,7 +134,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_one_operations.py
@@ -42,9 +42,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelTwo"] = None,
+        parameter_one: Optional["_models.ModelTwo"] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -54,7 +54,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapicredentialdefaultpolicy.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -80,7 +80,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/aio/operations/_operation_group_two_operations.py
@@ -80,7 +80,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_multiapi_service_client_operations.py
@@ -30,7 +30,7 @@ class MultiapiServiceClientOperationsMixin(object):
         message=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -42,7 +42,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~multiapicredentialdefaultpolicy.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_multiapi_service_client_operations.py
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelTwo"]
+        parameter_one=None,  # type: Optional["_models.ModelTwo"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapicredentialdefaultpolicy.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_two_operations.py
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": false,
-                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"models.PagingResult\"]:\n",
+                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"_models.PagingResult\"]:\n",
                 "doc": "\"\"\"Returns ModelThree with optionalProperty \u0027paged\u0027.\n\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: An iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapicredentialdefaultpolicy.v3.models.PagingResult]\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": ""

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_multiapi_service_client_operations.py
@@ -24,7 +24,7 @@ class MultiapiServiceClientOperationsMixin:
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncIterable["models.PagingResult"]:
+    ) -> AsyncIterable["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -32,7 +32,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapicredentialdefaultpolicy.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_one_operations.py
@@ -42,9 +42,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelThree"] = None,
+        parameter_one: Optional["_models.ModelThree"] = None,
         **kwargs
-    ) -> "models.ModelThree":
+    ) -> "_models.ModelThree":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -54,7 +54,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapicredentialdefaultpolicy.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_one_operations.py
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
@@ -97,7 +97,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
@@ -42,7 +42,7 @@ class OperationGroupTwoOperations:
 
     async def test_four(
         self,
-        input: Optional[Union[IO, "models.SourcePath"]] = None,
+        input: Optional[Union[IO, "_models.SourcePath"]] = None,
         **kwargs
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -97,7 +97,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_multiapi_service_client_operations.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.PagingResult"]
+        # type: (...) -> Iterable["_models.PagingResult"]
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~multiapicredentialdefaultpolicy.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelThree"]
+        parameter_one=None,  # type: Optional["_models.ModelThree"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelThree"
+        # type: (...) -> "_models.ModelThree"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapicredentialdefaultpolicy.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
@@ -46,7 +46,7 @@ class OperationGroupTwoOperations(object):
 
     def test_four(
         self,
-        input=None,  # type: Optional[Union[IO, "models.SourcePath"]]
+        input=None,  # type: Optional[Union[IO, "_models.SourcePath"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/aio/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/aio/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -64,7 +64,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/aio/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/aio/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -64,7 +64,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -69,7 +69,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -69,7 +69,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/aio/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/aio/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -64,7 +64,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/aio/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/aio/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -64,7 +64,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -69,7 +69,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/operations/_multiapi_custom_base_url_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/operations/_multiapi_custom_base_url_service_client_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -69,7 +69,7 @@ class MultiapiCustomBaseUrlServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/_operations_mixin.py
@@ -28,7 +28,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
@@ -61,7 +61,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
         """A long-running paging operation that includes a nextLink that has 10 pages.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/aio/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/aio/_operations_mixin.py
@@ -24,9 +24,9 @@ class MultiapiServiceClientOperationsMixin(object):
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -57,9 +57,9 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -124,7 +124,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncItemPaged["models.PagingResult"]:
+    ) -> AsyncItemPaged["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/_metadata.json
@@ -57,48 +57,48 @@
         },
         "_test_lro_initial" : {
             "sync": {
-                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapidataplane.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapidataplane.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"models.Product\"]:\n",
+                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"_models.Product\"]:\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapidataplane.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapidataplane.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "product"
         },
         "begin_test_lro" : {
             "sync": {
-                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapidataplane.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~multiapidataplane.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"models.Product\"]:\n",
+                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"_models.Product\"]:\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapidataplane.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~multiapidataplane.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "product"
         },
         "_test_lro_and_paging_initial" : {
             "sync": {
-                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapidataplane.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapidataplane.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"models.PagingResult\":\n",
+                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"_models.PagingResult\":\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapidataplane.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapidataplane.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"
         },
         "begin_test_lro_and_paging" : {
             "sync": {
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapidataplane.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapidataplane.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": false,
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"models.PagingResult\"]]:\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"_models.PagingResult\"]]:\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapidataplane.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapidataplane.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
@@ -15,7 +15,7 @@ from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.polling import AsyncLROPoller, AsyncNoPolling, AsyncPollingMethod
 from azure.core.polling.async_base_polling import AsyncLROBasePolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -67,7 +67,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -111,7 +111,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
@@ -67,7 +67,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -111,7 +111,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
@@ -77,10 +77,10 @@ class MultiapiServiceClientOperationsMixin:
 
     async def _test_lro_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -126,9 +126,9 @@ class MultiapiServiceClientOperationsMixin:
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -144,7 +144,7 @@ class MultiapiServiceClientOperationsMixin:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', False)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -184,10 +184,10 @@ class MultiapiServiceClientOperationsMixin:
     async def _test_lro_and_paging_initial(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> "models.PagingResult":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+    ) -> "_models.PagingResult":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -235,9 +235,9 @@ class MultiapiServiceClientOperationsMixin:
     async def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -254,7 +254,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapidataplane.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -311,7 +311,7 @@ class MultiapiServiceClientOperationsMixin:
             return pipeline_response
 
         polling = kwargs.pop('polling', False)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_operation_group_one_operations.py
@@ -75,7 +75,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_operation_group_one_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -31,7 +31,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
@@ -82,11 +82,11 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def _test_lro_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -132,10 +132,10 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -151,7 +151,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', False)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -191,11 +191,11 @@ class MultiapiServiceClientOperationsMixin(object):
     def _test_lro_and_paging_initial(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PagingResult"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        # type: (...) -> "_models.PagingResult"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -243,10 +243,10 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[ItemPaged["models.PagingResult"]]
+        # type: (...) -> LROPoller[ItemPaged["_models.PagingResult"]]
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -263,7 +263,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapidataplane.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -320,7 +320,7 @@ class MultiapiServiceClientOperationsMixin(object):
             return pipeline_response
 
         polling = kwargs.pop('polling', False)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
@@ -15,7 +15,7 @@ from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.polling import LROPoller, NoPolling, PollingMethod
 from azure.core.polling.base_polling import LROBasePolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -72,7 +72,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -117,7 +117,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
@@ -72,7 +72,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -117,7 +117,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_operation_group_one_operations.py
@@ -80,7 +80,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_operation_group_one_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -35,7 +35,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"models.ModelTwo\":\n",
+                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"_models.ModelTwo\":\n",
                 "doc": "\"\"\"TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.\n\n:param id: An int parameter.\n:type id: int\n:param message: An optional string parameter.\n:type message: str\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: ModelTwo, or the result of cls(response)\n:rtype: ~multiapidataplane.v2.models.ModelTwo\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "id, message"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_multiapi_service_client_operations.py
@@ -64,7 +64,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_multiapi_service_client_operations.py
@@ -24,7 +24,7 @@ class MultiapiServiceClientOperationsMixin:
         id: int,
         message: Optional[str] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -36,7 +36,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~multiapidataplane.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_multiapi_service_client_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -64,7 +64,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_one_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -31,7 +31,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -86,7 +86,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -133,7 +133,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_one_operations.py
@@ -41,9 +41,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelTwo"] = None,
+        parameter_one: Optional["_models.ModelTwo"] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -53,7 +53,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapidataplane.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_one_operations.py
@@ -86,7 +86,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -133,7 +133,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_two_operations.py
@@ -79,7 +79,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/aio/operations/_operation_group_two_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -31,7 +31,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -79,7 +79,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_multiapi_service_client_operations.py
@@ -69,7 +69,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_multiapi_service_client_operations.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
         message=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -41,7 +41,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~multiapidataplane.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_multiapi_service_client_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -69,7 +69,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_one_operations.py
@@ -45,10 +45,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelTwo"]
+        parameter_one=None,  # type: Optional["_models.ModelTwo"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -58,7 +58,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapidataplane.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_one_operations.py
@@ -91,7 +91,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -139,7 +139,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_one_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -35,7 +35,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -91,7 +91,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -139,7 +139,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_two_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -35,7 +35,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -84,7 +84,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/operations/_operation_group_two_operations.py
@@ -84,7 +84,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": false,
-                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"models.PagingResult\"]:\n",
+                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"_models.PagingResult\"]:\n",
                 "doc": "\"\"\"Returns ModelThree with optionalProperty \u0027paged\u0027.\n\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: An iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapidataplane.v3.models.PagingResult]\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": ""

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_multiapi_service_client_operations.py
@@ -23,7 +23,7 @@ class MultiapiServiceClientOperationsMixin:
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncIterable["models.PagingResult"]:
+    ) -> AsyncIterable["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -31,7 +31,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapidataplane.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_one_operations.py
@@ -86,7 +86,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_one_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -31,7 +31,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -86,7 +86,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_one_operations.py
@@ -41,9 +41,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelThree"] = None,
+        parameter_one: Optional["_models.ModelThree"] = None,
         **kwargs
-    ) -> "models.ModelThree":
+    ) -> "_models.ModelThree":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -53,7 +53,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapidataplane.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
@@ -41,7 +41,7 @@ class OperationGroupTwoOperations:
 
     async def test_four(
         self,
-        input: Optional[Union[IO, "models.SourcePath"]] = None,
+        input: Optional[Union[IO, "_models.SourcePath"]] = None,
         **kwargs
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
@@ -96,7 +96,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -140,7 +140,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -31,7 +31,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -96,7 +96,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -140,7 +140,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_multiapi_service_client_operations.py
@@ -28,7 +28,7 @@ class MultiapiServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.PagingResult"]
+        # type: (...) -> Iterable["_models.PagingResult"]
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -36,7 +36,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~multiapidataplane.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.paging import ItemPaged
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_one_operations.py
@@ -45,10 +45,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelThree"]
+        parameter_one=None,  # type: Optional["_models.ModelThree"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelThree"
+        # type: (...) -> "_models.ModelThree"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -58,7 +58,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapidataplane.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_one_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -35,7 +35,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -91,7 +91,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_one_operations.py
@@ -91,7 +91,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
@@ -45,7 +45,7 @@ class OperationGroupTwoOperations(object):
 
     def test_four(
         self,
-        input=None,  # type: Optional[Union[IO, "models.SourcePath"]]
+        input=None,  # type: Optional[Union[IO, "_models.SourcePath"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, 
 from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -35,7 +35,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -101,7 +101,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -146,7 +146,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
@@ -101,7 +101,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -146,7 +146,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/_operations_mixin.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
@@ -62,7 +62,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
         """A long-running paging operation that includes a nextLink that has 10 pages.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/_metadata.json
@@ -57,48 +57,48 @@
         },
         "_test_lro_initial" : {
             "sync": {
-                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapinoasync.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapinoasync.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"models.Product\"]:\n",
+                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"_models.Product\"]:\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapinoasync.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapinoasync.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "product"
         },
         "begin_test_lro" : {
             "sync": {
-                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapinoasync.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~multiapinoasync.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"models.Product\"]:\n",
+                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"_models.Product\"]:\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapinoasync.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~multiapinoasync.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "product"
         },
         "_test_lro_and_paging_initial" : {
             "sync": {
-                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapinoasync.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapinoasync.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"models.PagingResult\":\n",
+                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"_models.PagingResult\":\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapinoasync.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapinoasync.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"
         },
         "begin_test_lro_and_paging" : {
             "sync": {
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapinoasync.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapinoasync.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": false,
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"models.PagingResult\"]]:\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"_models.PagingResult\"]]:\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapinoasync.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapinoasync.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
@@ -83,11 +83,11 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def _test_lro_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -133,10 +133,10 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -152,7 +152,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -192,11 +192,11 @@ class MultiapiServiceClientOperationsMixin(object):
     def _test_lro_and_paging_initial(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PagingResult"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        # type: (...) -> "_models.PagingResult"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -244,10 +244,10 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[ItemPaged["models.PagingResult"]]
+        # type: (...) -> LROPoller[ItemPaged["_models.PagingResult"]]
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -264,7 +264,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapinoasync.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -321,7 +321,7 @@ class MultiapiServiceClientOperationsMixin(object):
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import LROPoller, NoPolling, PollingMethod
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_operation_group_one_operations.py
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"models.ModelTwo\":\n",
+                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"_models.ModelTwo\":\n",
                 "doc": "\"\"\"TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.\n\n:param id: An int parameter.\n:type id: int\n:param message: An optional string parameter.\n:type message: str\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: ModelTwo, or the result of cls(response)\n:rtype: ~multiapinoasync.v2.models.ModelTwo\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "id, message"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_multiapi_service_client_operations.py
@@ -30,7 +30,7 @@ class MultiapiServiceClientOperationsMixin(object):
         message=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -42,7 +42,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~multiapinoasync.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_multiapi_service_client_operations.py
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelTwo"]
+        parameter_one=None,  # type: Optional["_models.ModelTwo"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapinoasync.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_two_operations.py
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": false,
-                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"models.PagingResult\"]:\n",
+                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"_models.PagingResult\"]:\n",
                 "doc": "\"\"\"Returns ModelThree with optionalProperty \u0027paged\u0027.\n\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: An iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapinoasync.v3.models.PagingResult]\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": ""

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_multiapi_service_client_operations.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.PagingResult"]
+        # type: (...) -> Iterable["_models.PagingResult"]
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~multiapinoasync.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelThree"]
+        parameter_one=None,  # type: Optional["_models.ModelThree"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelThree"
+        # type: (...) -> "_models.ModelThree"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapinoasync.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -46,7 +46,7 @@ class OperationGroupTwoOperations(object):
 
     def test_four(
         self,
-        input=None,  # type: Optional[Union[IO, "models.SourcePath"]]
+        input=None,  # type: Optional[Union[IO, "_models.SourcePath"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_operations_mixin.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
@@ -62,7 +62,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
         """A long-running paging operation that includes a nextLink that has 10 pages.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/aio/_operations_mixin.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/aio/_operations_mixin.py
@@ -25,9 +25,9 @@ class MultiapiServiceClientOperationsMixin(object):
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -58,9 +58,9 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -125,7 +125,7 @@ class MultiapiServiceClientOperationsMixin(object):
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncItemPaged["models.PagingResult"]:
+    ) -> AsyncItemPaged["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/_metadata.json
@@ -57,48 +57,48 @@
         },
         "_test_lro_initial" : {
             "sync": {
-                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_initial(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapiwithsubmodule.submodule.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapiwithsubmodule.submodule.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"models.Product\"]:\n",
+                "signature": "async def _test_lro_initial(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e Optional[\"_models.Product\"]:\n",
                 "doc": "\"\"\"\n\n:param product: Product to put.\n:type product: ~multiapiwithsubmodule.submodule.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: Product, or the result of cls(response)\n:rtype: ~multiapiwithsubmodule.submodule.v1.models.Product or None\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "product"
         },
         "begin_test_lro" : {
             "sync": {
-                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"models.Product\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro(\n    self,\n    product=None,  # type: Optional[\"_models.Product\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapiwithsubmodule.submodule.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~multiapiwithsubmodule.submodule.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"models.Product\"]:\n",
+                "signature": "async def begin_test_lro(\n    self,\n    product: Optional[\"_models.Product\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[\"_models.Product\"]:\n",
                 "doc": "\"\"\"Put in whatever shape of Product you want, will return a Product with id equal to 100.\n\n:param product: Product to put.\n:type product: ~multiapiwithsubmodule.submodule.v1.models.Product\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns either Product or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~multiapiwithsubmodule.submodule.v1.models.Product]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "product"
         },
         "_test_lro_and_paging_initial" : {
             "sync": {
-                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def _test_lro_and_paging_initial(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapiwithsubmodule.submodule.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapiwithsubmodule.submodule.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"models.PagingResult\":\n",
+                "signature": "async def _test_lro_and_paging_initial(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e \"_models.PagingResult\":\n",
                 "doc": "\"\"\"\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapiwithsubmodule.submodule.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: PagingResult, or the result of cls(response)\n:rtype: ~multiapiwithsubmodule.submodule.v1.models.PagingResult\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"
         },
         "begin_test_lro_and_paging" : {
             "sync": {
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id=None,  # type: Optional[str]\n    test_lro_and_paging_options=None,  # type: Optional[\"_models.TestLroAndPagingOptions\"]\n    **kwargs  # type: Any\n):\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapiwithsubmodule.submodule.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.PollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of LROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapiwithsubmodule.submodule.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "async": {
                 "coroutine": false,
-                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"models.PagingResult\"]]:\n",
+                "signature": "def begin_test_lro_and_paging(\n    self,\n    client_request_id: Optional[str] = None,\n    test_lro_and_paging_options: Optional[\"_models.TestLroAndPagingOptions\"] = None,\n    **kwargs\n) -\u003e AsyncLROPoller[AsyncItemPaged[\"_models.PagingResult\"]]:\n",
                 "doc": "\"\"\"A long-running paging operation that includes a nextLink that has 10 pages.\n\n:param client_request_id:\n:type client_request_id: str\n:param test_lro_and_paging_options: Parameter group.\n:type test_lro_and_paging_options: ~multiapiwithsubmodule.submodule.v1.models.TestLroAndPagingOptions\n:keyword callable cls: A custom type or function that will be passed the direct response\n:keyword str continuation_token: A continuation token to restart a poller from a saved state.\n:keyword polling: True for ARMPolling, False for no polling, or a\n polling object for personal polling strategy\n:paramtype polling: bool or ~azure.core.polling.AsyncPollingMethod\n:keyword int polling_interval: Default waiting time between two polls for LRO operations if no Retry-After header is present.\n:return: An instance of AsyncLROPoller that returns an iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapiwithsubmodule.submodule.v1.models.PagingResult]]\n:raises ~azure.core.exceptions.HttpResponseError:\n\"\"\""
             },
             "call": "client_request_id, test_lro_and_paging_options"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
@@ -78,10 +78,10 @@ class MultiapiServiceClientOperationsMixin:
 
     async def _test_lro_initial(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> Optional["models.Product"]:
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+    ) -> Optional["_models.Product"]:
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -127,9 +127,9 @@ class MultiapiServiceClientOperationsMixin:
 
     async def begin_test_lro(
         self,
-        product: Optional["models.Product"] = None,
+        product: Optional["_models.Product"] = None,
         **kwargs
-    ) -> AsyncLROPoller["models.Product"]:
+    ) -> AsyncLROPoller["_models.Product"]:
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -145,7 +145,7 @@ class MultiapiServiceClientOperationsMixin:
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -185,10 +185,10 @@ class MultiapiServiceClientOperationsMixin:
     async def _test_lro_and_paging_initial(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> "models.PagingResult":
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+    ) -> "_models.PagingResult":
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -236,9 +236,9 @@ class MultiapiServiceClientOperationsMixin:
     async def begin_test_lro_and_paging(
         self,
         client_request_id: Optional[str] = None,
-        test_lro_and_paging_options: Optional["models.TestLroAndPagingOptions"] = None,
+        test_lro_and_paging_options: Optional["_models.TestLroAndPagingOptions"] = None,
         **kwargs
-    ) -> AsyncLROPoller[AsyncItemPaged["models.PagingResult"]]:
+    ) -> AsyncLROPoller[AsyncItemPaged["_models.PagingResult"]]:
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -255,7 +255,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.core.async_paging.AsyncItemPaged[~multiapiwithsubmodule.submodule.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -312,7 +312,7 @@ class MultiapiServiceClientOperationsMixin:
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, AsyncPollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import AsyncLROPoller, AsyncNoPolling, AsyncPollingMetho
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -68,7 +68,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -112,7 +112,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
@@ -68,7 +68,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -112,7 +112,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_operation_group_one_operations.py
@@ -76,7 +76,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
@@ -16,7 +16,7 @@ from azure.core.polling import LROPoller, NoPolling, PollingMethod
 from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.arm_polling import ARMPolling
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -73,7 +73,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -118,7 +118,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = None

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
@@ -83,11 +83,11 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def _test_lro_initial(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Product"]
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Product"]]
+        # type: (...) -> Optional["_models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -133,10 +133,10 @@ class MultiapiServiceClientOperationsMixin(object):
 
     def begin_test_lro(
         self,
-        product=None,  # type: Optional["models.Product"]
+        product=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller["models.Product"]
+        # type: (...) -> LROPoller["_models.Product"]
         """Put in whatever shape of Product you want, will return a Product with id equal to 100.
 
         :param product: Product to put.
@@ -152,7 +152,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval
@@ -192,11 +192,11 @@ class MultiapiServiceClientOperationsMixin(object):
     def _test_lro_and_paging_initial(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PagingResult"
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        # type: (...) -> "_models.PagingResult"
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -244,10 +244,10 @@ class MultiapiServiceClientOperationsMixin(object):
     def begin_test_lro_and_paging(
         self,
         client_request_id=None,  # type: Optional[str]
-        test_lro_and_paging_options=None,  # type: Optional["models.TestLroAndPagingOptions"]
+        test_lro_and_paging_options=None,  # type: Optional["_models.TestLroAndPagingOptions"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> LROPoller[ItemPaged["models.PagingResult"]]
+        # type: (...) -> LROPoller[ItemPaged["_models.PagingResult"]]
         """A long-running paging operation that includes a nextLink that has 10 pages.
 
         :param client_request_id:
@@ -264,7 +264,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.polling.LROPoller[~azure.core.paging.ItemPaged[~multiapiwithsubmodule.submodule.v1.models.PagingResult]]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -321,7 +321,7 @@ class MultiapiServiceClientOperationsMixin(object):
             return pipeline_response
 
         polling = kwargs.pop('polling', True)  # type: Union[bool, PollingMethod]
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         lro_delay = kwargs.pop(
             'polling_interval',
             self._config.polling_interval

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_operation_group_one_operations.py
@@ -81,7 +81,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": true,
-                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"models.ModelTwo\":\n",
+                "signature": "async def test_one(\n    self,\n    id: int,\n    message: Optional[str] = None,\n    **kwargs\n) -\u003e \"_models.ModelTwo\":\n",
                 "doc": "\"\"\"TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.\n\n:param id: An int parameter.\n:type id: int\n:param message: An optional string parameter.\n:type message: str\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: ModelTwo, or the result of cls(response)\n:rtype: ~multiapiwithsubmodule.submodule.v2.models.ModelTwo\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": "id, message"

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_multiapi_service_client_operations.py
@@ -65,7 +65,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -65,7 +65,7 @@ class MultiapiServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_multiapi_service_client_operations.py
@@ -25,7 +25,7 @@ class MultiapiServiceClientOperationsMixin:
         id: int,
         message: Optional[str] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~multiapiwithsubmodule.submodule.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_one_operations.py
@@ -42,9 +42,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelTwo"] = None,
+        parameter_one: Optional["_models.ModelTwo"] = None,
         **kwargs
-    ) -> "models.ModelTwo":
+    ) -> "_models.ModelTwo":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -54,7 +54,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapiwithsubmodule.submodule.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_one_operations.py
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -134,7 +134,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -134,7 +134,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -80,7 +80,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/aio/operations/_operation_group_two_operations.py
@@ -80,7 +80,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_multiapi_service_client_operations.py
@@ -30,7 +30,7 @@ class MultiapiServiceClientOperationsMixin(object):
         message=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestOne should be in an SecondVersionOperationsMixin. Returns ModelTwo.
 
         :param id: An int parameter.
@@ -42,7 +42,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~multiapiwithsubmodule.submodule.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_multiapi_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_multiapi_service_client_operations.py
@@ -70,7 +70,7 @@ class MultiapiServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelTwo"]
+        parameter_one=None,  # type: Optional["_models.ModelTwo"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelTwo"
+        # type: (...) -> "_models.ModelTwo"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelTwo and ouputs ModelTwo.
 
         :param parameter_one: A ModelTwo parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapiwithsubmodule.submodule.v2.models.ModelTwo
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelTwo"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelTwo"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelTwo', pipeline_response)
@@ -140,7 +140,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_two_operations.py
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/_metadata.json
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/_metadata.json
@@ -51,7 +51,7 @@
             },
             "async": {
                 "coroutine": false,
-                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"models.PagingResult\"]:\n",
+                "signature": "def test_paging(\n    self,\n    **kwargs\n) -\u003e AsyncItemPaged[\"_models.PagingResult\"]:\n",
                 "doc": "\"\"\"Returns ModelThree with optionalProperty \u0027paged\u0027.\n\n:keyword callable cls: A custom type or function that will be passed the direct response\n:return: An iterator like instance of either PagingResult or the result of cls(response)\n:rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapiwithsubmodule.submodule.v3.models.PagingResult]\n:raises: ~azure.core.exceptions.HttpResponseError\n\"\"\""
             },
             "call": ""

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_multiapi_service_client_operations.py
@@ -24,7 +24,7 @@ class MultiapiServiceClientOperationsMixin:
     def test_paging(
         self,
         **kwargs
-    ) -> AsyncIterable["models.PagingResult"]:
+    ) -> AsyncIterable["_models.PagingResult"]:
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -32,7 +32,7 @@ class MultiapiServiceClientOperationsMixin:
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~multiapiwithsubmodule.submodule.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_one_operations.py
@@ -42,9 +42,9 @@ class OperationGroupOneOperations:
 
     async def test_two(
         self,
-        parameter_one: Optional["models.ModelThree"] = None,
+        parameter_one: Optional["_models.ModelThree"] = None,
         **kwargs
-    ) -> "models.ModelThree":
+    ) -> "_models.ModelThree":
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -54,7 +54,7 @@ class OperationGroupOneOperations:
         :rtype: ~multiapiwithsubmodule.submodule.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupOneOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_one_operations.py
@@ -87,7 +87,7 @@ class OperationGroupOneOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
@@ -97,7 +97,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
@@ -42,7 +42,7 @@ class OperationGroupTwoOperations:
 
     async def test_four(
         self,
-        input: Optional[Union[IO, "models.SourcePath"]] = None,
+        input: Optional[Union[IO, "_models.SourcePath"]] = None,
         **kwargs
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class OperationGroupTwoOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -97,7 +97,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_multiapi_service_client_operations.py
@@ -29,7 +29,7 @@ class MultiapiServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Iterable["models.PagingResult"]
+        # type: (...) -> Iterable["_models.PagingResult"]
         """Returns ModelThree with optionalProperty 'paged'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -37,7 +37,7 @@ class MultiapiServiceClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~multiapiwithsubmodule.submodule.v3.models.PagingResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PagingResult"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PagingResult"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_multiapi_service_client_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_one_operations.py
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_one_operations.py
@@ -46,10 +46,10 @@ class OperationGroupOneOperations(object):
 
     def test_two(
         self,
-        parameter_one=None,  # type: Optional["models.ModelThree"]
+        parameter_one=None,  # type: Optional["_models.ModelThree"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ModelThree"
+        # type: (...) -> "_models.ModelThree"
         """TestTwo should be in OperationGroupOneOperations. Takes in ModelThree and ouputs ModelThree.
 
         :param parameter_one: A ModelThree parameter.
@@ -59,7 +59,7 @@ class OperationGroupOneOperations(object):
         :rtype: ~multiapiwithsubmodule.submodule.v3.models.ModelThree
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ModelThree"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ModelThree"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_one_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_one_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupOneOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -92,7 +92,7 @@ class OperationGroupOneOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         deserialized = self._deserialize('ModelThree', pipeline_response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.mgmt.core.exceptions import ARMErrorFormat
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class OperationGroupTwoOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -102,7 +102,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:
@@ -147,7 +147,7 @@ class OperationGroupTwoOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error, error_format=ARMErrorFormat)
 
         if cls:

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -46,7 +46,7 @@ class OperationGroupTwoOperations(object):
 
     def test_four(
         self,
-        input=None,  # type: Optional[Union[IO, "models.SourcePath"]]
+        input=None,  # type: Optional[Union[IO, "_models.SourcePath"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/AcceptanceTests/asynctests/test_xms_error.py
+++ b/test/vanilla/AcceptanceTests/asynctests/test_xms_error.py
@@ -97,3 +97,10 @@ class TestXmsErrorResponse(object):
 
         with pytest.raises(ResourceNotFoundError) as excinfo:
             await client.pet.do_something("fetch")
+
+    @pytest.mark.asyncio
+    async def test_error_deserialization_with_param_name_models(self, client):
+        with pytest.raises(HttpResponseError) as excinfo:
+            await client.pet.has_models_param()
+        assert isinstance(excinfo.value.model, PetSadError)
+        assert excinfo.value.status_code == 500

--- a/test/vanilla/AcceptanceTests/test_xms_error.py
+++ b/test/vanilla/AcceptanceTests/test_xms_error.py
@@ -92,6 +92,12 @@ class TestXmsErrorResponse(object):
         with pytest.raises(ResourceNotFoundError) as excinfo:
             client.pet.do_something("fetch")
 
+    def test_error_deserialization_with_param_name_models(self, client):
+        with pytest.raises(HttpResponseError) as excinfo:
+            client.pet.has_models_param()
+        assert isinstance(excinfo.value.model, PetSadError)
+        assert excinfo.value.status_code == 500
+
     def test_models(self):
         from xmserrorresponse.models import Animal
 

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/aio/operations/_pets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/aio/operations/_pets_operations.py
@@ -83,7 +83,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPTrue', pipeline_response)
@@ -137,7 +137,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('CatAPTrue', pipeline_response)
@@ -191,7 +191,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPObject', pipeline_response)
@@ -245,7 +245,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPString', pipeline_response)
@@ -299,7 +299,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInProperties', pipeline_response)
@@ -353,7 +353,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInPropertiesWithAPString', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/aio/operations/_pets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/aio/operations/_pets_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PetsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -83,7 +83,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPTrue', pipeline_response)
@@ -137,7 +137,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('CatAPTrue', pipeline_response)
@@ -191,7 +191,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPObject', pipeline_response)
@@ -245,7 +245,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPString', pipeline_response)
@@ -299,7 +299,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInProperties', pipeline_response)
@@ -353,7 +353,7 @@ class PetsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInPropertiesWithAPString', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/aio/operations/_pets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/aio/operations/_pets_operations.py
@@ -43,9 +43,9 @@ class PetsOperations:
     @distributed_trace_async
     async def create_ap_true(
         self,
-        create_parameters: "models.PetAPTrue",
+        create_parameters: "_models.PetAPTrue",
         **kwargs
-    ) -> "models.PetAPTrue":
+    ) -> "_models.PetAPTrue":
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -55,7 +55,7 @@ class PetsOperations:
         :rtype: ~additionalproperties.models.PetAPTrue
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPTrue"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPTrue"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -97,9 +97,9 @@ class PetsOperations:
     @distributed_trace_async
     async def create_cat_ap_true(
         self,
-        create_parameters: "models.CatAPTrue",
+        create_parameters: "_models.CatAPTrue",
         **kwargs
-    ) -> "models.CatAPTrue":
+    ) -> "_models.CatAPTrue":
         """Create a CatAPTrue which contains more properties than what is defined.
 
         :param create_parameters:
@@ -109,7 +109,7 @@ class PetsOperations:
         :rtype: ~additionalproperties.models.CatAPTrue
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.CatAPTrue"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.CatAPTrue"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -151,9 +151,9 @@ class PetsOperations:
     @distributed_trace_async
     async def create_ap_object(
         self,
-        create_parameters: "models.PetAPObject",
+        create_parameters: "_models.PetAPObject",
         **kwargs
-    ) -> "models.PetAPObject":
+    ) -> "_models.PetAPObject":
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -163,7 +163,7 @@ class PetsOperations:
         :rtype: ~additionalproperties.models.PetAPObject
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPObject"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPObject"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -205,9 +205,9 @@ class PetsOperations:
     @distributed_trace_async
     async def create_ap_string(
         self,
-        create_parameters: "models.PetAPString",
+        create_parameters: "_models.PetAPString",
         **kwargs
-    ) -> "models.PetAPString":
+    ) -> "_models.PetAPString":
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -217,7 +217,7 @@ class PetsOperations:
         :rtype: ~additionalproperties.models.PetAPString
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPString"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPString"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -259,9 +259,9 @@ class PetsOperations:
     @distributed_trace_async
     async def create_ap_in_properties(
         self,
-        create_parameters: "models.PetAPInProperties",
+        create_parameters: "_models.PetAPInProperties",
         **kwargs
-    ) -> "models.PetAPInProperties":
+    ) -> "_models.PetAPInProperties":
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -271,7 +271,7 @@ class PetsOperations:
         :rtype: ~additionalproperties.models.PetAPInProperties
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPInProperties"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPInProperties"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -313,9 +313,9 @@ class PetsOperations:
     @distributed_trace_async
     async def create_ap_in_properties_with_ap_string(
         self,
-        create_parameters: "models.PetAPInPropertiesWithAPString",
+        create_parameters: "_models.PetAPInPropertiesWithAPString",
         **kwargs
-    ) -> "models.PetAPInPropertiesWithAPString":
+    ) -> "_models.PetAPInPropertiesWithAPString":
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -325,7 +325,7 @@ class PetsOperations:
         :rtype: ~additionalproperties.models.PetAPInPropertiesWithAPString
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPInPropertiesWithAPString"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPInPropertiesWithAPString"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/operations/_pets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/operations/_pets_operations.py
@@ -47,10 +47,10 @@ class PetsOperations(object):
     @distributed_trace
     def create_ap_true(
         self,
-        create_parameters,  # type: "models.PetAPTrue"
+        create_parameters,  # type: "_models.PetAPTrue"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PetAPTrue"
+        # type: (...) -> "_models.PetAPTrue"
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -60,7 +60,7 @@ class PetsOperations(object):
         :rtype: ~additionalproperties.models.PetAPTrue
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPTrue"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPTrue"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -102,10 +102,10 @@ class PetsOperations(object):
     @distributed_trace
     def create_cat_ap_true(
         self,
-        create_parameters,  # type: "models.CatAPTrue"
+        create_parameters,  # type: "_models.CatAPTrue"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.CatAPTrue"
+        # type: (...) -> "_models.CatAPTrue"
         """Create a CatAPTrue which contains more properties than what is defined.
 
         :param create_parameters:
@@ -115,7 +115,7 @@ class PetsOperations(object):
         :rtype: ~additionalproperties.models.CatAPTrue
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.CatAPTrue"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.CatAPTrue"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -157,10 +157,10 @@ class PetsOperations(object):
     @distributed_trace
     def create_ap_object(
         self,
-        create_parameters,  # type: "models.PetAPObject"
+        create_parameters,  # type: "_models.PetAPObject"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PetAPObject"
+        # type: (...) -> "_models.PetAPObject"
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -170,7 +170,7 @@ class PetsOperations(object):
         :rtype: ~additionalproperties.models.PetAPObject
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPObject"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPObject"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -212,10 +212,10 @@ class PetsOperations(object):
     @distributed_trace
     def create_ap_string(
         self,
-        create_parameters,  # type: "models.PetAPString"
+        create_parameters,  # type: "_models.PetAPString"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PetAPString"
+        # type: (...) -> "_models.PetAPString"
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -225,7 +225,7 @@ class PetsOperations(object):
         :rtype: ~additionalproperties.models.PetAPString
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPString"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPString"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -267,10 +267,10 @@ class PetsOperations(object):
     @distributed_trace
     def create_ap_in_properties(
         self,
-        create_parameters,  # type: "models.PetAPInProperties"
+        create_parameters,  # type: "_models.PetAPInProperties"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PetAPInProperties"
+        # type: (...) -> "_models.PetAPInProperties"
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -280,7 +280,7 @@ class PetsOperations(object):
         :rtype: ~additionalproperties.models.PetAPInProperties
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPInProperties"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPInProperties"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -322,10 +322,10 @@ class PetsOperations(object):
     @distributed_trace
     def create_ap_in_properties_with_ap_string(
         self,
-        create_parameters,  # type: "models.PetAPInPropertiesWithAPString"
+        create_parameters,  # type: "_models.PetAPInPropertiesWithAPString"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PetAPInPropertiesWithAPString"
+        # type: (...) -> "_models.PetAPInPropertiesWithAPString"
         """Create a Pet which contains more properties than what is defined.
 
         :param create_parameters:
@@ -335,7 +335,7 @@ class PetsOperations(object):
         :rtype: ~additionalproperties.models.PetAPInPropertiesWithAPString
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAPInPropertiesWithAPString"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAPInPropertiesWithAPString"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/operations/_pets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/operations/_pets_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PetsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -88,7 +88,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPTrue', pipeline_response)
@@ -143,7 +143,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('CatAPTrue', pipeline_response)
@@ -198,7 +198,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPObject', pipeline_response)
@@ -253,7 +253,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPString', pipeline_response)
@@ -308,7 +308,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInProperties', pipeline_response)
@@ -363,7 +363,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInPropertiesWithAPString', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/operations/_pets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/operations/_pets_operations.py
@@ -88,7 +88,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPTrue', pipeline_response)
@@ -143,7 +143,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('CatAPTrue', pipeline_response)
@@ -198,7 +198,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPObject', pipeline_response)
@@ -253,7 +253,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPString', pipeline_response)
@@ -308,7 +308,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInProperties', pipeline_response)
@@ -363,7 +363,7 @@ class PetsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAPInPropertiesWithAPString', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/aio/operations/_array_operations.py
@@ -1276,7 +1276,7 @@ class ArrayOperations:
     async def get_enum_valid(
         self,
         **kwargs
-    ) -> List[Union[str, "models.FooEnum"]]:
+    ) -> List[Union[str, "_models.FooEnum"]]:
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1284,7 +1284,7 @@ class ArrayOperations:
         :rtype: list[str or ~bodyarray.models.FooEnum]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.FooEnum"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.FooEnum"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1321,7 +1321,7 @@ class ArrayOperations:
     @distributed_trace_async
     async def put_enum_valid(
         self,
-        array_body: List[Union[str, "models.FooEnum"]],
+        array_body: List[Union[str, "_models.FooEnum"]],
         **kwargs
     ) -> None:
         """Set array value ['foo1', 'foo2', 'foo3'].
@@ -1373,7 +1373,7 @@ class ArrayOperations:
     async def get_string_enum_valid(
         self,
         **kwargs
-    ) -> List[Union[str, "models.Enum0"]]:
+    ) -> List[Union[str, "_models.Enum0"]]:
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1381,7 +1381,7 @@ class ArrayOperations:
         :rtype: list[str or ~bodyarray.models.Enum0]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.Enum0"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.Enum0"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1418,7 +1418,7 @@ class ArrayOperations:
     @distributed_trace_async
     async def put_string_enum_valid(
         self,
-        array_body: List[Union[str, "models.Enum1"]],
+        array_body: List[Union[str, "_models.Enum1"]],
         **kwargs
     ) -> None:
         """Set array value ['foo1', 'foo2', 'foo3'].
@@ -2475,7 +2475,7 @@ class ArrayOperations:
     async def get_complex_null(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type null value.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2483,7 +2483,7 @@ class ArrayOperations:
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2521,7 +2521,7 @@ class ArrayOperations:
     async def get_complex_empty(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get empty array of complex type [].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2529,7 +2529,7 @@ class ArrayOperations:
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2567,7 +2567,7 @@ class ArrayOperations:
     async def get_complex_item_null(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5,
         'string': '6'}].
 
@@ -2576,7 +2576,7 @@ class ArrayOperations:
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2614,7 +2614,7 @@ class ArrayOperations:
     async def get_complex_item_empty(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5,
         'string': '6'}].
 
@@ -2623,7 +2623,7 @@ class ArrayOperations:
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2661,7 +2661,7 @@ class ArrayOperations:
     async def get_complex_valid(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
         {'integer': 5, 'string': '6'}].
 
@@ -2670,7 +2670,7 @@ class ArrayOperations:
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2707,7 +2707,7 @@ class ArrayOperations:
     @distributed_trace_async
     async def put_complex_valid(
         self,
-        array_body: List["models.Product"],
+        array_body: List["_models.Product"],
         **kwargs
     ) -> None:
         """Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3,

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/aio/operations/_array_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class ArrayOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -122,7 +122,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -168,7 +168,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -222,7 +222,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -265,7 +265,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -319,7 +319,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -362,7 +362,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -408,7 +408,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -454,7 +454,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -508,7 +508,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -551,7 +551,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -597,7 +597,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -643,7 +643,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -697,7 +697,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -740,7 +740,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -786,7 +786,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -832,7 +832,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -886,7 +886,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -975,7 +975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1021,7 +1021,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1075,7 +1075,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1118,7 +1118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1164,7 +1164,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1210,7 +1210,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1264,7 +1264,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1307,7 +1307,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1361,7 +1361,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1404,7 +1404,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1458,7 +1458,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1501,7 +1501,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1547,7 +1547,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1594,7 +1594,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1649,7 +1649,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1692,7 +1692,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1738,7 +1738,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1792,7 +1792,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1835,7 +1835,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1881,7 +1881,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1928,7 +1928,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -1983,7 +1983,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2026,7 +2026,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2072,7 +2072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2174,7 +2174,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2217,7 +2217,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2271,7 +2271,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2315,7 +2315,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2370,7 +2370,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2413,7 +2413,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2460,7 +2460,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2506,7 +2506,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2552,7 +2552,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2599,7 +2599,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2646,7 +2646,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2693,7 +2693,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2748,7 +2748,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2791,7 +2791,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2837,7 +2837,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2883,7 +2883,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2929,7 +2929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2975,7 +2975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3029,7 +3029,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3072,7 +3072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3118,7 +3118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3165,7 +3165,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3212,7 +3212,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3259,7 +3259,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3314,7 +3314,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/aio/operations/_array_operations.py
@@ -76,7 +76,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -122,7 +122,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -168,7 +168,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -222,7 +222,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -265,7 +265,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -319,7 +319,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -362,7 +362,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -408,7 +408,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -454,7 +454,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -508,7 +508,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -551,7 +551,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -597,7 +597,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -643,7 +643,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -697,7 +697,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -740,7 +740,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -786,7 +786,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -832,7 +832,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -886,7 +886,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -975,7 +975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1021,7 +1021,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1075,7 +1075,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1118,7 +1118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1164,7 +1164,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1210,7 +1210,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1264,7 +1264,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1307,7 +1307,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1361,7 +1361,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1404,7 +1404,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1458,7 +1458,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1501,7 +1501,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1547,7 +1547,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1594,7 +1594,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1649,7 +1649,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1692,7 +1692,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1738,7 +1738,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1792,7 +1792,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1835,7 +1835,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1881,7 +1881,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1928,7 +1928,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -1983,7 +1983,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2026,7 +2026,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2072,7 +2072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2174,7 +2174,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2217,7 +2217,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2271,7 +2271,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2315,7 +2315,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2370,7 +2370,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2413,7 +2413,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2460,7 +2460,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2506,7 +2506,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2552,7 +2552,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2599,7 +2599,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2646,7 +2646,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2693,7 +2693,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2748,7 +2748,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2791,7 +2791,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2837,7 +2837,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2883,7 +2883,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2929,7 +2929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2975,7 +2975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3029,7 +3029,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3072,7 +3072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3118,7 +3118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3165,7 +3165,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3212,7 +3212,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3259,7 +3259,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3314,7 +3314,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/_array_operations.py
@@ -1307,7 +1307,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List[Union[str, "models.FooEnum"]]
+        # type: (...) -> List[Union[str, "_models.FooEnum"]]
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1315,7 +1315,7 @@ class ArrayOperations(object):
         :rtype: list[str or ~bodyarray.models.FooEnum]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.FooEnum"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.FooEnum"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1352,7 +1352,7 @@ class ArrayOperations(object):
     @distributed_trace
     def put_enum_valid(
         self,
-        array_body,  # type: List[Union[str, "models.FooEnum"]]
+        array_body,  # type: List[Union[str, "_models.FooEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1406,7 +1406,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List[Union[str, "models.Enum0"]]
+        # type: (...) -> List[Union[str, "_models.Enum0"]]
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1414,7 +1414,7 @@ class ArrayOperations(object):
         :rtype: list[str or ~bodyarray.models.Enum0]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.Enum0"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.Enum0"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1451,7 +1451,7 @@ class ArrayOperations(object):
     @distributed_trace
     def put_string_enum_valid(
         self,
-        array_body,  # type: List[Union[str, "models.Enum1"]]
+        array_body,  # type: List[Union[str, "_models.Enum1"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -2531,7 +2531,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type null value.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2539,7 +2539,7 @@ class ArrayOperations(object):
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2578,7 +2578,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get empty array of complex type [].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2586,7 +2586,7 @@ class ArrayOperations(object):
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2625,7 +2625,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5,
         'string': '6'}].
 
@@ -2634,7 +2634,7 @@ class ArrayOperations(object):
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2673,7 +2673,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5,
         'string': '6'}].
 
@@ -2682,7 +2682,7 @@ class ArrayOperations(object):
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2721,7 +2721,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
         {'integer': 5, 'string': '6'}].
 
@@ -2730,7 +2730,7 @@ class ArrayOperations(object):
         :rtype: list[~bodyarray.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2767,7 +2767,7 @@ class ArrayOperations(object):
     @distributed_trace
     def put_complex_valid(
         self,
-        array_body,  # type: List["models.Product"]
+        array_body,  # type: List["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/_array_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class ArrayOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -128,7 +128,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -175,7 +175,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -230,7 +230,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -274,7 +274,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -329,7 +329,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -373,7 +373,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -420,7 +420,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -467,7 +467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -522,7 +522,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -566,7 +566,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -613,7 +613,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -660,7 +660,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -715,7 +715,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -759,7 +759,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -806,7 +806,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -853,7 +853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -908,7 +908,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -952,7 +952,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -999,7 +999,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1046,7 +1046,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1101,7 +1101,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1145,7 +1145,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1192,7 +1192,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1239,7 +1239,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1294,7 +1294,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1338,7 +1338,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1393,7 +1393,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1437,7 +1437,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1492,7 +1492,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1536,7 +1536,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1583,7 +1583,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1631,7 +1631,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1687,7 +1687,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1731,7 +1731,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1778,7 +1778,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1833,7 +1833,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1877,7 +1877,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1924,7 +1924,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1972,7 +1972,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2028,7 +2028,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2072,7 +2072,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2167,7 +2167,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2223,7 +2223,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2267,7 +2267,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2322,7 +2322,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2367,7 +2367,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2423,7 +2423,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2467,7 +2467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2515,7 +2515,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2562,7 +2562,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2609,7 +2609,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2657,7 +2657,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2705,7 +2705,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2753,7 +2753,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2809,7 +2809,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2853,7 +2853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2900,7 +2900,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2947,7 +2947,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2994,7 +2994,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3041,7 +3041,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3096,7 +3096,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3140,7 +3140,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3187,7 +3187,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3235,7 +3235,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3283,7 +3283,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3331,7 +3331,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3387,7 +3387,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/bodyarray/operations/_array_operations.py
@@ -81,7 +81,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -128,7 +128,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -175,7 +175,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -230,7 +230,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -274,7 +274,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -329,7 +329,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -373,7 +373,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -420,7 +420,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -467,7 +467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -522,7 +522,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -566,7 +566,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -613,7 +613,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -660,7 +660,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -715,7 +715,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -759,7 +759,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -806,7 +806,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -853,7 +853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -908,7 +908,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -952,7 +952,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -999,7 +999,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1046,7 +1046,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1101,7 +1101,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1145,7 +1145,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1192,7 +1192,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1239,7 +1239,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1294,7 +1294,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1338,7 +1338,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1393,7 +1393,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1437,7 +1437,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1492,7 +1492,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1536,7 +1536,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1583,7 +1583,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1631,7 +1631,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1687,7 +1687,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1731,7 +1731,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1778,7 +1778,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1833,7 +1833,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1877,7 +1877,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1924,7 +1924,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1972,7 +1972,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2028,7 +2028,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2072,7 +2072,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2167,7 +2167,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2223,7 +2223,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2267,7 +2267,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2322,7 +2322,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2367,7 +2367,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2423,7 +2423,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2467,7 +2467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2515,7 +2515,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2562,7 +2562,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2609,7 +2609,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2657,7 +2657,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2705,7 +2705,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2753,7 +2753,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2809,7 +2809,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2853,7 +2853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2900,7 +2900,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2947,7 +2947,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2994,7 +2994,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3041,7 +3041,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3096,7 +3096,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3140,7 +3140,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3187,7 +3187,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3235,7 +3235,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3283,7 +3283,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3331,7 +3331,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3387,7 +3387,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/aio/operations/_array_operations.py
@@ -1276,7 +1276,7 @@ class ArrayOperations:
     async def get_enum_valid(
         self,
         **kwargs
-    ) -> List[Union[str, "models.FooEnum"]]:
+    ) -> List[Union[str, "_models.FooEnum"]]:
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1284,7 +1284,7 @@ class ArrayOperations:
         :rtype: list[str or ~vanilla.body.array.models.FooEnum]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.FooEnum"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.FooEnum"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1321,7 +1321,7 @@ class ArrayOperations:
     @distributed_trace_async
     async def put_enum_valid(
         self,
-        array_body: List[Union[str, "models.FooEnum"]],
+        array_body: List[Union[str, "_models.FooEnum"]],
         **kwargs
     ) -> None:
         """Set array value ['foo1', 'foo2', 'foo3'].
@@ -1373,7 +1373,7 @@ class ArrayOperations:
     async def get_string_enum_valid(
         self,
         **kwargs
-    ) -> List[Union[str, "models.Enum0"]]:
+    ) -> List[Union[str, "_models.Enum0"]]:
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1381,7 +1381,7 @@ class ArrayOperations:
         :rtype: list[str or ~vanilla.body.array.models.Enum0]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.Enum0"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.Enum0"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1418,7 +1418,7 @@ class ArrayOperations:
     @distributed_trace_async
     async def put_string_enum_valid(
         self,
-        array_body: List[Union[str, "models.Enum1"]],
+        array_body: List[Union[str, "_models.Enum1"]],
         **kwargs
     ) -> None:
         """Set array value ['foo1', 'foo2', 'foo3'].
@@ -2475,7 +2475,7 @@ class ArrayOperations:
     async def get_complex_null(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type null value.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2483,7 +2483,7 @@ class ArrayOperations:
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2521,7 +2521,7 @@ class ArrayOperations:
     async def get_complex_empty(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get empty array of complex type [].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2529,7 +2529,7 @@ class ArrayOperations:
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2567,7 +2567,7 @@ class ArrayOperations:
     async def get_complex_item_null(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5,
         'string': '6'}].
 
@@ -2576,7 +2576,7 @@ class ArrayOperations:
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2614,7 +2614,7 @@ class ArrayOperations:
     async def get_complex_item_empty(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5,
         'string': '6'}].
 
@@ -2623,7 +2623,7 @@ class ArrayOperations:
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2661,7 +2661,7 @@ class ArrayOperations:
     async def get_complex_valid(
         self,
         **kwargs
-    ) -> List["models.Product"]:
+    ) -> List["_models.Product"]:
         """Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
         {'integer': 5, 'string': '6'}].
 
@@ -2670,7 +2670,7 @@ class ArrayOperations:
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2707,7 +2707,7 @@ class ArrayOperations:
     @distributed_trace_async
     async def put_complex_valid(
         self,
-        array_body: List["models.Product"],
+        array_body: List["_models.Product"],
         **kwargs
     ) -> None:
         """Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3,

--- a/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/aio/operations/_array_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class ArrayOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -122,7 +122,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -168,7 +168,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -222,7 +222,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -265,7 +265,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -319,7 +319,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -362,7 +362,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -408,7 +408,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -454,7 +454,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -508,7 +508,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -551,7 +551,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -597,7 +597,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -643,7 +643,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -697,7 +697,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -740,7 +740,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -786,7 +786,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -832,7 +832,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -886,7 +886,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -975,7 +975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1021,7 +1021,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1075,7 +1075,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1118,7 +1118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1164,7 +1164,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1210,7 +1210,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1264,7 +1264,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1307,7 +1307,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1361,7 +1361,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1404,7 +1404,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1458,7 +1458,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1501,7 +1501,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1547,7 +1547,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1594,7 +1594,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1649,7 +1649,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1692,7 +1692,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1738,7 +1738,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1792,7 +1792,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1835,7 +1835,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1881,7 +1881,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1928,7 +1928,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -1983,7 +1983,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2026,7 +2026,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2072,7 +2072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2174,7 +2174,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2217,7 +2217,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2271,7 +2271,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2315,7 +2315,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2370,7 +2370,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2413,7 +2413,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2460,7 +2460,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2506,7 +2506,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2552,7 +2552,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2599,7 +2599,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2646,7 +2646,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2693,7 +2693,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2748,7 +2748,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2791,7 +2791,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2837,7 +2837,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2883,7 +2883,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2929,7 +2929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2975,7 +2975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3029,7 +3029,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3072,7 +3072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3118,7 +3118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3165,7 +3165,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3212,7 +3212,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3259,7 +3259,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3314,7 +3314,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/aio/operations/_array_operations.py
@@ -76,7 +76,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -122,7 +122,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -168,7 +168,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -222,7 +222,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -265,7 +265,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -319,7 +319,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -362,7 +362,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -408,7 +408,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -454,7 +454,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -508,7 +508,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -551,7 +551,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -597,7 +597,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -643,7 +643,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -697,7 +697,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -740,7 +740,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -786,7 +786,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -832,7 +832,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -886,7 +886,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -975,7 +975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1021,7 +1021,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1075,7 +1075,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1118,7 +1118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1164,7 +1164,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1210,7 +1210,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1264,7 +1264,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1307,7 +1307,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1361,7 +1361,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1404,7 +1404,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1458,7 +1458,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1501,7 +1501,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1547,7 +1547,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1594,7 +1594,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1649,7 +1649,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1692,7 +1692,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1738,7 +1738,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1792,7 +1792,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1835,7 +1835,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1881,7 +1881,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1928,7 +1928,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -1983,7 +1983,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2026,7 +2026,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2072,7 +2072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2174,7 +2174,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2217,7 +2217,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2271,7 +2271,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2315,7 +2315,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2370,7 +2370,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2413,7 +2413,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2460,7 +2460,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2506,7 +2506,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2552,7 +2552,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2599,7 +2599,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2646,7 +2646,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2693,7 +2693,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2748,7 +2748,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2791,7 +2791,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2837,7 +2837,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2883,7 +2883,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2929,7 +2929,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2975,7 +2975,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3029,7 +3029,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3072,7 +3072,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3118,7 +3118,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3165,7 +3165,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3212,7 +3212,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3259,7 +3259,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3314,7 +3314,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/operations/_array_operations.py
@@ -1307,7 +1307,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List[Union[str, "models.FooEnum"]]
+        # type: (...) -> List[Union[str, "_models.FooEnum"]]
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1315,7 +1315,7 @@ class ArrayOperations(object):
         :rtype: list[str or ~vanilla.body.array.models.FooEnum]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.FooEnum"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.FooEnum"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1352,7 +1352,7 @@ class ArrayOperations(object):
     @distributed_trace
     def put_enum_valid(
         self,
-        array_body,  # type: List[Union[str, "models.FooEnum"]]
+        array_body,  # type: List[Union[str, "_models.FooEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1406,7 +1406,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List[Union[str, "models.Enum0"]]
+        # type: (...) -> List[Union[str, "_models.Enum0"]]
         """Get enum array value ['foo1', 'foo2', 'foo3'].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1414,7 +1414,7 @@ class ArrayOperations(object):
         :rtype: list[str or ~vanilla.body.array.models.Enum0]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "models.Enum0"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List[Union[str, "_models.Enum0"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1451,7 +1451,7 @@ class ArrayOperations(object):
     @distributed_trace
     def put_string_enum_valid(
         self,
-        array_body,  # type: List[Union[str, "models.Enum1"]]
+        array_body,  # type: List[Union[str, "_models.Enum1"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -2531,7 +2531,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type null value.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2539,7 +2539,7 @@ class ArrayOperations(object):
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2578,7 +2578,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get empty array of complex type [].
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2586,7 +2586,7 @@ class ArrayOperations(object):
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2625,7 +2625,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5,
         'string': '6'}].
 
@@ -2634,7 +2634,7 @@ class ArrayOperations(object):
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2673,7 +2673,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5,
         'string': '6'}].
 
@@ -2682,7 +2682,7 @@ class ArrayOperations(object):
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2721,7 +2721,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Product"]
+        # type: (...) -> List["_models.Product"]
         """Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
         {'integer': 5, 'string': '6'}].
 
@@ -2730,7 +2730,7 @@ class ArrayOperations(object):
         :rtype: list[~vanilla.body.array.models.Product]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Product"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Product"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2767,7 +2767,7 @@ class ArrayOperations(object):
     @distributed_trace
     def put_complex_valid(
         self,
-        array_body,  # type: List["models.Product"]
+        array_body,  # type: List["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/operations/_array_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class ArrayOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -128,7 +128,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -175,7 +175,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -230,7 +230,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -274,7 +274,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -329,7 +329,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -373,7 +373,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -420,7 +420,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -467,7 +467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -522,7 +522,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -566,7 +566,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -613,7 +613,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -660,7 +660,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -715,7 +715,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -759,7 +759,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -806,7 +806,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -853,7 +853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -908,7 +908,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -952,7 +952,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -999,7 +999,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1046,7 +1046,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1101,7 +1101,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1145,7 +1145,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1192,7 +1192,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1239,7 +1239,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1294,7 +1294,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1338,7 +1338,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1393,7 +1393,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1437,7 +1437,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1492,7 +1492,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1536,7 +1536,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1583,7 +1583,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1631,7 +1631,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1687,7 +1687,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1731,7 +1731,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1778,7 +1778,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1833,7 +1833,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1877,7 +1877,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1924,7 +1924,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1972,7 +1972,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2028,7 +2028,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2072,7 +2072,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2167,7 +2167,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2223,7 +2223,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2267,7 +2267,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2322,7 +2322,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2367,7 +2367,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2423,7 +2423,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2467,7 +2467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2515,7 +2515,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2562,7 +2562,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2609,7 +2609,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2657,7 +2657,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2705,7 +2705,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2753,7 +2753,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2809,7 +2809,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2853,7 +2853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2900,7 +2900,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2947,7 +2947,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2994,7 +2994,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3041,7 +3041,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3096,7 +3096,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3140,7 +3140,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3187,7 +3187,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3235,7 +3235,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3283,7 +3283,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3331,7 +3331,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3387,7 +3387,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/operations/_array_operations.py
@@ -81,7 +81,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -128,7 +128,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -175,7 +175,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -230,7 +230,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -274,7 +274,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -329,7 +329,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -373,7 +373,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -420,7 +420,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bool]', pipeline_response)
@@ -467,7 +467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -522,7 +522,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -566,7 +566,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -613,7 +613,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[int]', pipeline_response)
@@ -660,7 +660,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -715,7 +715,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -759,7 +759,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -806,7 +806,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[long]', pipeline_response)
@@ -853,7 +853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -908,7 +908,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -952,7 +952,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -999,7 +999,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1046,7 +1046,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1101,7 +1101,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1145,7 +1145,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1192,7 +1192,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[float]', pipeline_response)
@@ -1239,7 +1239,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1294,7 +1294,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1338,7 +1338,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1393,7 +1393,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1437,7 +1437,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1492,7 +1492,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1536,7 +1536,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1583,7 +1583,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1631,7 +1631,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1687,7 +1687,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1731,7 +1731,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[str]', pipeline_response)
@@ -1778,7 +1778,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1833,7 +1833,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1877,7 +1877,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1924,7 +1924,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[date]', pipeline_response)
@@ -1972,7 +1972,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2028,7 +2028,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2072,7 +2072,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2119,7 +2119,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[iso-8601]', pipeline_response)
@@ -2167,7 +2167,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[rfc-1123]', pipeline_response)
@@ -2223,7 +2223,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2267,7 +2267,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[duration]', pipeline_response)
@@ -2322,7 +2322,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2367,7 +2367,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2423,7 +2423,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2467,7 +2467,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[bytearray]', pipeline_response)
@@ -2515,7 +2515,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[base64]', pipeline_response)
@@ -2562,7 +2562,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2609,7 +2609,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2657,7 +2657,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2705,7 +2705,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2753,7 +2753,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[Product]', pipeline_response)
@@ -2809,7 +2809,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2853,7 +2853,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2900,7 +2900,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2947,7 +2947,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -2994,7 +2994,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3041,7 +3041,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[[str]]', pipeline_response)
@@ -3096,7 +3096,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -3140,7 +3140,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3187,7 +3187,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3235,7 +3235,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3283,7 +3283,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3331,7 +3331,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[{str}]', pipeline_response)
@@ -3387,7 +3387,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/aio/operations/_bool_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/aio/operations/_bool_operations.py
@@ -75,7 +75,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -127,7 +127,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -170,7 +170,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -222,7 +222,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -265,7 +265,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -311,7 +311,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/aio/operations/_bool_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/aio/operations/_bool_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class BoolOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -127,7 +127,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -170,7 +170,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -222,7 +222,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -265,7 +265,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -311,7 +311,7 @@ class BoolOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/operations/_bool_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/operations/_bool_operations.py
@@ -80,7 +80,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -133,7 +133,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -177,7 +177,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -230,7 +230,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -274,7 +274,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -321,7 +321,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/operations/_bool_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyBoolean/bodyboolean/operations/_bool_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class BoolOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -133,7 +133,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -177,7 +177,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -230,7 +230,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -274,7 +274,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -321,7 +321,7 @@ class BoolOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/aio/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/aio/operations/_byte_operations.py
@@ -75,7 +75,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -121,7 +121,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -167,7 +167,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -221,7 +221,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -264,7 +264,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/aio/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/aio/operations/_byte_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ByteOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -121,7 +121,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -167,7 +167,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -221,7 +221,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -264,7 +264,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/operations/_byte_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ByteOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -127,7 +127,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -174,7 +174,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -229,7 +229,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByte/bodybyte/operations/_byte_operations.py
@@ -80,7 +80,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -127,7 +127,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -174,7 +174,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -229,7 +229,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/aio/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/aio/operations/_byte_operations.py
@@ -75,7 +75,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -121,7 +121,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -167,7 +167,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -221,7 +221,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -264,7 +264,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/aio/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/aio/operations/_byte_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ByteOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -121,7 +121,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -167,7 +167,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -221,7 +221,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -264,7 +264,7 @@ class ByteOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/operations/_byte_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ByteOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -127,7 +127,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -174,7 +174,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -229,7 +229,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/operations/_byte_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/operations/_byte_operations.py
@@ -80,7 +80,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -127,7 +127,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -174,7 +174,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -229,7 +229,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class ByteOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_array_operations.py
@@ -44,7 +44,7 @@ class ArrayOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.ArrayWrapper":
+    ) -> "_models.ArrayWrapper":
         """Get complex types with array property.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class ArrayOperations:
         :rtype: ~bodycomplex.models.ArrayWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ArrayWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ArrayWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -107,7 +107,7 @@ class ArrayOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ArrayWrapper(array=array)
+        _complex_body = _models.ArrayWrapper(array=array)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -143,7 +143,7 @@ class ArrayOperations:
     async def get_empty(
         self,
         **kwargs
-    ) -> "models.ArrayWrapper":
+    ) -> "_models.ArrayWrapper":
         """Get complex types with array property which is empty.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -151,7 +151,7 @@ class ArrayOperations:
         :rtype: ~bodycomplex.models.ArrayWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ArrayWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ArrayWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -206,7 +206,7 @@ class ArrayOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ArrayWrapper(array=array)
+        _complex_body = _models.ArrayWrapper(array=array)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -242,7 +242,7 @@ class ArrayOperations:
     async def get_not_provided(
         self,
         **kwargs
-    ) -> "models.ArrayWrapper":
+    ) -> "_models.ArrayWrapper":
         """Get complex types with array property while server doesn't provide a response payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -250,7 +250,7 @@ class ArrayOperations:
         :rtype: ~bodycomplex.models.ArrayWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ArrayWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ArrayWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_array_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ArrayOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -131,7 +131,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -174,7 +174,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -230,7 +230,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_array_operations.py
@@ -75,7 +75,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -131,7 +131,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -174,7 +174,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -230,7 +230,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class ArrayOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_basic_operations.py
@@ -75,7 +75,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -131,7 +131,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -174,7 +174,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -220,7 +220,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -266,7 +266,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -312,7 +312,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_basic_operations.py
@@ -44,7 +44,7 @@ class BasicOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.Basic":
+    ) -> "_models.Basic":
         """Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class BasicOperations:
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -89,7 +89,7 @@ class BasicOperations:
     @distributed_trace_async
     async def put_valid(
         self,
-        complex_body: "models.Basic",
+        complex_body: "_models.Basic",
         **kwargs
     ) -> None:
         """Please put {id: 2, name: 'abc', color: 'Magenta'}.
@@ -143,7 +143,7 @@ class BasicOperations:
     async def get_invalid(
         self,
         **kwargs
-    ) -> "models.Basic":
+    ) -> "_models.Basic":
         """Get a basic complex type that is invalid for the local strong type.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -151,7 +151,7 @@ class BasicOperations:
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -189,7 +189,7 @@ class BasicOperations:
     async def get_empty(
         self,
         **kwargs
-    ) -> "models.Basic":
+    ) -> "_models.Basic":
         """Get a basic complex type that is empty.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -197,7 +197,7 @@ class BasicOperations:
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -235,7 +235,7 @@ class BasicOperations:
     async def get_null(
         self,
         **kwargs
-    ) -> "models.Basic":
+    ) -> "_models.Basic":
         """Get a basic complex type whose properties are null.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -243,7 +243,7 @@ class BasicOperations:
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -281,7 +281,7 @@ class BasicOperations:
     async def get_not_provided(
         self,
         **kwargs
-    ) -> "models.Basic":
+    ) -> "_models.Basic":
         """Get a basic complex type while the server doesn't provide a response payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -289,7 +289,7 @@ class BasicOperations:
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_basic_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class BasicOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -131,7 +131,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -174,7 +174,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -220,7 +220,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -266,7 +266,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -312,7 +312,7 @@ class BasicOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_dictionary_operations.py
@@ -44,7 +44,7 @@ class DictionaryOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.DictionaryWrapper":
+    ) -> "_models.DictionaryWrapper":
         """Get complex types with dictionary property.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class DictionaryOperations:
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -107,7 +107,7 @@ class DictionaryOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.DictionaryWrapper(default_program=default_program)
+        _complex_body = _models.DictionaryWrapper(default_program=default_program)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -143,7 +143,7 @@ class DictionaryOperations:
     async def get_empty(
         self,
         **kwargs
-    ) -> "models.DictionaryWrapper":
+    ) -> "_models.DictionaryWrapper":
         """Get complex types with dictionary property which is empty.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -151,7 +151,7 @@ class DictionaryOperations:
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -206,7 +206,7 @@ class DictionaryOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.DictionaryWrapper(default_program=default_program)
+        _complex_body = _models.DictionaryWrapper(default_program=default_program)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -242,7 +242,7 @@ class DictionaryOperations:
     async def get_null(
         self,
         **kwargs
-    ) -> "models.DictionaryWrapper":
+    ) -> "_models.DictionaryWrapper":
         """Get complex types with dictionary property which is null.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -250,7 +250,7 @@ class DictionaryOperations:
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -288,7 +288,7 @@ class DictionaryOperations:
     async def get_not_provided(
         self,
         **kwargs
-    ) -> "models.DictionaryWrapper":
+    ) -> "_models.DictionaryWrapper":
         """Get complex types with dictionary property while server doesn't provide a response payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -296,7 +296,7 @@ class DictionaryOperations:
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_dictionary_operations.py
@@ -75,7 +75,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -131,7 +131,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -174,7 +174,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -230,7 +230,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -319,7 +319,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_dictionary_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class DictionaryOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -131,7 +131,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -174,7 +174,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -230,7 +230,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -319,7 +319,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_flattencomplex_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_flattencomplex_operations.py
@@ -44,7 +44,7 @@ class FlattencomplexOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.MyBaseType":
+    ) -> "_models.MyBaseType":
         """get_valid.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class FlattencomplexOperations:
         :rtype: ~bodycomplex.models.MyBaseType
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyBaseType"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyBaseType"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_flattencomplex_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_flattencomplex_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class FlattencomplexOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_inheritance_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class InheritanceOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class InheritanceOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Siamese', pipeline_response)
@@ -131,7 +131,7 @@ class InheritanceOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_inheritance_operations.py
@@ -75,7 +75,7 @@ class InheritanceOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Siamese', pipeline_response)
@@ -131,7 +131,7 @@ class InheritanceOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_inheritance_operations.py
@@ -44,7 +44,7 @@ class InheritanceOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.Siamese":
+    ) -> "_models.Siamese":
         """Get complex types that extend others.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class InheritanceOperations:
         :rtype: ~bodycomplex.models.Siamese
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Siamese"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Siamese"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -89,7 +89,7 @@ class InheritanceOperations:
     @distributed_trace_async
     async def put_valid(
         self,
-        complex_body: "models.Siamese",
+        complex_body: "_models.Siamese",
         **kwargs
     ) -> None:
         """Put complex types that extend others.

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphicrecursive_operations.py
@@ -75,7 +75,7 @@ class PolymorphicrecursiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -181,7 +181,7 @@ class PolymorphicrecursiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphicrecursive_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PolymorphicrecursiveOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class PolymorphicrecursiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -181,7 +181,7 @@ class PolymorphicrecursiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphicrecursive_operations.py
@@ -44,7 +44,7 @@ class PolymorphicrecursiveOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.Fish":
+    ) -> "_models.Fish":
         """Get complex types that are polymorphic and have recursive references.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class PolymorphicrecursiveOperations:
         :rtype: ~bodycomplex.models.Fish
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Fish"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Fish"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -89,7 +89,7 @@ class PolymorphicrecursiveOperations:
     @distributed_trace_async
     async def put_valid(
         self,
-        complex_body: "models.Fish",
+        complex_body: "_models.Fish",
         **kwargs
     ) -> None:
         """Put complex types that are polymorphic and have recursive references.

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphism_operations.py
@@ -75,7 +75,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -161,7 +161,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -204,7 +204,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFish', pipeline_response)
@@ -252,7 +252,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -300,7 +300,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -347,7 +347,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -402,7 +402,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -453,7 +453,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -534,7 +534,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphism_operations.py
@@ -44,7 +44,7 @@ class PolymorphismOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.Fish":
+    ) -> "_models.Fish":
         """Get complex types that are polymorphic.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class PolymorphismOperations:
         :rtype: ~bodycomplex.models.Fish
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Fish"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Fish"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -89,7 +89,7 @@ class PolymorphismOperations:
     @distributed_trace_async
     async def put_valid(
         self,
-        complex_body: "models.Fish",
+        complex_body: "_models.Fish",
         **kwargs
     ) -> None:
         """Put complex types that are polymorphic.
@@ -173,7 +173,7 @@ class PolymorphismOperations:
     async def get_dot_syntax(
         self,
         **kwargs
-    ) -> "models.DotFish":
+    ) -> "_models.DotFish":
         """Get complex types that are polymorphic, JSON key contains a dot.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -181,7 +181,7 @@ class PolymorphismOperations:
         :rtype: ~bodycomplex.models.DotFish
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DotFish"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DotFish"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -219,7 +219,7 @@ class PolymorphismOperations:
     async def get_composed_with_discriminator(
         self,
         **kwargs
-    ) -> "models.DotFishMarket":
+    ) -> "_models.DotFishMarket":
         """Get complex object composing a polymorphic scalar property and array property with polymorphic
         element type, with discriminator specified. Deserialization must NOT fail and use the
         discriminator type specified on the wire.
@@ -229,7 +229,7 @@ class PolymorphismOperations:
         :rtype: ~bodycomplex.models.DotFishMarket
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DotFishMarket"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DotFishMarket"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -267,7 +267,7 @@ class PolymorphismOperations:
     async def get_composed_without_discriminator(
         self,
         **kwargs
-    ) -> "models.DotFishMarket":
+    ) -> "_models.DotFishMarket":
         """Get complex object composing a polymorphic scalar property and array property with polymorphic
         element type, without discriminator specified on wire. Deserialization must NOT fail and use
         the explicit type of the property.
@@ -277,7 +277,7 @@ class PolymorphismOperations:
         :rtype: ~bodycomplex.models.DotFishMarket
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DotFishMarket"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DotFishMarket"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -315,7 +315,7 @@ class PolymorphismOperations:
     async def get_complicated(
         self,
         **kwargs
-    ) -> "models.Salmon":
+    ) -> "_models.Salmon":
         """Get complex types that are polymorphic, but not at the root of the hierarchy; also have
         additional properties.
 
@@ -324,7 +324,7 @@ class PolymorphismOperations:
         :rtype: ~bodycomplex.models.Salmon
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Salmon"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Salmon"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -361,7 +361,7 @@ class PolymorphismOperations:
     @distributed_trace_async
     async def put_complicated(
         self,
-        complex_body: "models.Salmon",
+        complex_body: "_models.Salmon",
         **kwargs
     ) -> None:
         """Put complex types that are polymorphic, but not at the root of the hierarchy; also have
@@ -413,9 +413,9 @@ class PolymorphismOperations:
     @distributed_trace_async
     async def put_missing_discriminator(
         self,
-        complex_body: "models.Salmon",
+        complex_body: "_models.Salmon",
         **kwargs
-    ) -> "models.Salmon":
+    ) -> "_models.Salmon":
         """Put complex types that are polymorphic, omitting the discriminator.
 
         :param complex_body:
@@ -425,7 +425,7 @@ class PolymorphismOperations:
         :rtype: ~bodycomplex.models.Salmon
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Salmon"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Salmon"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -467,7 +467,7 @@ class PolymorphismOperations:
     @distributed_trace_async
     async def put_valid_missing_required(
         self,
-        complex_body: "models.Fish",
+        complex_body: "_models.Fish",
         **kwargs
     ) -> None:
         """Put complex types that are polymorphic, attempting to omit required 'birthday' field - the

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_polymorphism_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PolymorphismOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -161,7 +161,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -204,7 +204,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFish', pipeline_response)
@@ -252,7 +252,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -300,7 +300,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -347,7 +347,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -402,7 +402,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -453,7 +453,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -534,7 +534,7 @@ class PolymorphismOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_primitive_operations.py
@@ -76,7 +76,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('IntWrapper', pipeline_response)
@@ -130,7 +130,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -173,7 +173,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('LongWrapper', pipeline_response)
@@ -227,7 +227,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -270,7 +270,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('FloatWrapper', pipeline_response)
@@ -324,7 +324,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -367,7 +367,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DoubleWrapper', pipeline_response)
@@ -422,7 +422,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -465,7 +465,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('BooleanWrapper', pipeline_response)
@@ -519,7 +519,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -562,7 +562,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('StringWrapper', pipeline_response)
@@ -616,7 +616,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -659,7 +659,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DateWrapper', pipeline_response)
@@ -713,7 +713,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -756,7 +756,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DatetimeWrapper', pipeline_response)
@@ -810,7 +810,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -853,7 +853,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Datetimerfc1123Wrapper', pipeline_response)
@@ -908,7 +908,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -951,7 +951,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DurationWrapper', pipeline_response)
@@ -1007,7 +1007,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1050,7 +1050,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ByteWrapper', pipeline_response)
@@ -1106,7 +1106,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_primitive_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class PrimitiveOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('IntWrapper', pipeline_response)
@@ -130,7 +130,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -173,7 +173,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('LongWrapper', pipeline_response)
@@ -227,7 +227,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -270,7 +270,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('FloatWrapper', pipeline_response)
@@ -324,7 +324,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -367,7 +367,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DoubleWrapper', pipeline_response)
@@ -422,7 +422,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -465,7 +465,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('BooleanWrapper', pipeline_response)
@@ -519,7 +519,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -562,7 +562,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('StringWrapper', pipeline_response)
@@ -616,7 +616,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -659,7 +659,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DateWrapper', pipeline_response)
@@ -713,7 +713,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -756,7 +756,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DatetimeWrapper', pipeline_response)
@@ -810,7 +810,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -853,7 +853,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Datetimerfc1123Wrapper', pipeline_response)
@@ -908,7 +908,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -951,7 +951,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DurationWrapper', pipeline_response)
@@ -1007,7 +1007,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1050,7 +1050,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ByteWrapper', pipeline_response)
@@ -1106,7 +1106,7 @@ class PrimitiveOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_primitive_operations.py
@@ -45,7 +45,7 @@ class PrimitiveOperations:
     async def get_int(
         self,
         **kwargs
-    ) -> "models.IntWrapper":
+    ) -> "_models.IntWrapper":
         """Get complex types with integer properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -53,7 +53,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.IntWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.IntWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.IntWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -90,7 +90,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_int(
         self,
-        complex_body: "models.IntWrapper",
+        complex_body: "_models.IntWrapper",
         **kwargs
     ) -> None:
         """Put complex types with integer properties.
@@ -142,7 +142,7 @@ class PrimitiveOperations:
     async def get_long(
         self,
         **kwargs
-    ) -> "models.LongWrapper":
+    ) -> "_models.LongWrapper":
         """Get complex types with long properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -150,7 +150,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.LongWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.LongWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.LongWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -187,7 +187,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_long(
         self,
-        complex_body: "models.LongWrapper",
+        complex_body: "_models.LongWrapper",
         **kwargs
     ) -> None:
         """Put complex types with long properties.
@@ -239,7 +239,7 @@ class PrimitiveOperations:
     async def get_float(
         self,
         **kwargs
-    ) -> "models.FloatWrapper":
+    ) -> "_models.FloatWrapper":
         """Get complex types with float properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -247,7 +247,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.FloatWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.FloatWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.FloatWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -284,7 +284,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_float(
         self,
-        complex_body: "models.FloatWrapper",
+        complex_body: "_models.FloatWrapper",
         **kwargs
     ) -> None:
         """Put complex types with float properties.
@@ -336,7 +336,7 @@ class PrimitiveOperations:
     async def get_double(
         self,
         **kwargs
-    ) -> "models.DoubleWrapper":
+    ) -> "_models.DoubleWrapper":
         """Get complex types with double properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -344,7 +344,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.DoubleWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DoubleWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DoubleWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -381,7 +381,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_double(
         self,
-        complex_body: "models.DoubleWrapper",
+        complex_body: "_models.DoubleWrapper",
         **kwargs
     ) -> None:
         """Put complex types with double properties.
@@ -434,7 +434,7 @@ class PrimitiveOperations:
     async def get_bool(
         self,
         **kwargs
-    ) -> "models.BooleanWrapper":
+    ) -> "_models.BooleanWrapper":
         """Get complex types with bool properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -442,7 +442,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.BooleanWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.BooleanWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.BooleanWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -479,7 +479,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_bool(
         self,
-        complex_body: "models.BooleanWrapper",
+        complex_body: "_models.BooleanWrapper",
         **kwargs
     ) -> None:
         """Put complex types with bool properties.
@@ -531,7 +531,7 @@ class PrimitiveOperations:
     async def get_string(
         self,
         **kwargs
-    ) -> "models.StringWrapper":
+    ) -> "_models.StringWrapper":
         """Get complex types with string properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -539,7 +539,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.StringWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StringWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StringWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -576,7 +576,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_string(
         self,
-        complex_body: "models.StringWrapper",
+        complex_body: "_models.StringWrapper",
         **kwargs
     ) -> None:
         """Put complex types with string properties.
@@ -628,7 +628,7 @@ class PrimitiveOperations:
     async def get_date(
         self,
         **kwargs
-    ) -> "models.DateWrapper":
+    ) -> "_models.DateWrapper":
         """Get complex types with date properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -636,7 +636,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.DateWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DateWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DateWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -673,7 +673,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_date(
         self,
-        complex_body: "models.DateWrapper",
+        complex_body: "_models.DateWrapper",
         **kwargs
     ) -> None:
         """Put complex types with date properties.
@@ -725,7 +725,7 @@ class PrimitiveOperations:
     async def get_date_time(
         self,
         **kwargs
-    ) -> "models.DatetimeWrapper":
+    ) -> "_models.DatetimeWrapper":
         """Get complex types with datetime properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -733,7 +733,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.DatetimeWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DatetimeWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DatetimeWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -770,7 +770,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_date_time(
         self,
-        complex_body: "models.DatetimeWrapper",
+        complex_body: "_models.DatetimeWrapper",
         **kwargs
     ) -> None:
         """Put complex types with datetime properties.
@@ -822,7 +822,7 @@ class PrimitiveOperations:
     async def get_date_time_rfc1123(
         self,
         **kwargs
-    ) -> "models.Datetimerfc1123Wrapper":
+    ) -> "_models.Datetimerfc1123Wrapper":
         """Get complex types with datetimeRfc1123 properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -830,7 +830,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.Datetimerfc1123Wrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Datetimerfc1123Wrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Datetimerfc1123Wrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -867,7 +867,7 @@ class PrimitiveOperations:
     @distributed_trace_async
     async def put_date_time_rfc1123(
         self,
-        complex_body: "models.Datetimerfc1123Wrapper",
+        complex_body: "_models.Datetimerfc1123Wrapper",
         **kwargs
     ) -> None:
         """Put complex types with datetimeRfc1123 properties.
@@ -920,7 +920,7 @@ class PrimitiveOperations:
     async def get_duration(
         self,
         **kwargs
-    ) -> "models.DurationWrapper":
+    ) -> "_models.DurationWrapper":
         """Get complex types with duration properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -928,7 +928,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.DurationWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DurationWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DurationWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -983,7 +983,7 @@ class PrimitiveOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.DurationWrapper(field=field)
+        _complex_body = _models.DurationWrapper(field=field)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1019,7 +1019,7 @@ class PrimitiveOperations:
     async def get_byte(
         self,
         **kwargs
-    ) -> "models.ByteWrapper":
+    ) -> "_models.ByteWrapper":
         """Get complex types with byte properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1027,7 +1027,7 @@ class PrimitiveOperations:
         :rtype: ~bodycomplex.models.ByteWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ByteWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ByteWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1082,7 +1082,7 @@ class PrimitiveOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ByteWrapper(field=field)
+        _complex_body = _models.ByteWrapper(field=field)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_readonlyproperty_operations.py
@@ -44,7 +44,7 @@ class ReadonlypropertyOperations:
     async def get_valid(
         self,
         **kwargs
-    ) -> "models.ReadonlyObj":
+    ) -> "_models.ReadonlyObj":
         """Get complex types that have readonly properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class ReadonlypropertyOperations:
         :rtype: ~bodycomplex.models.ReadonlyObj
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ReadonlyObj"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ReadonlyObj"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -107,7 +107,7 @@ class ReadonlypropertyOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ReadonlyObj(size=size)
+        _complex_body = _models.ReadonlyObj(size=size)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_readonlyproperty_operations.py
@@ -75,7 +75,7 @@ class ReadonlypropertyOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ReadonlyObj', pipeline_response)
@@ -131,7 +131,7 @@ class ReadonlypropertyOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/aio/operations/_readonlyproperty_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ReadonlypropertyOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class ReadonlypropertyOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ReadonlyObj', pipeline_response)
@@ -131,7 +131,7 @@ class ReadonlypropertyOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_array_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ArrayOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -137,7 +137,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -181,7 +181,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -238,7 +238,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -282,7 +282,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_array_operations.py
@@ -80,7 +80,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -137,7 +137,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -181,7 +181,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)
@@ -238,7 +238,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -282,7 +282,7 @@ class ArrayOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ArrayWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_array_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_array_operations.py
@@ -49,7 +49,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ArrayWrapper"
+        # type: (...) -> "_models.ArrayWrapper"
         """Get complex types with array property.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class ArrayOperations(object):
         :rtype: ~bodycomplex.models.ArrayWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ArrayWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ArrayWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -113,7 +113,7 @@ class ArrayOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ArrayWrapper(array=array)
+        _complex_body = _models.ArrayWrapper(array=array)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -150,7 +150,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ArrayWrapper"
+        # type: (...) -> "_models.ArrayWrapper"
         """Get complex types with array property which is empty.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -158,7 +158,7 @@ class ArrayOperations(object):
         :rtype: ~bodycomplex.models.ArrayWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ArrayWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ArrayWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -214,7 +214,7 @@ class ArrayOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ArrayWrapper(array=array)
+        _complex_body = _models.ArrayWrapper(array=array)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -251,7 +251,7 @@ class ArrayOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ArrayWrapper"
+        # type: (...) -> "_models.ArrayWrapper"
         """Get complex types with array property while server doesn't provide a response payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -259,7 +259,7 @@ class ArrayOperations(object):
         :rtype: ~bodycomplex.models.ArrayWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ArrayWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ArrayWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_basic_operations.py
@@ -80,7 +80,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -137,7 +137,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -181,7 +181,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -228,7 +228,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -275,7 +275,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -322,7 +322,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_basic_operations.py
@@ -49,7 +49,7 @@ class BasicOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Basic"
+        # type: (...) -> "_models.Basic"
         """Get complex type {id: 2, name: 'abc', color: 'YELLOW'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class BasicOperations(object):
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -94,7 +94,7 @@ class BasicOperations(object):
     @distributed_trace
     def put_valid(
         self,
-        complex_body,  # type: "models.Basic"
+        complex_body,  # type: "_models.Basic"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -150,7 +150,7 @@ class BasicOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Basic"
+        # type: (...) -> "_models.Basic"
         """Get a basic complex type that is invalid for the local strong type.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -158,7 +158,7 @@ class BasicOperations(object):
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -197,7 +197,7 @@ class BasicOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Basic"
+        # type: (...) -> "_models.Basic"
         """Get a basic complex type that is empty.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -205,7 +205,7 @@ class BasicOperations(object):
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -244,7 +244,7 @@ class BasicOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Basic"
+        # type: (...) -> "_models.Basic"
         """Get a basic complex type whose properties are null.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -252,7 +252,7 @@ class BasicOperations(object):
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -291,7 +291,7 @@ class BasicOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Basic"
+        # type: (...) -> "_models.Basic"
         """Get a basic complex type while the server doesn't provide a response payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -299,7 +299,7 @@ class BasicOperations(object):
         :rtype: ~bodycomplex.models.Basic
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Basic"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Basic"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_basic_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_basic_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class BasicOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -137,7 +137,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -181,7 +181,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -228,7 +228,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -275,7 +275,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)
@@ -322,7 +322,7 @@ class BasicOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Basic', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_dictionary_operations.py
@@ -80,7 +80,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -137,7 +137,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -181,7 +181,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -238,7 +238,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -282,7 +282,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -329,7 +329,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_dictionary_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class DictionaryOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -137,7 +137,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -181,7 +181,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -238,7 +238,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -282,7 +282,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)
@@ -329,7 +329,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DictionaryWrapper', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_dictionary_operations.py
@@ -49,7 +49,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DictionaryWrapper"
+        # type: (...) -> "_models.DictionaryWrapper"
         """Get complex types with dictionary property.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class DictionaryOperations(object):
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -113,7 +113,7 @@ class DictionaryOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.DictionaryWrapper(default_program=default_program)
+        _complex_body = _models.DictionaryWrapper(default_program=default_program)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -150,7 +150,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DictionaryWrapper"
+        # type: (...) -> "_models.DictionaryWrapper"
         """Get complex types with dictionary property which is empty.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -158,7 +158,7 @@ class DictionaryOperations(object):
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -214,7 +214,7 @@ class DictionaryOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.DictionaryWrapper(default_program=default_program)
+        _complex_body = _models.DictionaryWrapper(default_program=default_program)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -251,7 +251,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DictionaryWrapper"
+        # type: (...) -> "_models.DictionaryWrapper"
         """Get complex types with dictionary property which is null.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -259,7 +259,7 @@ class DictionaryOperations(object):
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -298,7 +298,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DictionaryWrapper"
+        # type: (...) -> "_models.DictionaryWrapper"
         """Get complex types with dictionary property while server doesn't provide a response payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -306,7 +306,7 @@ class DictionaryOperations(object):
         :rtype: ~bodycomplex.models.DictionaryWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DictionaryWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DictionaryWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_flattencomplex_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_flattencomplex_operations.py
@@ -49,7 +49,7 @@ class FlattencomplexOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyBaseType"
+        # type: (...) -> "_models.MyBaseType"
         """get_valid.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class FlattencomplexOperations(object):
         :rtype: ~bodycomplex.models.MyBaseType
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyBaseType"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyBaseType"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_flattencomplex_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_flattencomplex_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class FlattencomplexOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_inheritance_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class InheritanceOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class InheritanceOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Siamese', pipeline_response)
@@ -137,7 +137,7 @@ class InheritanceOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_inheritance_operations.py
@@ -80,7 +80,7 @@ class InheritanceOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Siamese', pipeline_response)
@@ -137,7 +137,7 @@ class InheritanceOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_inheritance_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_inheritance_operations.py
@@ -49,7 +49,7 @@ class InheritanceOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Siamese"
+        # type: (...) -> "_models.Siamese"
         """Get complex types that extend others.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class InheritanceOperations(object):
         :rtype: ~bodycomplex.models.Siamese
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Siamese"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Siamese"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -94,7 +94,7 @@ class InheritanceOperations(object):
     @distributed_trace
     def put_valid(
         self,
-        complex_body,  # type: "models.Siamese"
+        complex_body,  # type: "_models.Siamese"
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphicrecursive_operations.py
@@ -49,7 +49,7 @@ class PolymorphicrecursiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Fish"
+        # type: (...) -> "_models.Fish"
         """Get complex types that are polymorphic and have recursive references.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class PolymorphicrecursiveOperations(object):
         :rtype: ~bodycomplex.models.Fish
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Fish"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Fish"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -94,7 +94,7 @@ class PolymorphicrecursiveOperations(object):
     @distributed_trace
     def put_valid(
         self,
-        complex_body,  # type: "models.Fish"
+        complex_body,  # type: "_models.Fish"
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphicrecursive_operations.py
@@ -80,7 +80,7 @@ class PolymorphicrecursiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -187,7 +187,7 @@ class PolymorphicrecursiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphicrecursive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphicrecursive_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PolymorphicrecursiveOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class PolymorphicrecursiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -187,7 +187,7 @@ class PolymorphicrecursiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphism_operations.py
@@ -80,7 +80,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -167,7 +167,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -211,7 +211,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFish', pipeline_response)
@@ -260,7 +260,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -309,7 +309,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -357,7 +357,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -413,7 +413,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -465,7 +465,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -547,7 +547,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphism_operations.py
@@ -49,7 +49,7 @@ class PolymorphismOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Fish"
+        # type: (...) -> "_models.Fish"
         """Get complex types that are polymorphic.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class PolymorphismOperations(object):
         :rtype: ~bodycomplex.models.Fish
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Fish"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Fish"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -94,7 +94,7 @@ class PolymorphismOperations(object):
     @distributed_trace
     def put_valid(
         self,
-        complex_body,  # type: "models.Fish"
+        complex_body,  # type: "_models.Fish"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -180,7 +180,7 @@ class PolymorphismOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DotFish"
+        # type: (...) -> "_models.DotFish"
         """Get complex types that are polymorphic, JSON key contains a dot.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -188,7 +188,7 @@ class PolymorphismOperations(object):
         :rtype: ~bodycomplex.models.DotFish
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DotFish"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DotFish"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -227,7 +227,7 @@ class PolymorphismOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DotFishMarket"
+        # type: (...) -> "_models.DotFishMarket"
         """Get complex object composing a polymorphic scalar property and array property with polymorphic
         element type, with discriminator specified. Deserialization must NOT fail and use the
         discriminator type specified on the wire.
@@ -237,7 +237,7 @@ class PolymorphismOperations(object):
         :rtype: ~bodycomplex.models.DotFishMarket
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DotFishMarket"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DotFishMarket"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -276,7 +276,7 @@ class PolymorphismOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DotFishMarket"
+        # type: (...) -> "_models.DotFishMarket"
         """Get complex object composing a polymorphic scalar property and array property with polymorphic
         element type, without discriminator specified on wire. Deserialization must NOT fail and use
         the explicit type of the property.
@@ -286,7 +286,7 @@ class PolymorphismOperations(object):
         :rtype: ~bodycomplex.models.DotFishMarket
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DotFishMarket"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DotFishMarket"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -325,7 +325,7 @@ class PolymorphismOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Salmon"
+        # type: (...) -> "_models.Salmon"
         """Get complex types that are polymorphic, but not at the root of the hierarchy; also have
         additional properties.
 
@@ -334,7 +334,7 @@ class PolymorphismOperations(object):
         :rtype: ~bodycomplex.models.Salmon
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Salmon"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Salmon"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -371,7 +371,7 @@ class PolymorphismOperations(object):
     @distributed_trace
     def put_complicated(
         self,
-        complex_body,  # type: "models.Salmon"
+        complex_body,  # type: "_models.Salmon"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -424,10 +424,10 @@ class PolymorphismOperations(object):
     @distributed_trace
     def put_missing_discriminator(
         self,
-        complex_body,  # type: "models.Salmon"
+        complex_body,  # type: "_models.Salmon"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Salmon"
+        # type: (...) -> "_models.Salmon"
         """Put complex types that are polymorphic, omitting the discriminator.
 
         :param complex_body:
@@ -437,7 +437,7 @@ class PolymorphismOperations(object):
         :rtype: ~bodycomplex.models.Salmon
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Salmon"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Salmon"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -479,7 +479,7 @@ class PolymorphismOperations(object):
     @distributed_trace
     def put_valid_missing_required(
         self,
-        complex_body,  # type: "models.Fish"
+        complex_body,  # type: "_models.Fish"
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphism_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_polymorphism_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PolymorphismOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Fish', pipeline_response)
@@ -167,7 +167,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -211,7 +211,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFish', pipeline_response)
@@ -260,7 +260,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -309,7 +309,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DotFishMarket', pipeline_response)
@@ -357,7 +357,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -413,7 +413,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -465,7 +465,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Salmon', pipeline_response)
@@ -547,7 +547,7 @@ class PolymorphismOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_primitive_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class PrimitiveOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('IntWrapper', pipeline_response)
@@ -136,7 +136,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -180,7 +180,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('LongWrapper', pipeline_response)
@@ -235,7 +235,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -279,7 +279,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('FloatWrapper', pipeline_response)
@@ -334,7 +334,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -378,7 +378,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DoubleWrapper', pipeline_response)
@@ -434,7 +434,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -478,7 +478,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('BooleanWrapper', pipeline_response)
@@ -533,7 +533,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -577,7 +577,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('StringWrapper', pipeline_response)
@@ -632,7 +632,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -676,7 +676,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DateWrapper', pipeline_response)
@@ -731,7 +731,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -775,7 +775,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DatetimeWrapper', pipeline_response)
@@ -830,7 +830,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -874,7 +874,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Datetimerfc1123Wrapper', pipeline_response)
@@ -930,7 +930,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -974,7 +974,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DurationWrapper', pipeline_response)
@@ -1031,7 +1031,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1075,7 +1075,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ByteWrapper', pipeline_response)
@@ -1132,7 +1132,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_primitive_operations.py
@@ -81,7 +81,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('IntWrapper', pipeline_response)
@@ -136,7 +136,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -180,7 +180,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('LongWrapper', pipeline_response)
@@ -235,7 +235,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -279,7 +279,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('FloatWrapper', pipeline_response)
@@ -334,7 +334,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -378,7 +378,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DoubleWrapper', pipeline_response)
@@ -434,7 +434,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -478,7 +478,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('BooleanWrapper', pipeline_response)
@@ -533,7 +533,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -577,7 +577,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('StringWrapper', pipeline_response)
@@ -632,7 +632,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -676,7 +676,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DateWrapper', pipeline_response)
@@ -731,7 +731,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -775,7 +775,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DatetimeWrapper', pipeline_response)
@@ -830,7 +830,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -874,7 +874,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Datetimerfc1123Wrapper', pipeline_response)
@@ -930,7 +930,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -974,7 +974,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('DurationWrapper', pipeline_response)
@@ -1031,7 +1031,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1075,7 +1075,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ByteWrapper', pipeline_response)
@@ -1132,7 +1132,7 @@ class PrimitiveOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_primitive_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_primitive_operations.py
@@ -50,7 +50,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.IntWrapper"
+        # type: (...) -> "_models.IntWrapper"
         """Get complex types with integer properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -58,7 +58,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.IntWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.IntWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.IntWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -95,7 +95,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_int(
         self,
-        complex_body,  # type: "models.IntWrapper"
+        complex_body,  # type: "_models.IntWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -149,7 +149,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.LongWrapper"
+        # type: (...) -> "_models.LongWrapper"
         """Get complex types with long properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -157,7 +157,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.LongWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.LongWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.LongWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -194,7 +194,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_long(
         self,
-        complex_body,  # type: "models.LongWrapper"
+        complex_body,  # type: "_models.LongWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -248,7 +248,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.FloatWrapper"
+        # type: (...) -> "_models.FloatWrapper"
         """Get complex types with float properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -256,7 +256,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.FloatWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.FloatWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.FloatWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -293,7 +293,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_float(
         self,
-        complex_body,  # type: "models.FloatWrapper"
+        complex_body,  # type: "_models.FloatWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -347,7 +347,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DoubleWrapper"
+        # type: (...) -> "_models.DoubleWrapper"
         """Get complex types with double properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -355,7 +355,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.DoubleWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DoubleWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DoubleWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -392,7 +392,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_double(
         self,
-        complex_body,  # type: "models.DoubleWrapper"
+        complex_body,  # type: "_models.DoubleWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -447,7 +447,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.BooleanWrapper"
+        # type: (...) -> "_models.BooleanWrapper"
         """Get complex types with bool properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -455,7 +455,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.BooleanWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.BooleanWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.BooleanWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -492,7 +492,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_bool(
         self,
-        complex_body,  # type: "models.BooleanWrapper"
+        complex_body,  # type: "_models.BooleanWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -546,7 +546,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.StringWrapper"
+        # type: (...) -> "_models.StringWrapper"
         """Get complex types with string properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -554,7 +554,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.StringWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StringWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StringWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -591,7 +591,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_string(
         self,
-        complex_body,  # type: "models.StringWrapper"
+        complex_body,  # type: "_models.StringWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -645,7 +645,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DateWrapper"
+        # type: (...) -> "_models.DateWrapper"
         """Get complex types with date properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -653,7 +653,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.DateWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DateWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DateWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -690,7 +690,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_date(
         self,
-        complex_body,  # type: "models.DateWrapper"
+        complex_body,  # type: "_models.DateWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -744,7 +744,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DatetimeWrapper"
+        # type: (...) -> "_models.DatetimeWrapper"
         """Get complex types with datetime properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -752,7 +752,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.DatetimeWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DatetimeWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DatetimeWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -789,7 +789,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_date_time(
         self,
-        complex_body,  # type: "models.DatetimeWrapper"
+        complex_body,  # type: "_models.DatetimeWrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -843,7 +843,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Datetimerfc1123Wrapper"
+        # type: (...) -> "_models.Datetimerfc1123Wrapper"
         """Get complex types with datetimeRfc1123 properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -851,7 +851,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.Datetimerfc1123Wrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Datetimerfc1123Wrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Datetimerfc1123Wrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -888,7 +888,7 @@ class PrimitiveOperations(object):
     @distributed_trace
     def put_date_time_rfc1123(
         self,
-        complex_body,  # type: "models.Datetimerfc1123Wrapper"
+        complex_body,  # type: "_models.Datetimerfc1123Wrapper"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -943,7 +943,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.DurationWrapper"
+        # type: (...) -> "_models.DurationWrapper"
         """Get complex types with duration properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -951,7 +951,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.DurationWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.DurationWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.DurationWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1007,7 +1007,7 @@ class PrimitiveOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.DurationWrapper(field=field)
+        _complex_body = _models.DurationWrapper(field=field)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1044,7 +1044,7 @@ class PrimitiveOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ByteWrapper"
+        # type: (...) -> "_models.ByteWrapper"
         """Get complex types with byte properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1052,7 +1052,7 @@ class PrimitiveOperations(object):
         :rtype: ~bodycomplex.models.ByteWrapper
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ByteWrapper"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ByteWrapper"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1108,7 +1108,7 @@ class PrimitiveOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ByteWrapper(field=field)
+        _complex_body = _models.ByteWrapper(field=field)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_readonlyproperty_operations.py
@@ -80,7 +80,7 @@ class ReadonlypropertyOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ReadonlyObj', pipeline_response)
@@ -137,7 +137,7 @@ class ReadonlypropertyOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_readonlyproperty_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ReadonlypropertyOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class ReadonlypropertyOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ReadonlyObj', pipeline_response)
@@ -137,7 +137,7 @@ class ReadonlypropertyOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_readonlyproperty_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/bodycomplex/operations/_readonlyproperty_operations.py
@@ -49,7 +49,7 @@ class ReadonlypropertyOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ReadonlyObj"
+        # type: (...) -> "_models.ReadonlyObj"
         """Get complex types that have readonly properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class ReadonlypropertyOperations(object):
         :rtype: ~bodycomplex.models.ReadonlyObj
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ReadonlyObj"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ReadonlyObj"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -113,7 +113,7 @@ class ReadonlypropertyOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _complex_body = models.ReadonlyObj(size=size)
+        _complex_body = _models.ReadonlyObj(size=size)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/aio/operations/_date_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/aio/operations/_date_operations.py
@@ -76,7 +76,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -122,7 +122,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -168,7 +168,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -214,7 +214,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -268,7 +268,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -365,7 +365,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -408,7 +408,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/aio/operations/_date_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/aio/operations/_date_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class DateOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -122,7 +122,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -168,7 +168,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -214,7 +214,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -268,7 +268,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -365,7 +365,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -408,7 +408,7 @@ class DateOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/operations/_date_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/operations/_date_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class DateOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -128,7 +128,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -175,7 +175,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -222,7 +222,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -277,7 +277,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -376,7 +376,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -420,7 +420,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/operations/_date_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDate/bodydate/operations/_date_operations.py
@@ -81,7 +81,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -128,7 +128,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -175,7 +175,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -222,7 +222,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -277,7 +277,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)
@@ -376,7 +376,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -420,7 +420,7 @@ class DateOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('date', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/aio/operations/_datetime_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/aio/operations/_datetime_operations.py
@@ -76,7 +76,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -122,7 +122,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -168,7 +168,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -214,7 +214,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -268,7 +268,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -322,7 +322,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -365,7 +365,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -411,7 +411,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -460,7 +460,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -514,7 +514,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -557,7 +557,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -603,7 +603,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -657,7 +657,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -700,7 +700,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -746,7 +746,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -800,7 +800,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -843,7 +843,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -897,7 +897,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -940,7 +940,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -994,7 +994,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1037,7 +1037,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -1083,7 +1083,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/aio/operations/_datetime_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/aio/operations/_datetime_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class DatetimeOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -122,7 +122,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -168,7 +168,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -214,7 +214,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -268,7 +268,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -322,7 +322,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -365,7 +365,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -411,7 +411,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -460,7 +460,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -514,7 +514,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -557,7 +557,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -603,7 +603,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -657,7 +657,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -700,7 +700,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -746,7 +746,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -800,7 +800,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -843,7 +843,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -897,7 +897,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -940,7 +940,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -994,7 +994,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1037,7 +1037,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -1083,7 +1083,7 @@ class DatetimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/operations/_datetime_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/operations/_datetime_operations.py
@@ -81,7 +81,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -128,7 +128,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -175,7 +175,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -222,7 +222,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -277,7 +277,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -332,7 +332,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -376,7 +376,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -423,7 +423,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -473,7 +473,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -528,7 +528,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -572,7 +572,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -619,7 +619,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -674,7 +674,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -718,7 +718,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -765,7 +765,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -820,7 +820,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -864,7 +864,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -919,7 +919,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -963,7 +963,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -1018,7 +1018,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1062,7 +1062,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -1109,7 +1109,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/operations/_datetime_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTime/bodydatetime/operations/_datetime_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class DatetimeOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -128,7 +128,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -175,7 +175,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -222,7 +222,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -277,7 +277,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -332,7 +332,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -376,7 +376,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -423,7 +423,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -473,7 +473,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -528,7 +528,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -572,7 +572,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -619,7 +619,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -674,7 +674,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -718,7 +718,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -765,7 +765,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -820,7 +820,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -864,7 +864,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -919,7 +919,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -963,7 +963,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -1018,7 +1018,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1062,7 +1062,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)
@@ -1109,7 +1109,7 @@ class DatetimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('iso-8601', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/aio/operations/_datetimerfc1123_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/aio/operations/_datetimerfc1123_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class Datetimerfc1123Operations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -122,7 +122,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -168,7 +168,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -214,7 +214,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -268,7 +268,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -357,7 +357,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -411,7 +411,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -454,7 +454,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/aio/operations/_datetimerfc1123_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/aio/operations/_datetimerfc1123_operations.py
@@ -76,7 +76,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -122,7 +122,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -168,7 +168,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -214,7 +214,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -268,7 +268,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -357,7 +357,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -411,7 +411,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -454,7 +454,7 @@ class Datetimerfc1123Operations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/operations/_datetimerfc1123_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/operations/_datetimerfc1123_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class Datetimerfc1123Operations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -128,7 +128,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -175,7 +175,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -222,7 +222,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -277,7 +277,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -368,7 +368,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -423,7 +423,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -467,7 +467,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/operations/_datetimerfc1123_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/operations/_datetimerfc1123_operations.py
@@ -81,7 +81,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -128,7 +128,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -175,7 +175,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -222,7 +222,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -277,7 +277,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -368,7 +368,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)
@@ -423,7 +423,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -467,7 +467,7 @@ class Datetimerfc1123Operations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('rfc-1123', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/aio/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/aio/operations/_dictionary_operations.py
@@ -2275,7 +2275,7 @@ class DictionaryOperations:
     async def get_complex_null(
         self,
         **kwargs
-    ) -> Optional[Dict[str, "models.Widget"]]:
+    ) -> Optional[Dict[str, "_models.Widget"]]:
         """Get dictionary of complex type null value.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2283,7 +2283,7 @@ class DictionaryOperations:
         :rtype: dict[str, ~bodydictionary.models.Widget] or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[Dict[str, "models.Widget"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[Dict[str, "_models.Widget"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2321,7 +2321,7 @@ class DictionaryOperations:
     async def get_complex_empty(
         self,
         **kwargs
-    ) -> Dict[str, "models.Widget"]:
+    ) -> Dict[str, "_models.Widget"]:
         """Get empty dictionary of complex type {}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2329,7 +2329,7 @@ class DictionaryOperations:
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2367,7 +2367,7 @@ class DictionaryOperations:
     async def get_complex_item_null(
         self,
         **kwargs
-    ) -> Dict[str, "models.Widget"]:
+    ) -> Dict[str, "_models.Widget"]:
         """Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null,
         "2": {"integer": 5, "string": "6"}}.
 
@@ -2376,7 +2376,7 @@ class DictionaryOperations:
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2414,7 +2414,7 @@ class DictionaryOperations:
     async def get_complex_item_empty(
         self,
         **kwargs
-    ) -> Dict[str, "models.Widget"]:
+    ) -> Dict[str, "_models.Widget"]:
         """Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {},
         "2": {"integer": 5, "string": "6"}}.
 
@@ -2423,7 +2423,7 @@ class DictionaryOperations:
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2461,7 +2461,7 @@ class DictionaryOperations:
     async def get_complex_valid(
         self,
         **kwargs
-    ) -> Dict[str, "models.Widget"]:
+    ) -> Dict[str, "_models.Widget"]:
         """Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
         "string": "4"}, "2": {"integer": 5, "string": "6"}}.
 
@@ -2470,7 +2470,7 @@ class DictionaryOperations:
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2507,7 +2507,7 @@ class DictionaryOperations:
     @distributed_trace_async
     async def put_complex_valid(
         self,
-        array_body: Dict[str, "models.Widget"],
+        array_body: Dict[str, "_models.Widget"],
         **kwargs
     ) -> None:
         """Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1":

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/aio/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/aio/operations/_dictionary_operations.py
@@ -76,7 +76,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -122,7 +122,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -176,7 +176,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -219,7 +219,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -265,7 +265,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -311,7 +311,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -357,7 +357,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -403,7 +403,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -457,7 +457,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -500,7 +500,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -546,7 +546,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -592,7 +592,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -646,7 +646,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -689,7 +689,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -735,7 +735,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -781,7 +781,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -835,7 +835,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -878,7 +878,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -924,7 +924,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -970,7 +970,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1024,7 +1024,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1067,7 +1067,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1113,7 +1113,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1159,7 +1159,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1213,7 +1213,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1256,7 +1256,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1302,7 +1302,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1348,7 +1348,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1402,7 +1402,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1445,7 +1445,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1491,7 +1491,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1537,7 +1537,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1591,7 +1591,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1634,7 +1634,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1680,7 +1680,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1727,7 +1727,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1782,7 +1782,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1825,7 +1825,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1871,7 +1871,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1918,7 +1918,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{rfc-1123}', pipeline_response)
@@ -1973,7 +1973,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2016,7 +2016,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{duration}', pipeline_response)
@@ -2070,7 +2070,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2114,7 +2114,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2169,7 +2169,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2213,7 +2213,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2260,7 +2260,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{base64}', pipeline_response)
@@ -2306,7 +2306,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2352,7 +2352,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2399,7 +2399,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2446,7 +2446,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2493,7 +2493,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2548,7 +2548,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2591,7 +2591,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2637,7 +2637,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2683,7 +2683,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2729,7 +2729,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2776,7 +2776,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2831,7 +2831,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2874,7 +2874,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -2920,7 +2920,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -2967,7 +2967,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3014,7 +3014,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3062,7 +3062,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3118,7 +3118,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/aio/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/aio/operations/_dictionary_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class DictionaryOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -122,7 +122,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -176,7 +176,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -219,7 +219,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -265,7 +265,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -311,7 +311,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -357,7 +357,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -403,7 +403,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -457,7 +457,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -500,7 +500,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -546,7 +546,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -592,7 +592,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -646,7 +646,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -689,7 +689,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -735,7 +735,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -781,7 +781,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -835,7 +835,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -878,7 +878,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -924,7 +924,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -970,7 +970,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1024,7 +1024,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1067,7 +1067,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1113,7 +1113,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1159,7 +1159,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1213,7 +1213,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1256,7 +1256,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1302,7 +1302,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1348,7 +1348,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1402,7 +1402,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1445,7 +1445,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1491,7 +1491,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1537,7 +1537,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1591,7 +1591,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1634,7 +1634,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1680,7 +1680,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1727,7 +1727,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1782,7 +1782,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1825,7 +1825,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1871,7 +1871,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1918,7 +1918,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{rfc-1123}', pipeline_response)
@@ -1973,7 +1973,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2016,7 +2016,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{duration}', pipeline_response)
@@ -2070,7 +2070,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2114,7 +2114,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2169,7 +2169,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2213,7 +2213,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2260,7 +2260,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{base64}', pipeline_response)
@@ -2306,7 +2306,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2352,7 +2352,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2399,7 +2399,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2446,7 +2446,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2493,7 +2493,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2548,7 +2548,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2591,7 +2591,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2637,7 +2637,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2683,7 +2683,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2729,7 +2729,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2776,7 +2776,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2831,7 +2831,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2874,7 +2874,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -2920,7 +2920,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -2967,7 +2967,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3014,7 +3014,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3062,7 +3062,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3118,7 +3118,7 @@ class DictionaryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/_dictionary_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class DictionaryOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -128,7 +128,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -183,7 +183,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -227,7 +227,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -274,7 +274,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -321,7 +321,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -368,7 +368,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -415,7 +415,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -470,7 +470,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -514,7 +514,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -561,7 +561,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -608,7 +608,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -663,7 +663,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -707,7 +707,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -754,7 +754,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -801,7 +801,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -856,7 +856,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -900,7 +900,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -947,7 +947,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -994,7 +994,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1049,7 +1049,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1093,7 +1093,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1140,7 +1140,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1187,7 +1187,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1242,7 +1242,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1286,7 +1286,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1333,7 +1333,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1380,7 +1380,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1435,7 +1435,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1479,7 +1479,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1526,7 +1526,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1573,7 +1573,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1628,7 +1628,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1672,7 +1672,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1719,7 +1719,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1767,7 +1767,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1823,7 +1823,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1867,7 +1867,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1914,7 +1914,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1962,7 +1962,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{rfc-1123}', pipeline_response)
@@ -2018,7 +2018,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2062,7 +2062,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{duration}', pipeline_response)
@@ -2117,7 +2117,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2162,7 +2162,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2218,7 +2218,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2263,7 +2263,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2311,7 +2311,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{base64}', pipeline_response)
@@ -2358,7 +2358,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2405,7 +2405,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2453,7 +2453,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2501,7 +2501,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2549,7 +2549,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2605,7 +2605,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2649,7 +2649,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2696,7 +2696,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2743,7 +2743,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2790,7 +2790,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2838,7 +2838,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2894,7 +2894,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2938,7 +2938,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -2985,7 +2985,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3033,7 +3033,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3081,7 +3081,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3130,7 +3130,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3187,7 +3187,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/_dictionary_operations.py
@@ -2327,7 +2327,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional[Dict[str, "models.Widget"]]
+        # type: (...) -> Optional[Dict[str, "_models.Widget"]]
         """Get dictionary of complex type null value.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2335,7 +2335,7 @@ class DictionaryOperations(object):
         :rtype: dict[str, ~bodydictionary.models.Widget] or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[Dict[str, "models.Widget"]]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional[Dict[str, "_models.Widget"]]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2374,7 +2374,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Dict[str, "models.Widget"]
+        # type: (...) -> Dict[str, "_models.Widget"]
         """Get empty dictionary of complex type {}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -2382,7 +2382,7 @@ class DictionaryOperations(object):
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2421,7 +2421,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Dict[str, "models.Widget"]
+        # type: (...) -> Dict[str, "_models.Widget"]
         """Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null,
         "2": {"integer": 5, "string": "6"}}.
 
@@ -2430,7 +2430,7 @@ class DictionaryOperations(object):
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2469,7 +2469,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Dict[str, "models.Widget"]
+        # type: (...) -> Dict[str, "_models.Widget"]
         """Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {},
         "2": {"integer": 5, "string": "6"}}.
 
@@ -2478,7 +2478,7 @@ class DictionaryOperations(object):
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2517,7 +2517,7 @@ class DictionaryOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Dict[str, "models.Widget"]
+        # type: (...) -> Dict[str, "_models.Widget"]
         """Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
         "string": "4"}, "2": {"integer": 5, "string": "6"}}.
 
@@ -2526,7 +2526,7 @@ class DictionaryOperations(object):
         :rtype: dict[str, ~bodydictionary.models.Widget]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.Widget"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.Widget"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -2563,7 +2563,7 @@ class DictionaryOperations(object):
     @distributed_trace
     def put_complex_valid(
         self,
-        array_body,  # type: Dict[str, "models.Widget"]
+        array_body,  # type: Dict[str, "_models.Widget"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/_dictionary_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/bodydictionary/operations/_dictionary_operations.py
@@ -81,7 +81,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -128,7 +128,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -183,7 +183,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -227,7 +227,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -274,7 +274,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -321,7 +321,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -368,7 +368,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -415,7 +415,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -470,7 +470,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -514,7 +514,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -561,7 +561,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bool}', pipeline_response)
@@ -608,7 +608,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -663,7 +663,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -707,7 +707,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -754,7 +754,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -801,7 +801,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -856,7 +856,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -900,7 +900,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -947,7 +947,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{long}', pipeline_response)
@@ -994,7 +994,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1049,7 +1049,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1093,7 +1093,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1140,7 +1140,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1187,7 +1187,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1242,7 +1242,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1286,7 +1286,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1333,7 +1333,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{float}', pipeline_response)
@@ -1380,7 +1380,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1435,7 +1435,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1479,7 +1479,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1526,7 +1526,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{str}', pipeline_response)
@@ -1573,7 +1573,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1628,7 +1628,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1672,7 +1672,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1719,7 +1719,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{date}', pipeline_response)
@@ -1767,7 +1767,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1823,7 +1823,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1867,7 +1867,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1914,7 +1914,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{iso-8601}', pipeline_response)
@@ -1962,7 +1962,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{rfc-1123}', pipeline_response)
@@ -2018,7 +2018,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2062,7 +2062,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{duration}', pipeline_response)
@@ -2117,7 +2117,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2162,7 +2162,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2218,7 +2218,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2263,7 +2263,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{bytearray}', pipeline_response)
@@ -2311,7 +2311,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{base64}', pipeline_response)
@@ -2358,7 +2358,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2405,7 +2405,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2453,7 +2453,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2501,7 +2501,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2549,7 +2549,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{Widget}', pipeline_response)
@@ -2605,7 +2605,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2649,7 +2649,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2696,7 +2696,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2743,7 +2743,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2790,7 +2790,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2838,7 +2838,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{[str]}', pipeline_response)
@@ -2894,7 +2894,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -2938,7 +2938,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -2985,7 +2985,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3033,7 +3033,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3081,7 +3081,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3130,7 +3130,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{object}', pipeline_response)
@@ -3187,7 +3187,7 @@ class DictionaryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/aio/operations/_duration_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/aio/operations/_duration_operations.py
@@ -76,7 +76,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -130,7 +130,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -173,7 +173,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -219,7 +219,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/aio/operations/_duration_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/aio/operations/_duration_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class DurationOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -130,7 +130,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -173,7 +173,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -219,7 +219,7 @@ class DurationOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/operations/_duration_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/operations/_duration_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class DurationOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -136,7 +136,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -180,7 +180,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -227,7 +227,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/operations/_duration_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDuration/bodyduration/operations/_duration_operations.py
@@ -81,7 +81,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -136,7 +136,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -180,7 +180,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)
@@ -227,7 +227,7 @@ class DurationOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('duration', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/aio/operations/_files_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/aio/operations/_files_operations.py
@@ -75,7 +75,7 @@ class FilesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -121,7 +121,7 @@ class FilesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -167,7 +167,7 @@ class FilesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/aio/operations/_files_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/aio/operations/_files_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class FilesOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class FilesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -121,7 +121,7 @@ class FilesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -167,7 +167,7 @@ class FilesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/operations/_files_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/operations/_files_operations.py
@@ -80,7 +80,7 @@ class FilesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -127,7 +127,7 @@ class FilesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -174,7 +174,7 @@ class FilesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/operations/_files_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFile/bodyfile/operations/_files_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class FilesOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class FilesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -127,7 +127,7 @@ class FilesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -174,7 +174,7 @@ class FilesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/aio/operations/_formdata_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/aio/operations/_formdata_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class FormdataOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -88,7 +88,7 @@ class FormdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -141,7 +141,7 @@ class FormdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -196,7 +196,7 @@ class FormdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/aio/operations/_formdata_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/aio/operations/_formdata_operations.py
@@ -88,7 +88,7 @@ class FormdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -141,7 +141,7 @@ class FormdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -196,7 +196,7 @@ class FormdataOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/operations/_formdata_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/operations/_formdata_operations.py
@@ -93,7 +93,7 @@ class FormdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -147,7 +147,7 @@ class FormdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -203,7 +203,7 @@ class FormdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/operations/_formdata_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFormData/bodyformdata/operations/_formdata_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class FormdataOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -93,7 +93,7 @@ class FormdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -147,7 +147,7 @@ class FormdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)
@@ -203,7 +203,7 @@ class FormdataOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = response.stream_download(self._client._pipeline)

--- a/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/aio/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/aio/operations/_int_operations.py
@@ -76,7 +76,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -122,7 +122,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -168,7 +168,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -214,7 +214,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -260,7 +260,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -306,7 +306,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -360,7 +360,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -462,7 +462,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -513,7 +513,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -556,7 +556,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -610,7 +610,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -653,7 +653,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -699,7 +699,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/aio/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/aio/operations/_int_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class IntOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -122,7 +122,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -168,7 +168,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -214,7 +214,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -260,7 +260,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -306,7 +306,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -360,7 +360,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -462,7 +462,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -513,7 +513,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -556,7 +556,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -610,7 +610,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -653,7 +653,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -699,7 +699,7 @@ class IntOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/operations/_int_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class IntOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -128,7 +128,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -175,7 +175,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -222,7 +222,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -269,7 +269,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -316,7 +316,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -371,7 +371,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -423,7 +423,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -475,7 +475,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -527,7 +527,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -571,7 +571,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -626,7 +626,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -670,7 +670,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -717,7 +717,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyInteger/bodyinteger/operations/_int_operations.py
@@ -81,7 +81,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -128,7 +128,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -175,7 +175,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -222,7 +222,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('int', pipeline_response)
@@ -269,7 +269,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -316,7 +316,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('long', pipeline_response)
@@ -371,7 +371,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -423,7 +423,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -475,7 +475,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -527,7 +527,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -571,7 +571,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -626,7 +626,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -670,7 +670,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)
@@ -717,7 +717,7 @@ class IntOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('unix-time', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/aio/operations/_number_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/aio/operations/_number_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class NumberOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -121,7 +121,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -167,7 +167,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -213,7 +213,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -267,7 +267,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -310,7 +310,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -364,7 +364,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -407,7 +407,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -459,7 +459,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -502,7 +502,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -554,7 +554,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -597,7 +597,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -651,7 +651,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -694,7 +694,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -746,7 +746,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -789,7 +789,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -841,7 +841,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -884,7 +884,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -938,7 +938,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -981,7 +981,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1035,7 +1035,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1078,7 +1078,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1132,7 +1132,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1175,7 +1175,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/aio/operations/_number_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/aio/operations/_number_operations.py
@@ -75,7 +75,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -121,7 +121,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -167,7 +167,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -213,7 +213,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -267,7 +267,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -310,7 +310,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -364,7 +364,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -407,7 +407,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -459,7 +459,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -502,7 +502,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -554,7 +554,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -597,7 +597,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -651,7 +651,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -694,7 +694,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -746,7 +746,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -789,7 +789,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -841,7 +841,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -884,7 +884,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -938,7 +938,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -981,7 +981,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1035,7 +1035,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1078,7 +1078,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1132,7 +1132,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1175,7 +1175,7 @@ class NumberOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/operations/_number_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/operations/_number_operations.py
@@ -80,7 +80,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -127,7 +127,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -174,7 +174,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -221,7 +221,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -276,7 +276,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -320,7 +320,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -375,7 +375,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -419,7 +419,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -472,7 +472,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -516,7 +516,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -569,7 +569,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -613,7 +613,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -668,7 +668,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -712,7 +712,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -765,7 +765,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -809,7 +809,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -862,7 +862,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -906,7 +906,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -961,7 +961,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1005,7 +1005,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1060,7 +1060,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1104,7 +1104,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1159,7 +1159,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1203,7 +1203,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/operations/_number_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyNumber/bodynumber/operations/_number_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class NumberOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -127,7 +127,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -174,7 +174,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -221,7 +221,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -276,7 +276,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -320,7 +320,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -375,7 +375,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -419,7 +419,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -472,7 +472,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -516,7 +516,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -569,7 +569,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -613,7 +613,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -668,7 +668,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -712,7 +712,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -765,7 +765,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -809,7 +809,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -862,7 +862,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -906,7 +906,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -961,7 +961,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1005,7 +1005,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1060,7 +1060,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1104,7 +1104,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)
@@ -1159,7 +1159,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1203,7 +1203,7 @@ class NumberOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('float', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_enum_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class EnumOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -129,7 +129,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -172,7 +172,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -226,7 +226,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -269,7 +269,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('RefColorConstant', pipeline_response)
@@ -325,7 +325,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_enum_operations.py
@@ -75,7 +75,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -129,7 +129,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -172,7 +172,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -226,7 +226,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -269,7 +269,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('RefColorConstant', pipeline_response)
@@ -325,7 +325,7 @@ class EnumOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_enum_operations.py
@@ -44,7 +44,7 @@ class EnumOperations:
     async def get_not_expandable(
         self,
         **kwargs
-    ) -> Union[str, "models.Colors"]:
+    ) -> Union[str, "_models.Colors"]:
         """Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class EnumOperations:
         :rtype: str or ~bodystring.models.Colors
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "models.Colors"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "_models.Colors"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -89,7 +89,7 @@ class EnumOperations:
     @distributed_trace_async
     async def put_not_expandable(
         self,
-        string_body: Union[str, "models.Colors"],
+        string_body: Union[str, "_models.Colors"],
         **kwargs
     ) -> None:
         """Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -141,7 +141,7 @@ class EnumOperations:
     async def get_referenced(
         self,
         **kwargs
-    ) -> Union[str, "models.Colors"]:
+    ) -> Union[str, "_models.Colors"]:
         """Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -149,7 +149,7 @@ class EnumOperations:
         :rtype: str or ~bodystring.models.Colors
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "models.Colors"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "_models.Colors"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -186,7 +186,7 @@ class EnumOperations:
     @distributed_trace_async
     async def put_referenced(
         self,
-        enum_string_body: Union[str, "models.Colors"],
+        enum_string_body: Union[str, "_models.Colors"],
         **kwargs
     ) -> None:
         """Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -238,7 +238,7 @@ class EnumOperations:
     async def get_referenced_constant(
         self,
         **kwargs
-    ) -> "models.RefColorConstant":
+    ) -> "_models.RefColorConstant":
         """Get value 'green-color' from the constant.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -246,7 +246,7 @@ class EnumOperations:
         :rtype: ~bodystring.models.RefColorConstant
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.RefColorConstant"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.RefColorConstant"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -301,7 +301,7 @@ class EnumOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _enum_string_body = models.RefColorConstant(field1=field1)
+        _enum_string_body = _models.RefColorConstant(field1=field1)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_string_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class StringOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -132,7 +132,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -175,7 +175,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -227,7 +227,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -270,7 +270,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -322,7 +322,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -367,7 +367,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -421,7 +421,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -464,7 +464,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -510,7 +510,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -556,7 +556,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)
@@ -610,7 +610,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -653,7 +653,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/aio/operations/_string_operations.py
@@ -75,7 +75,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -132,7 +132,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -175,7 +175,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -227,7 +227,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -270,7 +270,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -322,7 +322,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -367,7 +367,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -421,7 +421,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -464,7 +464,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -510,7 +510,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -556,7 +556,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)
@@ -610,7 +610,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -653,7 +653,7 @@ class StringOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_enum_operations.py
@@ -80,7 +80,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -135,7 +135,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -179,7 +179,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -234,7 +234,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -278,7 +278,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('RefColorConstant', pipeline_response)
@@ -335,7 +335,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_enum_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class EnumOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -135,7 +135,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -179,7 +179,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -234,7 +234,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -278,7 +278,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('RefColorConstant', pipeline_response)
@@ -335,7 +335,7 @@ class EnumOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_enum_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_enum_operations.py
@@ -49,7 +49,7 @@ class EnumOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union[str, "models.Colors"]
+        # type: (...) -> Union[str, "_models.Colors"]
         """Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class EnumOperations(object):
         :rtype: str or ~bodystring.models.Colors
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "models.Colors"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "_models.Colors"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -94,7 +94,7 @@ class EnumOperations(object):
     @distributed_trace
     def put_not_expandable(
         self,
-        string_body,  # type: Union[str, "models.Colors"]
+        string_body,  # type: Union[str, "_models.Colors"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -148,7 +148,7 @@ class EnumOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union[str, "models.Colors"]
+        # type: (...) -> Union[str, "_models.Colors"]
         """Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -156,7 +156,7 @@ class EnumOperations(object):
         :rtype: str or ~bodystring.models.Colors
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "models.Colors"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[str, "_models.Colors"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -193,7 +193,7 @@ class EnumOperations(object):
     @distributed_trace
     def put_referenced(
         self,
-        enum_string_body,  # type: Union[str, "models.Colors"]
+        enum_string_body,  # type: Union[str, "_models.Colors"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -247,7 +247,7 @@ class EnumOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.RefColorConstant"
+        # type: (...) -> "_models.RefColorConstant"
         """Get value 'green-color' from the constant.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -255,7 +255,7 @@ class EnumOperations(object):
         :rtype: ~bodystring.models.RefColorConstant
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.RefColorConstant"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.RefColorConstant"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -311,7 +311,7 @@ class EnumOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _enum_string_body = models.RefColorConstant(field1=field1)
+        _enum_string_body = _models.RefColorConstant(field1=field1)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
@@ -80,7 +80,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -138,7 +138,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -182,7 +182,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -235,7 +235,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -279,7 +279,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -332,7 +332,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -378,7 +378,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -433,7 +433,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -477,7 +477,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -524,7 +524,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -571,7 +571,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)
@@ -626,7 +626,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -670,7 +670,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/bodystring/operations/_string_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class StringOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -138,7 +138,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -182,7 +182,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -235,7 +235,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -279,7 +279,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -332,7 +332,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -378,7 +378,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -433,7 +433,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -477,7 +477,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)
@@ -524,7 +524,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bytearray', pipeline_response)
@@ -571,7 +571,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)
@@ -626,7 +626,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -670,7 +670,7 @@ class StringOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('base64', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/aio/operations/_time_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/aio/operations/_time_operations.py
@@ -76,7 +76,7 @@ class TimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('time', pipeline_response)
@@ -130,7 +130,7 @@ class TimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/aio/operations/_time_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/aio/operations/_time_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class TimeOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -76,7 +76,7 @@ class TimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('time', pipeline_response)
@@ -130,7 +130,7 @@ class TimeOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/operations/_time_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/operations/_time_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class TimeOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -81,7 +81,7 @@ class TimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('time', pipeline_response)
@@ -136,7 +136,7 @@ class TimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/operations/_time_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/BodyTime/bodytime/operations/_time_operations.py
@@ -81,7 +81,7 @@ class TimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('time', pipeline_response)
@@ -136,7 +136,7 @@ class TimeOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('str', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Constants/constants/aio/operations/_contants_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Constants/constants/aio/operations/_contants_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ContantsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/Constants/constants/aio/operations/_contants_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Constants/constants/aio/operations/_contants_operations.py
@@ -43,7 +43,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_no_model_as_string_no_required_two_value_no_default(
         self,
-        input: Optional[Union[str, "models.NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]] = None,
+        input: Optional[Union[str, "_models.NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]] = None,
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -90,7 +90,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_no_model_as_string_no_required_two_value_default(
         self,
-        input: Optional[Union[str, "models.NoModelAsStringNoRequiredTwoValueDefaultOpEnum"]] = "value1",
+        input: Optional[Union[str, "_models.NoModelAsStringNoRequiredTwoValueDefaultOpEnum"]] = "value1",
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -231,7 +231,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_no_model_as_string_required_two_value_no_default(
         self,
-        input: Union[str, "models.NoModelAsStringRequiredTwoValueNoDefaultOpEnum"],
+        input: Union[str, "_models.NoModelAsStringRequiredTwoValueNoDefaultOpEnum"],
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -277,7 +277,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_no_model_as_string_required_two_value_default(
         self,
-        input: Union[str, "models.NoModelAsStringRequiredTwoValueDefaultOpEnum"] = "value1",
+        input: Union[str, "_models.NoModelAsStringRequiredTwoValueDefaultOpEnum"] = "value1",
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -411,7 +411,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_no_required_two_value_no_default(
         self,
-        input: Optional[Union[str, "models.ModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]] = None,
+        input: Optional[Union[str, "_models.ModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]] = None,
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -458,7 +458,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_no_required_two_value_default(
         self,
-        input: Optional[Union[str, "models.ModelAsStringNoRequiredTwoValueDefaultOpEnum"]] = "value1",
+        input: Optional[Union[str, "_models.ModelAsStringNoRequiredTwoValueDefaultOpEnum"]] = "value1",
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -505,7 +505,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_no_required_one_value_no_default(
         self,
-        input: Optional[Union[str, "models.ModelAsStringNoRequiredOneValueNoDefaultOpEnum"]] = None,
+        input: Optional[Union[str, "_models.ModelAsStringNoRequiredOneValueNoDefaultOpEnum"]] = None,
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -552,7 +552,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_no_required_one_value_default(
         self,
-        input: Optional[Union[str, "models.ModelAsStringNoRequiredOneValueDefaultOpEnum"]] = "value1",
+        input: Optional[Union[str, "_models.ModelAsStringNoRequiredOneValueDefaultOpEnum"]] = "value1",
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -599,7 +599,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_required_two_value_no_default(
         self,
-        input: Union[str, "models.ModelAsStringRequiredTwoValueNoDefaultOpEnum"],
+        input: Union[str, "_models.ModelAsStringRequiredTwoValueNoDefaultOpEnum"],
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -645,7 +645,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_required_two_value_default(
         self,
-        input: Union[str, "models.ModelAsStringRequiredTwoValueDefaultOpEnum"] = "value1",
+        input: Union[str, "_models.ModelAsStringRequiredTwoValueDefaultOpEnum"] = "value1",
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -691,7 +691,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_required_one_value_no_default(
         self,
-        input: Union[str, "models.ModelAsStringRequiredOneValueNoDefaultOpEnum"],
+        input: Union[str, "_models.ModelAsStringRequiredOneValueNoDefaultOpEnum"],
         **kwargs
     ) -> None:
         """Puts constants to the testserver.
@@ -737,7 +737,7 @@ class ContantsOperations:
     @distributed_trace_async
     async def put_model_as_string_required_one_value_default(
         self,
-        input: Union[str, "models.ModelAsStringRequiredOneValueDefaultOpEnum"] = "value1",
+        input: Union[str, "_models.ModelAsStringRequiredOneValueDefaultOpEnum"] = "value1",
         **kwargs
     ) -> None:
         """Puts constants to the testserver.

--- a/test/vanilla/Expected/AcceptanceTests/Constants/constants/operations/_contants_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Constants/constants/operations/_contants_operations.py
@@ -47,7 +47,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_no_model_as_string_no_required_two_value_no_default(
         self,
-        input=None,  # type: Optional[Union[str, "models.NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]]
+        input=None,  # type: Optional[Union[str, "_models.NoModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -95,7 +95,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_no_model_as_string_no_required_two_value_default(
         self,
-        input="value1",  # type: Optional[Union[str, "models.NoModelAsStringNoRequiredTwoValueDefaultOpEnum"]]
+        input="value1",  # type: Optional[Union[str, "_models.NoModelAsStringNoRequiredTwoValueDefaultOpEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -239,7 +239,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_no_model_as_string_required_two_value_no_default(
         self,
-        input,  # type: Union[str, "models.NoModelAsStringRequiredTwoValueNoDefaultOpEnum"]
+        input,  # type: Union[str, "_models.NoModelAsStringRequiredTwoValueNoDefaultOpEnum"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -286,7 +286,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_no_model_as_string_required_two_value_default(
         self,
-        input="value1",  # type: Union[str, "models.NoModelAsStringRequiredTwoValueDefaultOpEnum"]
+        input="value1",  # type: Union[str, "_models.NoModelAsStringRequiredTwoValueDefaultOpEnum"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -423,7 +423,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_no_required_two_value_no_default(
         self,
-        input=None,  # type: Optional[Union[str, "models.ModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]]
+        input=None,  # type: Optional[Union[str, "_models.ModelAsStringNoRequiredTwoValueNoDefaultOpEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -471,7 +471,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_no_required_two_value_default(
         self,
-        input="value1",  # type: Optional[Union[str, "models.ModelAsStringNoRequiredTwoValueDefaultOpEnum"]]
+        input="value1",  # type: Optional[Union[str, "_models.ModelAsStringNoRequiredTwoValueDefaultOpEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -519,7 +519,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_no_required_one_value_no_default(
         self,
-        input=None,  # type: Optional[Union[str, "models.ModelAsStringNoRequiredOneValueNoDefaultOpEnum"]]
+        input=None,  # type: Optional[Union[str, "_models.ModelAsStringNoRequiredOneValueNoDefaultOpEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -567,7 +567,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_no_required_one_value_default(
         self,
-        input="value1",  # type: Optional[Union[str, "models.ModelAsStringNoRequiredOneValueDefaultOpEnum"]]
+        input="value1",  # type: Optional[Union[str, "_models.ModelAsStringNoRequiredOneValueDefaultOpEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -615,7 +615,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_required_two_value_no_default(
         self,
-        input,  # type: Union[str, "models.ModelAsStringRequiredTwoValueNoDefaultOpEnum"]
+        input,  # type: Union[str, "_models.ModelAsStringRequiredTwoValueNoDefaultOpEnum"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -662,7 +662,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_required_two_value_default(
         self,
-        input="value1",  # type: Union[str, "models.ModelAsStringRequiredTwoValueDefaultOpEnum"]
+        input="value1",  # type: Union[str, "_models.ModelAsStringRequiredTwoValueDefaultOpEnum"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -709,7 +709,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_required_one_value_no_default(
         self,
-        input,  # type: Union[str, "models.ModelAsStringRequiredOneValueNoDefaultOpEnum"]
+        input,  # type: Union[str, "_models.ModelAsStringRequiredOneValueNoDefaultOpEnum"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -756,7 +756,7 @@ class ContantsOperations(object):
     @distributed_trace
     def put_model_as_string_required_one_value_default(
         self,
-        input="value1",  # type: Union[str, "models.ModelAsStringRequiredOneValueDefaultOpEnum"]
+        input="value1",  # type: Union[str, "_models.ModelAsStringRequiredOneValueDefaultOpEnum"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/Constants/constants/operations/_contants_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Constants/constants/operations/_contants_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ContantsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
@@ -83,7 +83,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/aio/operations/_paths_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PathsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -83,7 +83,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PathsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -88,7 +88,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/custombaseurl/operations/_paths_operations.py
@@ -88,7 +88,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/aio/operations/_paths_operations.py
@@ -97,7 +97,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/aio/operations/_paths_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PathsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -97,7 +97,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/operations/_paths_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PathsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -102,7 +102,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/operations/_paths_operations.py
@@ -102,7 +102,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/aio/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/aio/operations/_pet_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PetOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/aio/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/aio/operations/_pet_operations.py
@@ -45,7 +45,7 @@ class PetOperations:
         self,
         pet_id: str,
         **kwargs
-    ) -> "models.Pet":
+    ) -> "_models.Pet":
         """get pet by id.
 
         :param pet_id: Pet id.
@@ -55,7 +55,7 @@ class PetOperations:
         :rtype: ~extensibleenumsswagger.models.Pet
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Pet"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Pet"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -95,9 +95,9 @@ class PetOperations:
     @distributed_trace_async
     async def add_pet(
         self,
-        pet_param: Optional["models.Pet"] = None,
+        pet_param: Optional["_models.Pet"] = None,
         **kwargs
-    ) -> "models.Pet":
+    ) -> "_models.Pet":
         """add pet.
 
         :param pet_param: pet param.
@@ -107,7 +107,7 @@ class PetOperations:
         :rtype: ~extensibleenumsswagger.models.Pet
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Pet"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Pet"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/operations/_pet_operations.py
@@ -50,7 +50,7 @@ class PetOperations(object):
         pet_id,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Pet"
+        # type: (...) -> "_models.Pet"
         """get pet by id.
 
         :param pet_id: Pet id.
@@ -60,7 +60,7 @@ class PetOperations(object):
         :rtype: ~extensibleenumsswagger.models.Pet
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Pet"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Pet"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -100,10 +100,10 @@ class PetOperations(object):
     @distributed_trace
     def add_pet(
         self,
-        pet_param=None,  # type: Optional["models.Pet"]
+        pet_param=None,  # type: Optional["_models.Pet"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Pet"
+        # type: (...) -> "_models.Pet"
         """add pet.
 
         :param pet_param: pet param.
@@ -113,7 +113,7 @@ class PetOperations(object):
         :rtype: ~extensibleenumsswagger.models.Pet
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Pet"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Pet"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/operations/_pet_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PetOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/aio/operations/_header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/aio/operations/_header_operations.py
@@ -80,7 +80,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -123,7 +123,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -173,7 +173,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -216,7 +216,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -271,7 +271,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -318,7 +318,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -373,7 +373,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -420,7 +420,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -475,7 +475,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -522,7 +522,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -577,7 +577,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -624,7 +624,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -679,7 +679,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -726,7 +726,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -784,7 +784,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -832,7 +832,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -887,7 +887,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -934,7 +934,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -990,7 +990,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1037,7 +1037,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1094,7 +1094,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1142,7 +1142,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1196,7 +1196,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1243,7 +1243,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1297,7 +1297,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1344,7 +1344,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1401,7 +1401,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1449,7 +1449,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1496,7 +1496,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/aio/operations/_header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/aio/operations/_header_operations.py
@@ -1359,7 +1359,7 @@ class HeaderOperations:
     async def param_enum(
         self,
         scenario: str,
-        value: Optional[Union[str, "models.GreyscaleColors"]] = None,
+        value: Optional[Union[str, "_models.GreyscaleColors"]] = None,
         **kwargs
     ) -> None:
         """Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario":

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/aio/operations/_header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/aio/operations/_header_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class HeaderOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -80,7 +80,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -123,7 +123,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -173,7 +173,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -216,7 +216,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -271,7 +271,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -318,7 +318,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -373,7 +373,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -420,7 +420,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -475,7 +475,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -522,7 +522,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -577,7 +577,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -624,7 +624,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -679,7 +679,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -726,7 +726,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -784,7 +784,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -832,7 +832,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -887,7 +887,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -934,7 +934,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -990,7 +990,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1037,7 +1037,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1094,7 +1094,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1142,7 +1142,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1196,7 +1196,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1243,7 +1243,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1297,7 +1297,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1344,7 +1344,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1401,7 +1401,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1449,7 +1449,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1496,7 +1496,7 @@ class HeaderOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/operations/_header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/operations/_header_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class HeaderOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -180,7 +180,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -224,7 +224,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -280,7 +280,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -328,7 +328,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -384,7 +384,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -432,7 +432,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -488,7 +488,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -536,7 +536,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -592,7 +592,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -640,7 +640,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -696,7 +696,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -744,7 +744,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -803,7 +803,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -852,7 +852,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -908,7 +908,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -956,7 +956,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1013,7 +1013,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1061,7 +1061,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1119,7 +1119,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1168,7 +1168,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1223,7 +1223,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1271,7 +1271,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1326,7 +1326,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1374,7 +1374,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1432,7 +1432,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1481,7 +1481,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1529,7 +1529,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/operations/_header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/operations/_header_operations.py
@@ -85,7 +85,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -180,7 +180,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -224,7 +224,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -280,7 +280,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -328,7 +328,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -384,7 +384,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -432,7 +432,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -488,7 +488,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -536,7 +536,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -592,7 +592,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -640,7 +640,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -696,7 +696,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -744,7 +744,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -803,7 +803,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -852,7 +852,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -908,7 +908,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -956,7 +956,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1013,7 +1013,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1061,7 +1061,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1119,7 +1119,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1168,7 +1168,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1223,7 +1223,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1271,7 +1271,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1326,7 +1326,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1374,7 +1374,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1432,7 +1432,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1481,7 +1481,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -1529,7 +1529,7 @@ class HeaderOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Header/header/operations/_header_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Header/header/operations/_header_operations.py
@@ -1389,7 +1389,7 @@ class HeaderOperations(object):
     def param_enum(
         self,
         scenario,  # type: str
-        value=None,  # type: Optional[Union[str, "models.GreyscaleColors"]]
+        value=None,  # type: Optional[Union[str, "_models.GreyscaleColors"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_client_failure_operations.py
@@ -75,7 +75,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -118,7 +118,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -161,7 +161,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -215,7 +215,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -269,7 +269,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -323,7 +323,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -377,7 +377,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -420,7 +420,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -463,7 +463,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -506,7 +506,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -549,7 +549,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -603,7 +603,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -657,7 +657,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -711,7 +711,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -765,7 +765,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -819,7 +819,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -862,7 +862,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -905,7 +905,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -948,7 +948,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -991,7 +991,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1045,7 +1045,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1099,7 +1099,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1153,7 +1153,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1196,7 +1196,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1250,7 +1250,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1293,7 +1293,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_client_failure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class HttpClientFailureOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -118,7 +118,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -161,7 +161,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -215,7 +215,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -269,7 +269,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -323,7 +323,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -377,7 +377,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -420,7 +420,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -463,7 +463,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -506,7 +506,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -549,7 +549,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -603,7 +603,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -657,7 +657,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -711,7 +711,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -765,7 +765,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -819,7 +819,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -862,7 +862,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -905,7 +905,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -948,7 +948,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -991,7 +991,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1045,7 +1045,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1099,7 +1099,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1153,7 +1153,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1196,7 +1196,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1250,7 +1250,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1293,7 +1293,7 @@ class HttpClientFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_failure_operations.py
@@ -75,7 +75,7 @@ class HttpFailureOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_failure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class HttpFailureOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class HttpFailureOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_redirects_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class HttpRedirectsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -122,7 +122,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -172,7 +172,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -219,7 +219,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -278,7 +278,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -324,7 +324,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -371,7 +371,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -430,7 +430,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -488,7 +488,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 303]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -535,7 +535,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -582,7 +582,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -629,7 +629,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -687,7 +687,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -745,7 +745,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -803,7 +803,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -861,7 +861,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_redirects_operations.py
@@ -75,7 +75,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -122,7 +122,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -172,7 +172,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -219,7 +219,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -278,7 +278,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -324,7 +324,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -371,7 +371,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -430,7 +430,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -488,7 +488,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 303]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -535,7 +535,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -582,7 +582,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -629,7 +629,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -687,7 +687,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -745,7 +745,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -803,7 +803,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -861,7 +861,7 @@ class HttpRedirectsOperations:
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_retry_operations.py
@@ -75,7 +75,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -183,7 +183,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -226,7 +226,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -269,7 +269,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -326,7 +326,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -380,7 +380,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -434,7 +434,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -488,7 +488,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_retry_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class HttpRetryOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -183,7 +183,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -226,7 +226,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -269,7 +269,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -326,7 +326,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -380,7 +380,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -434,7 +434,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -488,7 +488,7 @@ class HttpRetryOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_server_failure_operations.py
@@ -75,7 +75,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -118,7 +118,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -172,7 +172,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -226,7 +226,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_server_failure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class HttpServerFailureOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -118,7 +118,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -172,7 +172,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -226,7 +226,7 @@ class HttpServerFailureOperations:
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_success_operations.py
@@ -75,7 +75,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -118,7 +118,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -164,7 +164,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -221,7 +221,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -275,7 +275,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -329,7 +329,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -383,7 +383,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -437,7 +437,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -491,7 +491,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -545,7 +545,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -599,7 +599,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -653,7 +653,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -707,7 +707,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -750,7 +750,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -804,7 +804,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -858,7 +858,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -912,7 +912,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -966,7 +966,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1009,7 +1009,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_http_success_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class HttpSuccessOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -118,7 +118,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -164,7 +164,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -221,7 +221,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -275,7 +275,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -329,7 +329,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -383,7 +383,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -437,7 +437,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -491,7 +491,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -545,7 +545,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -599,7 +599,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -653,7 +653,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -707,7 +707,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -750,7 +750,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -804,7 +804,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -858,7 +858,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -912,7 +912,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -966,7 +966,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1009,7 +1009,7 @@ class HttpSuccessOperations:
 
         if response.status_code not in [204, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_multiple_responses_operations.py
@@ -44,7 +44,7 @@ class MultipleResponsesOperations:
     async def get200_model204_no_model_default_error200_valid(
         self,
         **kwargs
-    ) -> Optional["models.MyException"]:
+    ) -> Optional["_models.MyException"]:
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -92,7 +92,7 @@ class MultipleResponsesOperations:
     async def get200_model204_no_model_default_error204_valid(
         self,
         **kwargs
-    ) -> Optional["models.MyException"]:
+    ) -> Optional["_models.MyException"]:
         """Send a 204 response with no payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -100,7 +100,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -140,7 +140,7 @@ class MultipleResponsesOperations:
     async def get200_model204_no_model_default_error201_invalid(
         self,
         **kwargs
-    ) -> Optional["models.MyException"]:
+    ) -> Optional["_models.MyException"]:
         """Send a 201 response with valid payload: {'statusCode': '201'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -148,7 +148,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -188,7 +188,7 @@ class MultipleResponsesOperations:
     async def get200_model204_no_model_default_error202_none(
         self,
         **kwargs
-    ) -> Optional["models.MyException"]:
+    ) -> Optional["_models.MyException"]:
         """Send a 202 response with no payload:.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -196,7 +196,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -236,7 +236,7 @@ class MultipleResponsesOperations:
     async def get200_model204_no_model_default_error400_valid(
         self,
         **kwargs
-    ) -> Optional["models.MyException"]:
+    ) -> Optional["_models.MyException"]:
         """Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -244,7 +244,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -284,7 +284,7 @@ class MultipleResponsesOperations:
     async def get200_model201_model_default_error200_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.B"]:
+    ) -> Union["_models.MyException", "_models.B"]:
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -292,7 +292,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.B
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.B"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.B"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -334,7 +334,7 @@ class MultipleResponsesOperations:
     async def get200_model201_model_default_error201_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.B"]:
+    ) -> Union["_models.MyException", "_models.B"]:
         """Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -342,7 +342,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.B
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.B"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.B"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -384,7 +384,7 @@ class MultipleResponsesOperations:
     async def get200_model201_model_default_error400_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.B"]:
+    ) -> Union["_models.MyException", "_models.B"]:
         """Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -392,7 +392,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.B
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.B"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.B"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -434,7 +434,7 @@ class MultipleResponsesOperations:
     async def get200_model_a201_model_c404_model_d_default_error200_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.C", "models.D"]:
+    ) -> Union["_models.MyException", "_models.C", "_models.D"]:
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -442,7 +442,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -487,7 +487,7 @@ class MultipleResponsesOperations:
     async def get200_model_a201_model_c404_model_d_default_error201_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.C", "models.D"]:
+    ) -> Union["_models.MyException", "_models.C", "_models.D"]:
         """Send a 200 response with valid payload: {'httpCode': '201'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -495,7 +495,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -540,7 +540,7 @@ class MultipleResponsesOperations:
     async def get200_model_a201_model_c404_model_d_default_error404_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.C", "models.D"]:
+    ) -> Union["_models.MyException", "_models.C", "_models.D"]:
         """Send a 200 response with valid payload: {'httpStatusCode': '404'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -548,7 +548,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -593,7 +593,7 @@ class MultipleResponsesOperations:
     async def get200_model_a201_model_c404_model_d_default_error400_valid(
         self,
         **kwargs
-    ) -> Union["models.MyException", "models.C", "models.D"]:
+    ) -> Union["_models.MyException", "_models.C", "_models.D"]:
         """Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -601,7 +601,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -935,7 +935,7 @@ class MultipleResponsesOperations:
     async def get_default_model_a200_valid(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -943,7 +943,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -980,7 +980,7 @@ class MultipleResponsesOperations:
     async def get_default_model_a200_none(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with no payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -988,7 +988,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1271,7 +1271,7 @@ class MultipleResponsesOperations:
     async def get200_model_a200_none(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with no payload, when a payload is expected - client should return a null
         object of thde type for model A.
 
@@ -1280,7 +1280,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1317,7 +1317,7 @@ class MultipleResponsesOperations:
     async def get200_model_a200_valid(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with payload {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1325,7 +1325,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1362,7 +1362,7 @@ class MultipleResponsesOperations:
     async def get200_model_a200_invalid(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1370,7 +1370,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1407,7 +1407,7 @@ class MultipleResponsesOperations:
     async def get200_model_a400_none(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 400 response with no payload client should treat as an http error with no error model.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1415,7 +1415,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1452,7 +1452,7 @@ class MultipleResponsesOperations:
     async def get200_model_a400_valid(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with payload {'statusCode': '400'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1460,7 +1460,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1497,7 +1497,7 @@ class MultipleResponsesOperations:
     async def get200_model_a400_invalid(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1505,7 +1505,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1542,7 +1542,7 @@ class MultipleResponsesOperations:
     async def get200_model_a202_valid(
         self,
         **kwargs
-    ) -> "models.MyException":
+    ) -> "_models.MyException":
         """Send a 202 response with payload {'statusCode': '202'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1550,7 +1550,7 @@ class MultipleResponsesOperations:
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_multiple_responses_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class MultipleResponsesOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -75,7 +75,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -123,7 +123,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -171,7 +171,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -219,7 +219,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -267,7 +267,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -315,7 +315,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -365,7 +365,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -415,7 +415,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -465,7 +465,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -518,7 +518,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -571,7 +571,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -624,7 +624,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -677,7 +677,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -720,7 +720,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -763,7 +763,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1056,7 +1056,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.MyException, response)
+            error = self._deserialize(_models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1099,7 +1099,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.MyException, response)
+            error = self._deserialize(_models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/aio/operations/_multiple_responses_operations.py
@@ -75,7 +75,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -123,7 +123,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -171,7 +171,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -219,7 +219,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -267,7 +267,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -315,7 +315,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -365,7 +365,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -415,7 +415,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -465,7 +465,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -518,7 +518,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -571,7 +571,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -624,7 +624,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -677,7 +677,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -720,7 +720,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -763,7 +763,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1056,7 +1056,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.MyException, response)
+            error = self._deserialize(self.models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1099,7 +1099,7 @@ class MultipleResponsesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.MyException, response)
+            error = self._deserialize(self.models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class HttpClientFailureOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -124,7 +124,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -168,7 +168,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -223,7 +223,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -278,7 +278,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -333,7 +333,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -388,7 +388,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -432,7 +432,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -476,7 +476,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -520,7 +520,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -564,7 +564,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -619,7 +619,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -674,7 +674,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -729,7 +729,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -784,7 +784,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -839,7 +839,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -883,7 +883,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -927,7 +927,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -971,7 +971,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1015,7 +1015,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1070,7 +1070,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1125,7 +1125,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1180,7 +1180,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1224,7 +1224,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1279,7 +1279,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1323,7 +1323,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_client_failure_operations.py
@@ -80,7 +80,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -124,7 +124,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -168,7 +168,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -223,7 +223,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -278,7 +278,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -333,7 +333,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -388,7 +388,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -432,7 +432,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -476,7 +476,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -520,7 +520,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -564,7 +564,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -619,7 +619,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -674,7 +674,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -729,7 +729,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -784,7 +784,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -839,7 +839,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -883,7 +883,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -927,7 +927,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -971,7 +971,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1015,7 +1015,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1070,7 +1070,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1125,7 +1125,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1180,7 +1180,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1224,7 +1224,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1279,7 +1279,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1323,7 +1323,7 @@ class HttpClientFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_failure_operations.py
@@ -80,7 +80,7 @@ class HttpFailureOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_failure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class HttpFailureOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class HttpFailureOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class HttpRedirectsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -128,7 +128,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -179,7 +179,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -227,7 +227,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -287,7 +287,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -334,7 +334,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -382,7 +382,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -442,7 +442,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -501,7 +501,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 303]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -549,7 +549,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -597,7 +597,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -645,7 +645,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -704,7 +704,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -763,7 +763,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -822,7 +822,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -881,7 +881,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_redirects_operations.py
@@ -80,7 +80,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -128,7 +128,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 300]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -179,7 +179,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -227,7 +227,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -287,7 +287,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [301]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -334,7 +334,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -382,7 +382,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -442,7 +442,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [302]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -501,7 +501,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 303]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -549,7 +549,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -597,7 +597,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -645,7 +645,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -704,7 +704,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -763,7 +763,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -822,7 +822,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}
@@ -881,7 +881,7 @@ class HttpRedirectsOperations(object):
 
         if response.status_code not in [200, 307]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         response_headers = {}

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
@@ -80,7 +80,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -135,7 +135,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -190,7 +190,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -234,7 +234,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -278,7 +278,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -336,7 +336,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -391,7 +391,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -446,7 +446,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -501,7 +501,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_retry_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class HttpRetryOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -135,7 +135,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -190,7 +190,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -234,7 +234,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -278,7 +278,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -336,7 +336,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -391,7 +391,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -446,7 +446,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -501,7 +501,7 @@ class HttpRetryOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class HttpServerFailureOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -124,7 +124,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -179,7 +179,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -234,7 +234,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_server_failure_operations.py
@@ -80,7 +80,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -124,7 +124,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -179,7 +179,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -234,7 +234,7 @@ class HttpServerFailureOperations(object):
 
         if response.status_code not in []:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class HttpSuccessOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -124,7 +124,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -171,7 +171,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -229,7 +229,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -284,7 +284,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -339,7 +339,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -394,7 +394,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -449,7 +449,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -504,7 +504,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -559,7 +559,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -614,7 +614,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -669,7 +669,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -724,7 +724,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -768,7 +768,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -823,7 +823,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -878,7 +878,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -933,7 +933,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -988,7 +988,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1032,7 +1032,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_http_success_operations.py
@@ -80,7 +80,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -124,7 +124,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -171,7 +171,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('bool', pipeline_response)
@@ -229,7 +229,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -284,7 +284,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -339,7 +339,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -394,7 +394,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -449,7 +449,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -504,7 +504,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -559,7 +559,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -614,7 +614,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -669,7 +669,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -724,7 +724,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [202]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -768,7 +768,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -823,7 +823,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -878,7 +878,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -933,7 +933,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -988,7 +988,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1032,7 +1032,7 @@ class HttpSuccessOperations(object):
 
         if response.status_code not in [204, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_multiple_responses_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class MultipleResponsesOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -80,7 +80,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -129,7 +129,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -178,7 +178,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -227,7 +227,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -276,7 +276,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -325,7 +325,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -376,7 +376,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -427,7 +427,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -478,7 +478,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -532,7 +532,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -586,7 +586,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -640,7 +640,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -694,7 +694,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -738,7 +738,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -782,7 +782,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1082,7 +1082,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.MyException, response)
+            error = self._deserialize(_models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1126,7 +1126,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.MyException, response)
+            error = self._deserialize(_models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_multiple_responses_operations.py
@@ -80,7 +80,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -129,7 +129,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -178,7 +178,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -227,7 +227,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -276,7 +276,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = None
@@ -325,7 +325,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -376,7 +376,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -427,7 +427,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -478,7 +478,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -532,7 +532,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -586,7 +586,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -640,7 +640,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200, 201, 404]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if response.status_code == 200:
@@ -694,7 +694,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -738,7 +738,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -782,7 +782,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [202, 204]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1082,7 +1082,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.MyException, response)
+            error = self._deserialize(self.models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1126,7 +1126,7 @@ class MultipleResponsesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.MyException, response)
+            error = self._deserialize(self.models.MyException, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_multiple_responses_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Http/httpinfrastructure/operations/_multiple_responses_operations.py
@@ -49,7 +49,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.MyException"]
+        # type: (...) -> Optional["_models.MyException"]
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -98,7 +98,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.MyException"]
+        # type: (...) -> Optional["_models.MyException"]
         """Send a 204 response with no payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -106,7 +106,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -147,7 +147,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.MyException"]
+        # type: (...) -> Optional["_models.MyException"]
         """Send a 201 response with valid payload: {'statusCode': '201'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -155,7 +155,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -196,7 +196,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.MyException"]
+        # type: (...) -> Optional["_models.MyException"]
         """Send a 202 response with no payload:.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -204,7 +204,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -245,7 +245,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.MyException"]
+        # type: (...) -> Optional["_models.MyException"]
         """Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -253,7 +253,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.MyException"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.MyException"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -294,7 +294,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.B"]
+        # type: (...) -> Union["_models.MyException", "_models.B"]
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -302,7 +302,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.B
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.B"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.B"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -345,7 +345,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.B"]
+        # type: (...) -> Union["_models.MyException", "_models.B"]
         """Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -353,7 +353,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.B
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.B"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.B"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -396,7 +396,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.B"]
+        # type: (...) -> Union["_models.MyException", "_models.B"]
         """Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -404,7 +404,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.B
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.B"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.B"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -447,7 +447,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.C", "models.D"]
+        # type: (...) -> Union["_models.MyException", "_models.C", "_models.D"]
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -455,7 +455,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -501,7 +501,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.C", "models.D"]
+        # type: (...) -> Union["_models.MyException", "_models.C", "_models.D"]
         """Send a 200 response with valid payload: {'httpCode': '201'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -509,7 +509,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -555,7 +555,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.C", "models.D"]
+        # type: (...) -> Union["_models.MyException", "_models.C", "_models.D"]
         """Send a 200 response with valid payload: {'httpStatusCode': '404'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -563,7 +563,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -609,7 +609,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union["models.MyException", "models.C", "models.D"]
+        # type: (...) -> Union["_models.MyException", "_models.C", "_models.D"]
         """Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -617,7 +617,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException or ~httpinfrastructure.models.C or ~httpinfrastructure.models.D
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union["models.MyException", "models.C", "models.D"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union["_models.MyException", "_models.C", "_models.D"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -959,7 +959,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with valid payload: {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -967,7 +967,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1005,7 +1005,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with no payload.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1013,7 +1013,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1303,7 +1303,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with no payload, when a payload is expected - client should return a null
         object of thde type for model A.
 
@@ -1312,7 +1312,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1350,7 +1350,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with payload {'statusCode': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1358,7 +1358,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1396,7 +1396,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with invalid payload {'statusCodeInvalid': '200'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1404,7 +1404,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1442,7 +1442,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 400 response with no payload client should treat as an http error with no error model.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1450,7 +1450,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1488,7 +1488,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with payload {'statusCode': '400'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1496,7 +1496,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1534,7 +1534,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 200 response with invalid payload {'statusCodeInvalid': '400'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1542,7 +1542,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1580,7 +1580,7 @@ class MultipleResponsesOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.MyException"
+        # type: (...) -> "_models.MyException"
         """Send a 202 response with payload {'statusCode': '202'}.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1588,7 +1588,7 @@ class MultipleResponsesOperations(object):
         :rtype: ~httpinfrastructure.models.MyException
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.MyException"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.MyException"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
@@ -23,7 +23,7 @@ class MediaTypesClientOperationsMixin:
     @distributed_trace_async
     async def analyze_body(
         self,
-        input: Optional[Union[IO, "models.SourcePath"]] = None,
+        input: Optional[Union[IO, "_models.SourcePath"]] = None,
         **kwargs
     ) -> str:
         """Analyze body, that could be different media types.

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -27,7 +27,7 @@ class MediaTypesClientOperationsMixin(object):
     @distributed_trace
     def analyze_body(
         self,
-        input=None,  # type: Optional[Union[IO, "models.SourcePath"]]
+        input=None,  # type: Optional[Union[IO, "_models.SourcePath"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> str

--- a/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/aio/operations/_auto_rest_resource_flattening_test_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/aio/operations/_auto_rest_resource_flattening_test_service_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -66,7 +66,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -109,7 +109,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[FlattenedProduct]', pipeline_response)
@@ -167,7 +167,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -211,7 +211,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[ProductWrapper]', pipeline_response)
@@ -268,7 +268,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{FlattenedProduct}', pipeline_response)
@@ -368,7 +368,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ResourceCollection', pipeline_response)
@@ -468,7 +468,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -541,7 +541,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -620,7 +620,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/aio/operations/_auto_rest_resource_flattening_test_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/aio/operations/_auto_rest_resource_flattening_test_service_operations.py
@@ -23,7 +23,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     @distributed_trace_async
     async def put_array(
         self,
-        resource_array: Optional[List["models.Resource"]] = None,
+        resource_array: Optional[List["_models.Resource"]] = None,
         **kwargs
     ) -> None:
         """Put External Resource as an Array.
@@ -78,7 +78,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     async def get_array(
         self,
         **kwargs
-    ) -> List["models.FlattenedProduct"]:
+    ) -> List["_models.FlattenedProduct"]:
         """Get External Resource as an Array.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -86,7 +86,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: list[~modelflattening.models.FlattenedProduct]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.FlattenedProduct"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.FlattenedProduct"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -123,7 +123,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     @distributed_trace_async
     async def put_wrapped_array(
         self,
-        resource_array: Optional[List["models.WrappedProduct"]] = None,
+        resource_array: Optional[List["_models.WrappedProduct"]] = None,
         **kwargs
     ) -> None:
         """No need to have a route in Express server for this operation. Used to verify the type flattened
@@ -179,7 +179,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     async def get_wrapped_array(
         self,
         **kwargs
-    ) -> List["models.ProductWrapper"]:
+    ) -> List["_models.ProductWrapper"]:
         """No need to have a route in Express server for this operation. Used to verify the type flattened
         is not removed if it's referenced in an array.
 
@@ -188,7 +188,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: list[~modelflattening.models.ProductWrapper]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.ProductWrapper"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.ProductWrapper"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -225,7 +225,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     @distributed_trace_async
     async def put_dictionary(
         self,
-        resource_dictionary: Optional[Dict[str, "models.FlattenedProduct"]] = None,
+        resource_dictionary: Optional[Dict[str, "_models.FlattenedProduct"]] = None,
         **kwargs
     ) -> None:
         """Put External Resource as a Dictionary.
@@ -280,7 +280,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     async def get_dictionary(
         self,
         **kwargs
-    ) -> Dict[str, "models.FlattenedProduct"]:
+    ) -> Dict[str, "_models.FlattenedProduct"]:
         """Get External Resource as a Dictionary.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -288,7 +288,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: dict[str, ~modelflattening.models.FlattenedProduct]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.FlattenedProduct"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.FlattenedProduct"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -325,7 +325,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     @distributed_trace_async
     async def put_resource_collection(
         self,
-        resource_complex_object: Optional["models.ResourceCollection"] = None,
+        resource_complex_object: Optional["_models.ResourceCollection"] = None,
         **kwargs
     ) -> None:
         """Put External Resource as a ResourceCollection.
@@ -380,7 +380,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     async def get_resource_collection(
         self,
         **kwargs
-    ) -> "models.ResourceCollection":
+    ) -> "_models.ResourceCollection":
         """Get External Resource as a ResourceCollection.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -388,7 +388,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: ~modelflattening.models.ResourceCollection
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ResourceCollection"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ResourceCollection"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -425,9 +425,9 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     @distributed_trace_async
     async def put_simple_product(
         self,
-        simple_body_product: Optional["models.SimpleProduct"] = None,
+        simple_body_product: Optional["_models.SimpleProduct"] = None,
         **kwargs
-    ) -> "models.SimpleProduct":
+    ) -> "_models.SimpleProduct":
         """Put Simple Product with client flattening true on the model.
 
         :param simple_body_product: Simple body product to put.
@@ -437,7 +437,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: ~modelflattening.models.SimpleProduct
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SimpleProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SimpleProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -488,7 +488,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         generic_value: Optional[str] = None,
         odata_value: Optional[str] = None,
         **kwargs
-    ) -> "models.SimpleProduct":
+    ) -> "_models.SimpleProduct":
         """Put Flattened Simple Product with client flattening true on the parameter.
 
         :param product_id: Unique identifier representing a specific product for a given latitude &
@@ -508,13 +508,13 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: ~modelflattening.models.SimpleProduct
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SimpleProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SimpleProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _simple_body_product = models.SimpleProduct(product_id=product_id, description=description, max_product_display_name=max_product_display_name, generic_value=generic_value, odata_value=odata_value)
+        _simple_body_product = _models.SimpleProduct(product_id=product_id, description=description, max_product_display_name=max_product_display_name, generic_value=generic_value, odata_value=odata_value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -555,9 +555,9 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
     @distributed_trace_async
     async def put_simple_product_with_grouping(
         self,
-        flatten_parameter_group: "models.FlattenParameterGroup",
+        flatten_parameter_group: "_models.FlattenParameterGroup",
         **kwargs
-    ) -> "models.SimpleProduct":
+    ) -> "_models.SimpleProduct":
         """Put Simple Product with client flattening true on the model.
 
         :param flatten_parameter_group: Parameter group.
@@ -567,7 +567,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
         :rtype: ~modelflattening.models.SimpleProduct
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SimpleProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SimpleProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -589,7 +589,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
             _generic_value = flatten_parameter_group.generic_value
             _odata_value = flatten_parameter_group.odata_value
 
-        _simple_body_product = models.SimpleProduct(product_id=_product_id, description=_description, max_product_display_name=_max_product_display_name, generic_value=_generic_value, odata_value=_odata_value)
+        _simple_body_product = _models.SimpleProduct(product_id=_product_id, description=_description, max_product_display_name=_max_product_display_name, generic_value=_generic_value, odata_value=_odata_value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/aio/operations/_auto_rest_resource_flattening_test_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/aio/operations/_auto_rest_resource_flattening_test_service_operations.py
@@ -66,7 +66,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -109,7 +109,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[FlattenedProduct]', pipeline_response)
@@ -167,7 +167,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -211,7 +211,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[ProductWrapper]', pipeline_response)
@@ -268,7 +268,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{FlattenedProduct}', pipeline_response)
@@ -368,7 +368,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ResourceCollection', pipeline_response)
@@ -468,7 +468,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -541,7 +541,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -620,7 +620,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/operations/_auto_rest_resource_flattening_test_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/operations/_auto_rest_resource_flattening_test_service_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -71,7 +71,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -115,7 +115,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[FlattenedProduct]', pipeline_response)
@@ -174,7 +174,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -219,7 +219,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[ProductWrapper]', pipeline_response)
@@ -277,7 +277,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{FlattenedProduct}', pipeline_response)
@@ -379,7 +379,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -423,7 +423,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ResourceCollection', pipeline_response)
@@ -481,7 +481,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -555,7 +555,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -635,7 +635,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/operations/_auto_rest_resource_flattening_test_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/operations/_auto_rest_resource_flattening_test_service_operations.py
@@ -27,7 +27,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
     @distributed_trace
     def put_array(
         self,
-        resource_array=None,  # type: Optional[List["models.Resource"]]
+        resource_array=None,  # type: Optional[List["_models.Resource"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -84,7 +84,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.FlattenedProduct"]
+        # type: (...) -> List["_models.FlattenedProduct"]
         """Get External Resource as an Array.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -92,7 +92,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: list[~modelflattening.models.FlattenedProduct]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.FlattenedProduct"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.FlattenedProduct"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -129,7 +129,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
     @distributed_trace
     def put_wrapped_array(
         self,
-        resource_array=None,  # type: Optional[List["models.WrappedProduct"]]
+        resource_array=None,  # type: Optional[List["_models.WrappedProduct"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -187,7 +187,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.ProductWrapper"]
+        # type: (...) -> List["_models.ProductWrapper"]
         """No need to have a route in Express server for this operation. Used to verify the type flattened
         is not removed if it's referenced in an array.
 
@@ -196,7 +196,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: list[~modelflattening.models.ProductWrapper]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.ProductWrapper"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.ProductWrapper"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -233,7 +233,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
     @distributed_trace
     def put_dictionary(
         self,
-        resource_dictionary=None,  # type: Optional[Dict[str, "models.FlattenedProduct"]]
+        resource_dictionary=None,  # type: Optional[Dict[str, "_models.FlattenedProduct"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -290,7 +290,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Dict[str, "models.FlattenedProduct"]
+        # type: (...) -> Dict[str, "_models.FlattenedProduct"]
         """Get External Resource as a Dictionary.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -298,7 +298,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: dict[str, ~modelflattening.models.FlattenedProduct]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "models.FlattenedProduct"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Dict[str, "_models.FlattenedProduct"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -335,7 +335,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
     @distributed_trace
     def put_resource_collection(
         self,
-        resource_complex_object=None,  # type: Optional["models.ResourceCollection"]
+        resource_complex_object=None,  # type: Optional["_models.ResourceCollection"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -392,7 +392,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ResourceCollection"
+        # type: (...) -> "_models.ResourceCollection"
         """Get External Resource as a ResourceCollection.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -400,7 +400,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: ~modelflattening.models.ResourceCollection
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ResourceCollection"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ResourceCollection"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -437,10 +437,10 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
     @distributed_trace
     def put_simple_product(
         self,
-        simple_body_product=None,  # type: Optional["models.SimpleProduct"]
+        simple_body_product=None,  # type: Optional["_models.SimpleProduct"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.SimpleProduct"
+        # type: (...) -> "_models.SimpleProduct"
         """Put Simple Product with client flattening true on the model.
 
         :param simple_body_product: Simple body product to put.
@@ -450,7 +450,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: ~modelflattening.models.SimpleProduct
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SimpleProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SimpleProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -502,7 +502,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         odata_value=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.SimpleProduct"
+        # type: (...) -> "_models.SimpleProduct"
         """Put Flattened Simple Product with client flattening true on the parameter.
 
         :param product_id: Unique identifier representing a specific product for a given latitude &
@@ -522,13 +522,13 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: ~modelflattening.models.SimpleProduct
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SimpleProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SimpleProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _simple_body_product = models.SimpleProduct(product_id=product_id, description=description, max_product_display_name=max_product_display_name, generic_value=generic_value, odata_value=odata_value)
+        _simple_body_product = _models.SimpleProduct(product_id=product_id, description=description, max_product_display_name=max_product_display_name, generic_value=generic_value, odata_value=odata_value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -569,10 +569,10 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
     @distributed_trace
     def put_simple_product_with_grouping(
         self,
-        flatten_parameter_group,  # type: "models.FlattenParameterGroup"
+        flatten_parameter_group,  # type: "_models.FlattenParameterGroup"
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.SimpleProduct"
+        # type: (...) -> "_models.SimpleProduct"
         """Put Simple Product with client flattening true on the model.
 
         :param flatten_parameter_group: Parameter group.
@@ -582,7 +582,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
         :rtype: ~modelflattening.models.SimpleProduct
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.SimpleProduct"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.SimpleProduct"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -604,7 +604,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
             _generic_value = flatten_parameter_group.generic_value
             _odata_value = flatten_parameter_group.odata_value
 
-        _simple_body_product = models.SimpleProduct(product_id=_product_id, description=_description, max_product_display_name=_max_product_display_name, generic_value=_generic_value, odata_value=_odata_value)
+        _simple_body_product = _models.SimpleProduct(product_id=_product_id, description=_description, max_product_display_name=_max_product_display_name, generic_value=_generic_value, odata_value=_odata_value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/operations/_auto_rest_resource_flattening_test_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/modelflattening/operations/_auto_rest_resource_flattening_test_service_operations.py
@@ -71,7 +71,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -115,7 +115,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[FlattenedProduct]', pipeline_response)
@@ -174,7 +174,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -219,7 +219,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('[ProductWrapper]', pipeline_response)
@@ -277,7 +277,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{FlattenedProduct}', pipeline_response)
@@ -379,7 +379,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -423,7 +423,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('ResourceCollection', pipeline_response)
@@ -481,7 +481,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -555,7 +555,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)
@@ -635,7 +635,7 @@ class AutoRestResourceFlatteningTestServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('SimpleProduct', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/aio/operations/_multiple_inheritance_service_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/aio/operations/_multiple_inheritance_service_client_operations.py
@@ -24,7 +24,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     async def get_horse(
         self,
         **kwargs
-    ) -> "models.Horse":
+    ) -> "_models.Horse":
         """Get a horse with name 'Fred' and isAShowHorse true.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -32,7 +32,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
         :rtype: ~multipleinheritance.models.Horse
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Horse"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Horse"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -69,7 +69,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     @distributed_trace_async
     async def put_horse(
         self,
-        horse: "models.Horse",
+        horse: "_models.Horse",
         **kwargs
     ) -> str:
         """Put a horse with name 'General' and isAShowHorse false.
@@ -123,7 +123,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     async def get_pet(
         self,
         **kwargs
-    ) -> "models.Pet":
+    ) -> "_models.Pet":
         """Get a pet with name 'Peanut'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -131,7 +131,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
         :rtype: ~multipleinheritance.models.Pet
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Pet"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Pet"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -186,7 +186,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _pet = models.Pet(name=name)
+        _pet = _models.Pet(name=name)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -224,7 +224,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     async def get_feline(
         self,
         **kwargs
-    ) -> "models.Feline":
+    ) -> "_models.Feline":
         """Get a feline where meows and hisses are true.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -232,7 +232,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
         :rtype: ~multipleinheritance.models.Feline
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Feline"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Feline"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -269,7 +269,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     @distributed_trace_async
     async def put_feline(
         self,
-        feline: "models.Feline",
+        feline: "_models.Feline",
         **kwargs
     ) -> str:
         """Put a feline who hisses and doesn't meow.
@@ -323,7 +323,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     async def get_cat(
         self,
         **kwargs
-    ) -> "models.Cat":
+    ) -> "_models.Cat":
         """Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -331,7 +331,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
         :rtype: ~multipleinheritance.models.Cat
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Cat"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Cat"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -368,7 +368,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     @distributed_trace_async
     async def put_cat(
         self,
-        cat: "models.Cat",
+        cat: "_models.Cat",
         **kwargs
     ) -> str:
         """Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true.
@@ -422,7 +422,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     async def get_kitten(
         self,
         **kwargs
-    ) -> "models.Kitten":
+    ) -> "_models.Kitten":
         """Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet
         is false.
 
@@ -431,7 +431,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
         :rtype: ~multipleinheritance.models.Kitten
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Kitten"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Kitten"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -468,7 +468,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
     @distributed_trace_async
     async def put_kitten(
         self,
-        kitten: "models.Kitten",
+        kitten: "_models.Kitten",
         **kwargs
     ) -> str:
         """Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is

--- a/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/aio/operations/_multiple_inheritance_service_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/aio/operations/_multiple_inheritance_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -55,7 +55,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Horse', pipeline_response)
@@ -154,7 +154,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Pet', pipeline_response)
@@ -255,7 +255,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Feline', pipeline_response)
@@ -354,7 +354,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Cat', pipeline_response)
@@ -454,7 +454,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Kitten', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/aio/operations/_multiple_inheritance_service_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/aio/operations/_multiple_inheritance_service_client_operations.py
@@ -55,7 +55,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Horse', pipeline_response)
@@ -154,7 +154,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Pet', pipeline_response)
@@ -255,7 +255,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Feline', pipeline_response)
@@ -354,7 +354,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Cat', pipeline_response)
@@ -454,7 +454,7 @@ class MultipleInheritanceServiceClientOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Kitten', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/operations/_multiple_inheritance_service_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/operations/_multiple_inheritance_service_client_operations.py
@@ -29,7 +29,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Horse"
+        # type: (...) -> "_models.Horse"
         """Get a horse with name 'Fred' and isAShowHorse true.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -37,7 +37,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         :rtype: ~multipleinheritance.models.Horse
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Horse"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Horse"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -74,7 +74,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
     @distributed_trace
     def put_horse(
         self,
-        horse,  # type: "models.Horse"
+        horse,  # type: "_models.Horse"
         **kwargs  # type: Any
     ):
         # type: (...) -> str
@@ -130,7 +130,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Pet"
+        # type: (...) -> "_models.Pet"
         """Get a pet with name 'Peanut'.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -138,7 +138,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         :rtype: ~multipleinheritance.models.Pet
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Pet"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Pet"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -194,7 +194,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _pet = models.Pet(name=name)
+        _pet = _models.Pet(name=name)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -233,7 +233,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Feline"
+        # type: (...) -> "_models.Feline"
         """Get a feline where meows and hisses are true.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -241,7 +241,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         :rtype: ~multipleinheritance.models.Feline
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Feline"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Feline"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -278,7 +278,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
     @distributed_trace
     def put_feline(
         self,
-        feline,  # type: "models.Feline"
+        feline,  # type: "_models.Feline"
         **kwargs  # type: Any
     ):
         # type: (...) -> str
@@ -334,7 +334,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Cat"
+        # type: (...) -> "_models.Cat"
         """Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -342,7 +342,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         :rtype: ~multipleinheritance.models.Cat
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Cat"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Cat"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -379,7 +379,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
     @distributed_trace
     def put_cat(
         self,
-        cat,  # type: "models.Cat"
+        cat,  # type: "_models.Cat"
         **kwargs  # type: Any
     ):
         # type: (...) -> str
@@ -435,7 +435,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Kitten"
+        # type: (...) -> "_models.Kitten"
         """Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet
         is false.
 
@@ -444,7 +444,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
         :rtype: ~multipleinheritance.models.Kitten
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Kitten"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Kitten"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -481,7 +481,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
     @distributed_trace
     def put_kitten(
         self,
-        kitten,  # type: "models.Kitten"
+        kitten,  # type: "_models.Kitten"
         **kwargs  # type: Any
     ):
         # type: (...) -> str

--- a/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/operations/_multiple_inheritance_service_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/operations/_multiple_inheritance_service_client_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -60,7 +60,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Horse', pipeline_response)
@@ -161,7 +161,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Pet', pipeline_response)
@@ -264,7 +264,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Feline', pipeline_response)
@@ -365,7 +365,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Cat', pipeline_response)
@@ -467,7 +467,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Kitten', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/operations/_multiple_inheritance_service_client_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/operations/_multiple_inheritance_service_client_operations.py
@@ -60,7 +60,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Horse', pipeline_response)
@@ -161,7 +161,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Pet', pipeline_response)
@@ -264,7 +264,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Feline', pipeline_response)
@@ -365,7 +365,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Cat', pipeline_response)
@@ -467,7 +467,7 @@ class MultipleInheritanceServiceClientOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Kitten', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_float_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_float_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_float_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_float_operations.py
@@ -39,7 +39,7 @@ class FloatOperations:
     @distributed_trace_async
     async def put(
         self,
-        input: Optional[Union[float, "models.FloatEnum"]] = None,
+        input: Optional[Union[float, "_models.FloatEnum"]] = None,
         **kwargs
     ) -> str:
         """Put a float enum.
@@ -96,7 +96,7 @@ class FloatOperations:
     async def get(
         self,
         **kwargs
-    ) -> Union[float, "models.FloatEnum"]:
+    ) -> Union[float, "_models.FloatEnum"]:
         """Get a float enum.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -104,7 +104,7 @@ class FloatOperations:
         :rtype: str or ~nonstringenums.models.FloatEnum
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[float, "models.FloatEnum"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[float, "_models.FloatEnum"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_int_operations.py
@@ -39,7 +39,7 @@ class IntOperations:
     @distributed_trace_async
     async def put(
         self,
-        input: Optional[Union[int, "models.IntEnum"]] = None,
+        input: Optional[Union[int, "_models.IntEnum"]] = None,
         **kwargs
     ) -> str:
         """Put an int enum.
@@ -96,7 +96,7 @@ class IntOperations:
     async def get(
         self,
         **kwargs
-    ) -> Union[int, "models.IntEnum"]:
+    ) -> Union[int, "_models.IntEnum"]:
         """Get an int enum.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -104,7 +104,7 @@ class IntOperations:
         :rtype: str or ~nonstringenums.models.IntEnum
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[int, "models.IntEnum"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[int, "_models.IntEnum"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/aio/operations/_int_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_float_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_float_operations.py
@@ -43,7 +43,7 @@ class FloatOperations(object):
     @distributed_trace
     def put(
         self,
-        input=None,  # type: Optional[Union[float, "models.FloatEnum"]]
+        input=None,  # type: Optional[Union[float, "_models.FloatEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> str
@@ -102,7 +102,7 @@ class FloatOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union[float, "models.FloatEnum"]
+        # type: (...) -> Union[float, "_models.FloatEnum"]
         """Get a float enum.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -110,7 +110,7 @@ class FloatOperations(object):
         :rtype: str or ~nonstringenums.models.FloatEnum
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[float, "models.FloatEnum"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[float, "_models.FloatEnum"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_float_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_float_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_int_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports

--- a/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_int_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/NonStringEnums/nonstringenums/operations/_int_operations.py
@@ -43,7 +43,7 @@ class IntOperations(object):
     @distributed_trace
     def put(
         self,
-        input=None,  # type: Optional[Union[int, "models.IntEnum"]]
+        input=None,  # type: Optional[Union[int, "_models.IntEnum"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> str
@@ -102,7 +102,7 @@ class IntOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> Union[int, "models.IntEnum"]
+        # type: (...) -> Union[int, "_models.IntEnum"]
         """Get an int enum.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -110,7 +110,7 @@ class IntOperations(object):
         :rtype: str or ~nonstringenums.models.IntEnum
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Union[int, "models.IntEnum"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Union[int, "_models.IntEnum"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/aio/operations/_availability_sets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/aio/operations/_availability_sets_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class AvailabilitySetsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/aio/operations/_availability_sets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/aio/operations/_availability_sets_operations.py
@@ -67,7 +67,7 @@ class AvailabilitySetsOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _tags = models.AvailabilitySetUpdateParameters(tags=tags)
+        _tags = _models.AvailabilitySetUpdateParameters(tags=tags)
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/operations/_availability_sets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/operations/_availability_sets_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class AvailabilitySetsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client

--- a/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/operations/_availability_sets_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/operations/_availability_sets_operations.py
@@ -72,7 +72,7 @@ class AvailabilitySetsOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _tags = models.AvailabilitySetUpdateParameters(tags=tags)
+        _tags = _models.AvailabilitySetUpdateParameters(tags=tags)
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/test/vanilla/Expected/AcceptanceTests/Report/report/aio/operations/_auto_rest_report_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Report/report/aio/operations/_auto_rest_report_service_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -62,7 +62,7 @@ class AutoRestReportServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -115,7 +115,7 @@ class AutoRestReportServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Report/report/aio/operations/_auto_rest_report_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Report/report/aio/operations/_auto_rest_report_service_operations.py
@@ -62,7 +62,7 @@ class AutoRestReportServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -115,7 +115,7 @@ class AutoRestReportServiceOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Report/report/operations/_auto_rest_report_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Report/report/operations/_auto_rest_report_service_operations.py
@@ -67,7 +67,7 @@ class AutoRestReportServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -121,7 +121,7 @@ class AutoRestReportServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Report/report/operations/_auto_rest_report_service_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Report/report/operations/_auto_rest_report_service_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -67,7 +67,7 @@ class AutoRestReportServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)
@@ -121,7 +121,7 @@ class AutoRestReportServiceOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('{int}', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_explicit_operations.py
@@ -84,7 +84,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -138,7 +138,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -192,7 +192,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -248,7 +248,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -296,7 +296,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -344,7 +344,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -396,7 +396,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -450,7 +450,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -504,7 +504,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -560,7 +560,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -608,7 +608,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -656,7 +656,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -708,7 +708,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -762,7 +762,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -816,7 +816,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -872,7 +872,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -924,7 +924,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -978,7 +978,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1032,7 +1032,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1088,7 +1088,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1136,7 +1136,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1184,7 +1184,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_explicit_operations.py
@@ -168,7 +168,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.IntWrapper(value=value)
+        _body_parameter = _models.IntWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -221,7 +221,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.IntOptionalWrapper(value=value)
+        _body_parameter = _models.IntOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -480,7 +480,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.StringWrapper(value=value)
+        _body_parameter = _models.StringWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -533,7 +533,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.StringOptionalWrapper(value=value)
+        _body_parameter = _models.StringOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -667,7 +667,7 @@ class ExplicitOperations:
     @distributed_trace_async
     async def post_required_class_parameter(
         self,
-        body_parameter: "models.Product",
+        body_parameter: "_models.Product",
         **kwargs
     ) -> None:
         """Test explicitly required complex object. Please put null and the client library should throw
@@ -719,7 +719,7 @@ class ExplicitOperations:
     @distributed_trace_async
     async def post_optional_class_parameter(
         self,
-        body_parameter: Optional["models.Product"] = None,
+        body_parameter: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         """Test explicitly optional complex object. Please put null.
@@ -773,7 +773,7 @@ class ExplicitOperations:
     @distributed_trace_async
     async def post_required_class_property(
         self,
-        value: "models.Product",
+        value: "_models.Product",
         **kwargs
     ) -> None:
         """Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null
@@ -792,7 +792,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ClassWrapper(value=value)
+        _body_parameter = _models.ClassWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -827,7 +827,7 @@ class ExplicitOperations:
     @distributed_trace_async
     async def post_optional_class_property(
         self,
-        value: Optional["models.Product"] = None,
+        value: Optional["_models.Product"] = None,
         **kwargs
     ) -> None:
         """Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -845,7 +845,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ClassOptionalWrapper(value=value)
+        _body_parameter = _models.ClassOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1008,7 +1008,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ArrayWrapper(value=value)
+        _body_parameter = _models.ArrayWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1061,7 +1061,7 @@ class ExplicitOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ArrayOptionalWrapper(value=value)
+        _body_parameter = _models.ArrayOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_explicit_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ExplicitOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -84,7 +84,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -138,7 +138,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -192,7 +192,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -248,7 +248,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -296,7 +296,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -344,7 +344,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -396,7 +396,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -450,7 +450,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -504,7 +504,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -560,7 +560,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -608,7 +608,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -656,7 +656,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -708,7 +708,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -762,7 +762,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -816,7 +816,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -872,7 +872,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -924,7 +924,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -978,7 +978,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1032,7 +1032,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1088,7 +1088,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1136,7 +1136,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1184,7 +1184,7 @@ class ExplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_implicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_implicit_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class ImplicitOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -82,7 +82,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -130,7 +130,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -232,7 +232,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -279,7 +279,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -323,7 +323,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -368,7 +368,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_implicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/aio/operations/_implicit_operations.py
@@ -82,7 +82,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -130,7 +130,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -232,7 +232,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -279,7 +279,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -323,7 +323,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -368,7 +368,7 @@ class ImplicitOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_explicit_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ExplicitOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -89,7 +89,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -144,7 +144,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -199,7 +199,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -256,7 +256,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -305,7 +305,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -354,7 +354,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -407,7 +407,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -462,7 +462,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -517,7 +517,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -574,7 +574,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -623,7 +623,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -672,7 +672,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -725,7 +725,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -780,7 +780,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -835,7 +835,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -892,7 +892,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -945,7 +945,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1000,7 +1000,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1055,7 +1055,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1112,7 +1112,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1161,7 +1161,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1210,7 +1210,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_explicit_operations.py
@@ -175,7 +175,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.IntWrapper(value=value)
+        _body_parameter = _models.IntWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -229,7 +229,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.IntOptionalWrapper(value=value)
+        _body_parameter = _models.IntOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -493,7 +493,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.StringWrapper(value=value)
+        _body_parameter = _models.StringWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -547,7 +547,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.StringOptionalWrapper(value=value)
+        _body_parameter = _models.StringOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -683,7 +683,7 @@ class ExplicitOperations(object):
     @distributed_trace
     def post_required_class_parameter(
         self,
-        body_parameter,  # type: "models.Product"
+        body_parameter,  # type: "_models.Product"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -736,7 +736,7 @@ class ExplicitOperations(object):
     @distributed_trace
     def post_optional_class_parameter(
         self,
-        body_parameter=None,  # type: Optional["models.Product"]
+        body_parameter=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -791,7 +791,7 @@ class ExplicitOperations(object):
     @distributed_trace
     def post_required_class_property(
         self,
-        value,  # type: "models.Product"
+        value,  # type: "_models.Product"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -811,7 +811,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ClassWrapper(value=value)
+        _body_parameter = _models.ClassWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -846,7 +846,7 @@ class ExplicitOperations(object):
     @distributed_trace
     def post_optional_class_property(
         self,
-        value=None,  # type: Optional["models.Product"]
+        value=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -865,7 +865,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ClassOptionalWrapper(value=value)
+        _body_parameter = _models.ClassOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1031,7 +1031,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ArrayWrapper(value=value)
+        _body_parameter = _models.ArrayWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -1085,7 +1085,7 @@ class ExplicitOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _body_parameter = models.ArrayOptionalWrapper(value=value)
+        _body_parameter = _models.ArrayOptionalWrapper(value=value)
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_explicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_explicit_operations.py
@@ -89,7 +89,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -144,7 +144,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -199,7 +199,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -256,7 +256,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -305,7 +305,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -354,7 +354,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -407,7 +407,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -462,7 +462,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -517,7 +517,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -574,7 +574,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -623,7 +623,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -672,7 +672,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -725,7 +725,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -780,7 +780,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -835,7 +835,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -892,7 +892,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -945,7 +945,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1000,7 +1000,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1055,7 +1055,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1112,7 +1112,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1161,7 +1161,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1210,7 +1210,7 @@ class ExplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_implicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_implicit_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class ImplicitOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -87,7 +87,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -136,7 +136,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -185,7 +185,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -240,7 +240,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -288,7 +288,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -333,7 +333,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -379,7 +379,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_implicit_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/requiredoptional/operations/_implicit_operations.py
@@ -87,7 +87,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -136,7 +136,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -185,7 +185,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -240,7 +240,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -288,7 +288,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -333,7 +333,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -379,7 +379,7 @@ class ImplicitOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_path_items_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_path_items_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PathItemsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -102,7 +102,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -172,7 +172,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -242,7 +242,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_path_items_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_path_items_operations.py
@@ -102,7 +102,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -172,7 +172,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -242,7 +242,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -311,7 +311,7 @@ class PathItemsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_paths_operations.py
@@ -81,7 +81,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -177,7 +177,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -225,7 +225,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -369,7 +369,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -417,7 +417,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -465,7 +465,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -513,7 +513,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -561,7 +561,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -609,7 +609,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -659,7 +659,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -707,7 +707,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -757,7 +757,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -807,7 +807,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -857,7 +857,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -907,7 +907,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -955,7 +955,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1005,7 +1005,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1053,7 +1053,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1104,7 +1104,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1152,7 +1152,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1202,7 +1202,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1252,7 +1252,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1304,7 +1304,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1354,7 +1354,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_paths_operations.py
@@ -768,7 +768,7 @@ class PathsOperations:
     @distributed_trace_async
     async def enum_valid(
         self,
-        enum_path: Union[str, "models.UriColor"],
+        enum_path: Union[str, "_models.UriColor"],
         **kwargs
     ) -> None:
         """Get using uri with 'green color' in path parameter.
@@ -818,7 +818,7 @@ class PathsOperations:
     @distributed_trace_async
     async def enum_null(
         self,
-        enum_path: Union[str, "models.UriColor"],
+        enum_path: Union[str, "_models.UriColor"],
         **kwargs
     ) -> None:
         """Get null (should throw on the client before the request is sent on wire).

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_paths_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class PathsOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -81,7 +81,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -177,7 +177,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -225,7 +225,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -273,7 +273,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -321,7 +321,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -369,7 +369,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -417,7 +417,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -465,7 +465,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -513,7 +513,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -561,7 +561,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -609,7 +609,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -659,7 +659,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -707,7 +707,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -757,7 +757,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -807,7 +807,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -857,7 +857,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -907,7 +907,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -955,7 +955,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1005,7 +1005,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1053,7 +1053,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1104,7 +1104,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1152,7 +1152,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1202,7 +1202,7 @@ class PathsOperations:
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1252,7 +1252,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1304,7 +1304,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1354,7 +1354,7 @@ class PathsOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_queries_operations.py
@@ -917,7 +917,7 @@ class QueriesOperations:
     @distributed_trace_async
     async def enum_valid(
         self,
-        enum_query: Optional[Union[str, "models.UriColor"]] = None,
+        enum_query: Optional[Union[str, "_models.UriColor"]] = None,
         **kwargs
     ) -> None:
         """Get using uri with query parameter 'green color'.
@@ -965,7 +965,7 @@ class QueriesOperations:
     @distributed_trace_async
     async def enum_null(
         self,
-        enum_query: Optional[Union[str, "models.UriColor"]] = None,
+        enum_query: Optional[Union[str, "_models.UriColor"]] = None,
         **kwargs
     ) -> None:
         """Get null (no query parameter in url).

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_queries_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -33,7 +33,7 @@ class QueriesOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -78,7 +78,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -123,7 +123,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -171,7 +171,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -216,7 +216,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -261,7 +261,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -309,7 +309,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -354,7 +354,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -399,7 +399,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -447,7 +447,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -492,7 +492,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -537,7 +537,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -585,7 +585,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -630,7 +630,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -675,7 +675,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -723,7 +723,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -768,7 +768,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -813,7 +813,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -858,7 +858,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -906,7 +906,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -954,7 +954,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1002,7 +1002,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1050,7 +1050,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1095,7 +1095,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1143,7 +1143,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1188,7 +1188,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1236,7 +1236,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1281,7 +1281,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1329,7 +1329,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1379,7 +1379,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1427,7 +1427,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1475,7 +1475,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1524,7 +1524,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1574,7 +1574,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1624,7 +1624,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1674,7 +1674,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/aio/operations/_queries_operations.py
@@ -78,7 +78,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -123,7 +123,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -171,7 +171,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -216,7 +216,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -261,7 +261,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -309,7 +309,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -354,7 +354,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -399,7 +399,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -447,7 +447,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -492,7 +492,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -537,7 +537,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -585,7 +585,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -630,7 +630,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -675,7 +675,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -723,7 +723,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -768,7 +768,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -813,7 +813,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -858,7 +858,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -906,7 +906,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -954,7 +954,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1002,7 +1002,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1050,7 +1050,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1095,7 +1095,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1143,7 +1143,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1188,7 +1188,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1236,7 +1236,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1281,7 +1281,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1329,7 +1329,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1379,7 +1379,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1427,7 +1427,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1475,7 +1475,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1524,7 +1524,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1574,7 +1574,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1624,7 +1624,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1674,7 +1674,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_path_items_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_path_items_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PathItemsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -107,7 +107,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -249,7 +249,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -319,7 +319,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_path_items_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_path_items_operations.py
@@ -107,7 +107,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -249,7 +249,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -319,7 +319,7 @@ class PathItemsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_paths_operations.py
@@ -787,7 +787,7 @@ class PathsOperations(object):
     @distributed_trace
     def enum_valid(
         self,
-        enum_path,  # type: Union[str, "models.UriColor"]
+        enum_path,  # type: Union[str, "_models.UriColor"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -838,7 +838,7 @@ class PathsOperations(object):
     @distributed_trace
     def enum_null(
         self,
-        enum_path,  # type: Union[str, "models.UriColor"]
+        enum_path,  # type: Union[str, "_models.UriColor"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_paths_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class PathsOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -86,7 +86,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -135,7 +135,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -184,7 +184,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -233,7 +233,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -282,7 +282,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -331,7 +331,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -380,7 +380,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -429,7 +429,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -478,7 +478,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -527,7 +527,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -576,7 +576,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -625,7 +625,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -676,7 +676,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -725,7 +725,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -776,7 +776,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -827,7 +827,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -878,7 +878,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -978,7 +978,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1029,7 +1029,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1078,7 +1078,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1130,7 +1130,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1179,7 +1179,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1230,7 +1230,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1281,7 +1281,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1334,7 +1334,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1385,7 +1385,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_paths_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_paths_operations.py
@@ -86,7 +86,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -135,7 +135,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -184,7 +184,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -233,7 +233,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -282,7 +282,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -331,7 +331,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -380,7 +380,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -429,7 +429,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -478,7 +478,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -527,7 +527,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -576,7 +576,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -625,7 +625,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -676,7 +676,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -725,7 +725,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -776,7 +776,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -827,7 +827,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -878,7 +878,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -978,7 +978,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1029,7 +1029,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1078,7 +1078,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1130,7 +1130,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1179,7 +1179,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1230,7 +1230,7 @@ class PathsOperations(object):
 
         if response.status_code not in [400]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1281,7 +1281,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1334,7 +1334,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1385,7 +1385,7 @@ class PathsOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_queries_operations.py
@@ -940,7 +940,7 @@ class QueriesOperations(object):
     @distributed_trace
     def enum_valid(
         self,
-        enum_query=None,  # type: Optional[Union[str, "models.UriColor"]]
+        enum_query=None,  # type: Optional[Union[str, "_models.UriColor"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -989,7 +989,7 @@ class QueriesOperations(object):
     @distributed_trace
     def enum_null(
         self,
-        enum_query=None,  # type: Optional[Union[str, "models.UriColor"]]
+        enum_query=None,  # type: Optional[Union[str, "_models.UriColor"]]
         **kwargs  # type: Any
     ):
         # type: (...) -> None

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_queries_operations.py
@@ -83,7 +83,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -224,7 +224,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -270,7 +270,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -319,7 +319,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -365,7 +365,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -460,7 +460,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -506,7 +506,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -552,7 +552,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -601,7 +601,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -647,7 +647,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -693,7 +693,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -742,7 +742,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -788,7 +788,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -834,7 +834,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -880,7 +880,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -978,7 +978,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1027,7 +1027,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1076,7 +1076,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1122,7 +1122,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1171,7 +1171,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1217,7 +1217,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1266,7 +1266,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1312,7 +1312,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1361,7 +1361,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1412,7 +1412,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1461,7 +1461,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1510,7 +1510,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1560,7 +1560,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1611,7 +1611,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1662,7 +1662,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1713,7 +1713,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Url/url/operations/_queries_operations.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -37,7 +37,7 @@ class QueriesOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -83,7 +83,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -129,7 +129,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -224,7 +224,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -270,7 +270,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -319,7 +319,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -365,7 +365,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -460,7 +460,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -506,7 +506,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -552,7 +552,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -601,7 +601,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -647,7 +647,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -693,7 +693,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -742,7 +742,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -788,7 +788,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -834,7 +834,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -880,7 +880,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -929,7 +929,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -978,7 +978,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1027,7 +1027,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1076,7 +1076,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1122,7 +1122,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1171,7 +1171,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1217,7 +1217,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1266,7 +1266,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1312,7 +1312,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1361,7 +1361,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1412,7 +1412,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1461,7 +1461,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1510,7 +1510,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1560,7 +1560,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1611,7 +1611,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1662,7 +1662,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -1713,7 +1713,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/aio/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/aio/operations/_queries_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class QueriesOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -80,7 +80,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -128,7 +128,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/aio/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/aio/operations/_queries_operations.py
@@ -80,7 +80,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -128,7 +128,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -178,7 +178,7 @@ class QueriesOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/operations/_queries_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class QueriesOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -85,7 +85,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -134,7 +134,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -185,7 +185,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/operations/_queries_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/operations/_queries_operations.py
@@ -85,7 +85,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -134,7 +134,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -185,7 +185,7 @@ class QueriesOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/aio/operations/_auto_rest_validation_test_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/aio/operations/_auto_rest_validation_test_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -69,7 +69,7 @@ class AutoRestValidationTestOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)
@@ -140,7 +140,7 @@ class AutoRestValidationTestOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/aio/operations/_auto_rest_validation_test_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/aio/operations/_auto_rest_validation_test_operations.py
@@ -69,7 +69,7 @@ class AutoRestValidationTestOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)
@@ -140,7 +140,7 @@ class AutoRestValidationTestOperationsMixin:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/aio/operations/_auto_rest_validation_test_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/aio/operations/_auto_rest_validation_test_operations.py
@@ -26,7 +26,7 @@ class AutoRestValidationTestOperationsMixin:
         resource_group_name: str,
         id: int,
         **kwargs
-    ) -> "models.Product":
+    ) -> "_models.Product":
         """Validates input parameters on the method. See swagger for details.
 
         :param resource_group_name: Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
@@ -38,7 +38,7 @@ class AutoRestValidationTestOperationsMixin:
         :rtype: ~validation.models.Product
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -85,9 +85,9 @@ class AutoRestValidationTestOperationsMixin:
         self,
         resource_group_name: str,
         id: int,
-        body: Optional["models.Product"] = None,
+        body: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
+    ) -> "_models.Product":
         """Validates body parameters on the method. See swagger for details.
 
         :param resource_group_name: Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
@@ -101,7 +101,7 @@ class AutoRestValidationTestOperationsMixin:
         :rtype: ~validation.models.Product
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -199,9 +199,9 @@ class AutoRestValidationTestOperationsMixin:
     @distributed_trace_async
     async def post_with_constant_in_body(
         self,
-        body: Optional["models.Product"] = None,
+        body: Optional["_models.Product"] = None,
         **kwargs
-    ) -> "models.Product":
+    ) -> "_models.Product":
         """post_with_constant_in_body.
 
         :param body:
@@ -211,7 +211,7 @@ class AutoRestValidationTestOperationsMixin:
         :rtype: ~validation.models.Product
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/operations/_auto_rest_validation_test_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/operations/_auto_rest_validation_test_operations.py
@@ -31,7 +31,7 @@ class AutoRestValidationTestOperationsMixin(object):
         id,  # type: int
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
+        # type: (...) -> "_models.Product"
         """Validates input parameters on the method. See swagger for details.
 
         :param resource_group_name: Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
@@ -43,7 +43,7 @@ class AutoRestValidationTestOperationsMixin(object):
         :rtype: ~validation.models.Product
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -90,10 +90,10 @@ class AutoRestValidationTestOperationsMixin(object):
         self,
         resource_group_name,  # type: str
         id,  # type: int
-        body=None,  # type: Optional["models.Product"]
+        body=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
+        # type: (...) -> "_models.Product"
         """Validates body parameters on the method. See swagger for details.
 
         :param resource_group_name: Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
@@ -107,7 +107,7 @@ class AutoRestValidationTestOperationsMixin(object):
         :rtype: ~validation.models.Product
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -206,10 +206,10 @@ class AutoRestValidationTestOperationsMixin(object):
     @distributed_trace
     def post_with_constant_in_body(
         self,
-        body=None,  # type: Optional["models.Product"]
+        body=None,  # type: Optional["_models.Product"]
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Product"
+        # type: (...) -> "_models.Product"
         """post_with_constant_in_body.
 
         :param body:
@@ -219,7 +219,7 @@ class AutoRestValidationTestOperationsMixin(object):
         :rtype: ~validation.models.Product
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Product"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Product"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/operations/_auto_rest_validation_test_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/operations/_auto_rest_validation_test_operations.py
@@ -74,7 +74,7 @@ class AutoRestValidationTestOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)
@@ -146,7 +146,7 @@ class AutoRestValidationTestOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Validation/validation/operations/_auto_rest_validation_test_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/validation/operations/_auto_rest_validation_test_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -74,7 +74,7 @@ class AutoRestValidationTestOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)
@@ -146,7 +146,7 @@ class AutoRestValidationTestOperationsMixin(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Product', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/aio/operations/_xml_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/aio/operations/_xml_operations.py
@@ -261,7 +261,7 @@ class XmlOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Slideshow', pipeline_response)
@@ -315,7 +315,7 @@ class XmlOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class XmlOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/aio/operations/_xml_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/aio/operations/_xml_operations.py
@@ -44,7 +44,7 @@ class XmlOperations:
     async def get_complex_type_ref_no_meta(
         self,
         **kwargs
-    ) -> "models.RootWithRefAndNoMeta":
+    ) -> "_models.RootWithRefAndNoMeta":
         """Get a complex type that has a ref to a complex type with no XML node.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -52,7 +52,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.RootWithRefAndNoMeta
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.RootWithRefAndNoMeta"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.RootWithRefAndNoMeta"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -88,7 +88,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_complex_type_ref_no_meta(
         self,
-        model: "models.RootWithRefAndNoMeta",
+        model: "_models.RootWithRefAndNoMeta",
         **kwargs
     ) -> None:
         """Puts a complex type that has a ref to a complex type with no XML node.
@@ -137,7 +137,7 @@ class XmlOperations:
     async def get_complex_type_ref_with_meta(
         self,
         **kwargs
-    ) -> "models.RootWithRefAndMeta":
+    ) -> "_models.RootWithRefAndMeta":
         """Get a complex type that has a ref to a complex type with XML node.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -145,7 +145,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.RootWithRefAndMeta
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.RootWithRefAndMeta"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.RootWithRefAndMeta"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -181,7 +181,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_complex_type_ref_with_meta(
         self,
-        model: "models.RootWithRefAndMeta",
+        model: "_models.RootWithRefAndMeta",
         **kwargs
     ) -> None:
         """Puts a complex type that has a ref to a complex type with XML node.
@@ -230,7 +230,7 @@ class XmlOperations:
     async def get_simple(
         self,
         **kwargs
-    ) -> "models.Slideshow":
+    ) -> "_models.Slideshow":
         """Get a simple XML document.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -238,7 +238,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.Slideshow
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Slideshow"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Slideshow"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -275,7 +275,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_simple(
         self,
-        slideshow: "models.Slideshow",
+        slideshow: "_models.Slideshow",
         **kwargs
     ) -> None:
         """Put a simple XML document.
@@ -327,7 +327,7 @@ class XmlOperations:
     async def get_wrapped_lists(
         self,
         **kwargs
-    ) -> "models.AppleBarrel":
+    ) -> "_models.AppleBarrel":
         """Get an XML document with multiple wrapped lists.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -335,7 +335,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.AppleBarrel
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.AppleBarrel"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.AppleBarrel"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -371,7 +371,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_wrapped_lists(
         self,
-        wrapped_lists: "models.AppleBarrel",
+        wrapped_lists: "_models.AppleBarrel",
         **kwargs
     ) -> None:
         """Put an XML document with multiple wrapped lists.
@@ -466,7 +466,7 @@ class XmlOperations:
     async def get_empty_list(
         self,
         **kwargs
-    ) -> "models.Slideshow":
+    ) -> "_models.Slideshow":
         """Get an empty list.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -474,7 +474,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.Slideshow
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Slideshow"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Slideshow"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -510,7 +510,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_empty_list(
         self,
-        slideshow: "models.Slideshow",
+        slideshow: "_models.Slideshow",
         **kwargs
     ) -> None:
         """Puts an empty list.
@@ -559,7 +559,7 @@ class XmlOperations:
     async def get_empty_wrapped_lists(
         self,
         **kwargs
-    ) -> "models.AppleBarrel":
+    ) -> "_models.AppleBarrel":
         """Gets some empty wrapped lists.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -567,7 +567,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.AppleBarrel
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.AppleBarrel"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.AppleBarrel"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -603,7 +603,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_empty_wrapped_lists(
         self,
-        apple_barrel: "models.AppleBarrel",
+        apple_barrel: "_models.AppleBarrel",
         **kwargs
     ) -> None:
         """Puts some empty wrapped lists.
@@ -652,7 +652,7 @@ class XmlOperations:
     async def get_root_list(
         self,
         **kwargs
-    ) -> List["models.Banana"]:
+    ) -> List["_models.Banana"]:
         """Gets a list as the root element.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -660,7 +660,7 @@ class XmlOperations:
         :rtype: list[~xmlservice.models.Banana]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Banana"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Banana"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -696,7 +696,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_root_list(
         self,
-        bananas: List["models.Banana"],
+        bananas: List["_models.Banana"],
         **kwargs
     ) -> None:
         """Puts a list as the root element.
@@ -746,7 +746,7 @@ class XmlOperations:
     async def get_root_list_single_item(
         self,
         **kwargs
-    ) -> List["models.Banana"]:
+    ) -> List["_models.Banana"]:
         """Gets a list with a single item.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -754,7 +754,7 @@ class XmlOperations:
         :rtype: list[~xmlservice.models.Banana]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Banana"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Banana"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -790,7 +790,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_root_list_single_item(
         self,
-        bananas: List["models.Banana"],
+        bananas: List["_models.Banana"],
         **kwargs
     ) -> None:
         """Puts a list with a single item.
@@ -840,7 +840,7 @@ class XmlOperations:
     async def get_empty_root_list(
         self,
         **kwargs
-    ) -> List["models.Banana"]:
+    ) -> List["_models.Banana"]:
         """Gets an empty list as the root element.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -848,7 +848,7 @@ class XmlOperations:
         :rtype: list[~xmlservice.models.Banana]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Banana"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Banana"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -884,7 +884,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_empty_root_list(
         self,
-        bananas: List["models.Banana"],
+        bananas: List["_models.Banana"],
         **kwargs
     ) -> None:
         """Puts an empty list as the root element.
@@ -934,7 +934,7 @@ class XmlOperations:
     async def get_empty_child_element(
         self,
         **kwargs
-    ) -> "models.Banana":
+    ) -> "_models.Banana":
         """Gets an XML document with an empty child element.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -942,7 +942,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.Banana
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Banana"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Banana"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -978,7 +978,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_empty_child_element(
         self,
-        banana: "models.Banana",
+        banana: "_models.Banana",
         **kwargs
     ) -> None:
         """Puts a value with an empty child element.
@@ -1027,7 +1027,7 @@ class XmlOperations:
     async def list_containers(
         self,
         **kwargs
-    ) -> "models.ListContainersResponse":
+    ) -> "_models.ListContainersResponse":
         """Lists containers in a storage account.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1035,7 +1035,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.ListContainersResponse
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ListContainersResponse"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ListContainersResponse"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1074,7 +1074,7 @@ class XmlOperations:
     async def get_service_properties(
         self,
         **kwargs
-    ) -> "models.StorageServiceProperties":
+    ) -> "_models.StorageServiceProperties":
         """Gets storage service properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1082,7 +1082,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.StorageServiceProperties
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageServiceProperties"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageServiceProperties"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1122,7 +1122,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_service_properties(
         self,
-        properties: "models.StorageServiceProperties",
+        properties: "_models.StorageServiceProperties",
         **kwargs
     ) -> None:
         """Puts storage service properties.
@@ -1175,7 +1175,7 @@ class XmlOperations:
     async def get_acls(
         self,
         **kwargs
-    ) -> List["models.SignedIdentifier"]:
+    ) -> List["_models.SignedIdentifier"]:
         """Gets storage ACLs for a container.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1183,7 +1183,7 @@ class XmlOperations:
         :rtype: list[~xmlservice.models.SignedIdentifier]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.SignedIdentifier"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.SignedIdentifier"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1223,7 +1223,7 @@ class XmlOperations:
     @distributed_trace_async
     async def put_acls(
         self,
-        properties: List["models.SignedIdentifier"],
+        properties: List["_models.SignedIdentifier"],
         **kwargs
     ) -> None:
         """Puts storage ACLs for a container.
@@ -1277,7 +1277,7 @@ class XmlOperations:
     async def list_blobs(
         self,
         **kwargs
-    ) -> "models.ListBlobsResponse":
+    ) -> "_models.ListBlobsResponse":
         """Lists blobs in a storage container.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1285,7 +1285,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.ListBlobsResponse
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ListBlobsResponse"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ListBlobsResponse"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1344,7 +1344,7 @@ class XmlOperations:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _properties = models.JSONInput(id=id)
+        _properties = _models.JSONInput(id=id)
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL
@@ -1377,7 +1377,7 @@ class XmlOperations:
     async def json_output(
         self,
         **kwargs
-    ) -> "models.JSONOutput":
+    ) -> "_models.JSONOutput":
         """A Swagger with XML that has one operation that returns JSON. ID number 42.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1385,7 +1385,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.JSONOutput
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.JSONOutput"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.JSONOutput"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1422,7 +1422,7 @@ class XmlOperations:
     async def get_xms_text(
         self,
         **kwargs
-    ) -> "models.ObjectWithXMsTextProperty":
+    ) -> "_models.ObjectWithXMsTextProperty":
         """Get back an XML object with an x-ms-text property, which should translate to the returned
         object's 'language' property being 'english' and its 'content' property being 'I am text'.
 
@@ -1431,7 +1431,7 @@ class XmlOperations:
         :rtype: ~xmlservice.models.ObjectWithXMsTextProperty
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ObjectWithXMsTextProperty"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ObjectWithXMsTextProperty"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/aio/operations/_xml_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/aio/operations/_xml_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class XmlOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -261,7 +261,7 @@ class XmlOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Slideshow', pipeline_response)
@@ -315,7 +315,7 @@ class XmlOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -411,7 +411,7 @@ class XmlOperations:
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/operations/_xml_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/operations/_xml_operations.py
@@ -270,7 +270,7 @@ class XmlOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Slideshow', pipeline_response)
@@ -325,7 +325,7 @@ class XmlOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -423,7 +423,7 @@ class XmlOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.Error, response)
+            error = self._deserialize(self.models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/operations/_xml_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/operations/_xml_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class XmlOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -270,7 +270,7 @@ class XmlOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('Slideshow', pipeline_response)
@@ -325,7 +325,7 @@ class XmlOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:
@@ -423,7 +423,7 @@ class XmlOperations(object):
 
         if response.status_code not in [201]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.Error, response)
+            error = self._deserialize(_models.Error, response)
             raise HttpResponseError(response=response, model=error)
 
         if cls:

--- a/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/operations/_xml_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/Xml/xmlservice/operations/_xml_operations.py
@@ -49,7 +49,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.RootWithRefAndNoMeta"
+        # type: (...) -> "_models.RootWithRefAndNoMeta"
         """Get a complex type that has a ref to a complex type with no XML node.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -57,7 +57,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.RootWithRefAndNoMeta
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.RootWithRefAndNoMeta"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.RootWithRefAndNoMeta"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -93,7 +93,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_complex_type_ref_no_meta(
         self,
-        model,  # type: "models.RootWithRefAndNoMeta"
+        model,  # type: "_models.RootWithRefAndNoMeta"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -144,7 +144,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.RootWithRefAndMeta"
+        # type: (...) -> "_models.RootWithRefAndMeta"
         """Get a complex type that has a ref to a complex type with XML node.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -152,7 +152,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.RootWithRefAndMeta
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.RootWithRefAndMeta"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.RootWithRefAndMeta"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -188,7 +188,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_complex_type_ref_with_meta(
         self,
-        model,  # type: "models.RootWithRefAndMeta"
+        model,  # type: "_models.RootWithRefAndMeta"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -239,7 +239,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Slideshow"
+        # type: (...) -> "_models.Slideshow"
         """Get a simple XML document.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -247,7 +247,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.Slideshow
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Slideshow"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Slideshow"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -284,7 +284,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_simple(
         self,
-        slideshow,  # type: "models.Slideshow"
+        slideshow,  # type: "_models.Slideshow"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -338,7 +338,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.AppleBarrel"
+        # type: (...) -> "_models.AppleBarrel"
         """Get an XML document with multiple wrapped lists.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -346,7 +346,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.AppleBarrel
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.AppleBarrel"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.AppleBarrel"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -382,7 +382,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_wrapped_lists(
         self,
-        wrapped_lists,  # type: "models.AppleBarrel"
+        wrapped_lists,  # type: "_models.AppleBarrel"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -480,7 +480,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Slideshow"
+        # type: (...) -> "_models.Slideshow"
         """Get an empty list.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -488,7 +488,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.Slideshow
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Slideshow"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Slideshow"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -524,7 +524,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_empty_list(
         self,
-        slideshow,  # type: "models.Slideshow"
+        slideshow,  # type: "_models.Slideshow"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -575,7 +575,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.AppleBarrel"
+        # type: (...) -> "_models.AppleBarrel"
         """Gets some empty wrapped lists.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -583,7 +583,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.AppleBarrel
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.AppleBarrel"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.AppleBarrel"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -619,7 +619,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_empty_wrapped_lists(
         self,
-        apple_barrel,  # type: "models.AppleBarrel"
+        apple_barrel,  # type: "_models.AppleBarrel"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -670,7 +670,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Banana"]
+        # type: (...) -> List["_models.Banana"]
         """Gets a list as the root element.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -678,7 +678,7 @@ class XmlOperations(object):
         :rtype: list[~xmlservice.models.Banana]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Banana"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Banana"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -714,7 +714,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_root_list(
         self,
-        bananas,  # type: List["models.Banana"]
+        bananas,  # type: List["_models.Banana"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -766,7 +766,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Banana"]
+        # type: (...) -> List["_models.Banana"]
         """Gets a list with a single item.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -774,7 +774,7 @@ class XmlOperations(object):
         :rtype: list[~xmlservice.models.Banana]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Banana"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Banana"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -810,7 +810,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_root_list_single_item(
         self,
-        bananas,  # type: List["models.Banana"]
+        bananas,  # type: List["_models.Banana"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -862,7 +862,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.Banana"]
+        # type: (...) -> List["_models.Banana"]
         """Gets an empty list as the root element.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -870,7 +870,7 @@ class XmlOperations(object):
         :rtype: list[~xmlservice.models.Banana]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.Banana"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.Banana"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -906,7 +906,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_empty_root_list(
         self,
-        bananas,  # type: List["models.Banana"]
+        bananas,  # type: List["_models.Banana"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -958,7 +958,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.Banana"
+        # type: (...) -> "_models.Banana"
         """Gets an XML document with an empty child element.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -966,7 +966,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.Banana
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.Banana"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.Banana"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1002,7 +1002,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_empty_child_element(
         self,
-        banana,  # type: "models.Banana"
+        banana,  # type: "_models.Banana"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1053,7 +1053,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ListContainersResponse"
+        # type: (...) -> "_models.ListContainersResponse"
         """Lists containers in a storage account.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1061,7 +1061,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.ListContainersResponse
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ListContainersResponse"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ListContainersResponse"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1101,7 +1101,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.StorageServiceProperties"
+        # type: (...) -> "_models.StorageServiceProperties"
         """Gets storage service properties.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1109,7 +1109,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.StorageServiceProperties
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.StorageServiceProperties"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.StorageServiceProperties"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1149,7 +1149,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_service_properties(
         self,
-        properties,  # type: "models.StorageServiceProperties"
+        properties,  # type: "_models.StorageServiceProperties"
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1204,7 +1204,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> List["models.SignedIdentifier"]
+        # type: (...) -> List["_models.SignedIdentifier"]
         """Gets storage ACLs for a container.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1212,7 +1212,7 @@ class XmlOperations(object):
         :rtype: list[~xmlservice.models.SignedIdentifier]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[List["models.SignedIdentifier"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[List["_models.SignedIdentifier"]]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1252,7 +1252,7 @@ class XmlOperations(object):
     @distributed_trace
     def put_acls(
         self,
-        properties,  # type: List["models.SignedIdentifier"]
+        properties,  # type: List["_models.SignedIdentifier"]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1308,7 +1308,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ListBlobsResponse"
+        # type: (...) -> "_models.ListBlobsResponse"
         """Lists blobs in a storage container.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1316,7 +1316,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.ListBlobsResponse
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ListBlobsResponse"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ListBlobsResponse"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1376,7 +1376,7 @@ class XmlOperations(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        _properties = models.JSONInput(id=id)
+        _properties = _models.JSONInput(id=id)
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL
@@ -1410,7 +1410,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.JSONOutput"
+        # type: (...) -> "_models.JSONOutput"
         """A Swagger with XML that has one operation that returns JSON. ID number 42.
 
         :keyword callable cls: A custom type or function that will be passed the direct response
@@ -1418,7 +1418,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.JSONOutput
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.JSONOutput"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.JSONOutput"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
@@ -1456,7 +1456,7 @@ class XmlOperations(object):
         self,
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.ObjectWithXMsTextProperty"
+        # type: (...) -> "_models.ObjectWithXMsTextProperty"
         """Get back an XML object with an x-ms-text property, which should translate to the returned
         object's 'language' property being 'english' and its 'content' property being 'I am text'.
 
@@ -1465,7 +1465,7 @@ class XmlOperations(object):
         :rtype: ~xmlservice.models.ObjectWithXMsTextProperty
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.ObjectWithXMsTextProperty"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.ObjectWithXMsTextProperty"]
         error_map = {
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }

--- a/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/aio/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/aio/operations/_pet_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
-from ... import models
+from ... import models as _models
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
@@ -32,7 +32,7 @@ class PetOperations:
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer) -> None:
         self._client = client
@@ -60,7 +60,7 @@ class PetOperations:
             401: ClientAuthenticationError,
             409: ResourceExistsError,
             400: HttpResponseError,
-            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(self.models.NotFoundErrorBase, response)),
+            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(_models.NotFoundErrorBase, response)),
             501: HttpResponseError,
         }
         error_map.update(kwargs.pop('error_map', {}))
@@ -118,7 +118,7 @@ class PetOperations:
             401: ClientAuthenticationError,
             404: ResourceNotFoundError,
             409: ResourceExistsError,
-            500: lambda response: HttpResponseError(response=response, model=self._deserialize(self.models.PetActionError, response)),
+            500: lambda response: HttpResponseError(response=response, model=self._deserialize(_models.PetActionError, response)),
         }
         error_map.update(kwargs.pop('error_map', {}))
         accept = "application/json"
@@ -143,7 +143,7 @@ class PetOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.PetActionError, response)
+            error = self._deserialize(_models.PetActionError, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAction', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/aio/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/aio/operations/_pet_operations.py
@@ -45,7 +45,7 @@ class PetOperations:
         self,
         pet_id: str,
         **kwargs
-    ) -> Optional["models.Pet"]:
+    ) -> Optional["_models.Pet"]:
         """Gets pets by id.
 
         :param pet_id: pet id.
@@ -55,7 +55,7 @@ class PetOperations:
         :rtype: ~xmserrorresponse.models.Pet or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Pet"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Pet"]]
         error_map = {
             401: ClientAuthenticationError,
             409: ResourceExistsError,
@@ -103,7 +103,7 @@ class PetOperations:
         self,
         what_action: str,
         **kwargs
-    ) -> "models.PetAction":
+    ) -> "_models.PetAction":
         """Asks pet to do something.
 
         :param what_action: what action the pet should do.
@@ -113,7 +113,7 @@ class PetOperations:
         :rtype: ~xmserrorresponse.models.PetAction
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAction"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAction"]
         error_map = {
             401: ClientAuthenticationError,
             404: ResourceNotFoundError,

--- a/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/aio/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/aio/operations/_pet_operations.py
@@ -60,7 +60,7 @@ class PetOperations:
             401: ClientAuthenticationError,
             409: ResourceExistsError,
             400: HttpResponseError,
-            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(models.NotFoundErrorBase, response)),
+            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(self.models.NotFoundErrorBase, response)),
             501: HttpResponseError,
         }
         error_map.update(kwargs.pop('error_map', {}))
@@ -118,7 +118,7 @@ class PetOperations:
             401: ClientAuthenticationError,
             404: ResourceNotFoundError,
             409: ResourceExistsError,
-            500: lambda response: HttpResponseError(response=response, model=self._deserialize(models.PetActionError, response)),
+            500: lambda response: HttpResponseError(response=response, model=self._deserialize(self.models.PetActionError, response)),
         }
         error_map.update(kwargs.pop('error_map', {}))
         accept = "application/json"
@@ -143,7 +143,7 @@ class PetOperations:
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.PetActionError, response)
+            error = self._deserialize(self.models.PetActionError, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAction', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/operations/_pet_operations.py
@@ -50,7 +50,7 @@ class PetOperations(object):
         pet_id,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional["models.Pet"]
+        # type: (...) -> Optional["_models.Pet"]
         """Gets pets by id.
 
         :param pet_id: pet id.
@@ -60,7 +60,7 @@ class PetOperations(object):
         :rtype: ~xmserrorresponse.models.Pet or None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["models.Pet"]]
+        cls = kwargs.pop('cls', None)  # type: ClsType[Optional["_models.Pet"]]
         error_map = {
             401: ClientAuthenticationError,
             409: ResourceExistsError,
@@ -109,7 +109,7 @@ class PetOperations(object):
         what_action,  # type: str
         **kwargs  # type: Any
     ):
-        # type: (...) -> "models.PetAction"
+        # type: (...) -> "_models.PetAction"
         """Asks pet to do something.
 
         :param what_action: what action the pet should do.
@@ -119,7 +119,7 @@ class PetOperations(object):
         :rtype: ~xmserrorresponse.models.PetAction
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        cls = kwargs.pop('cls', None)  # type: ClsType["models.PetAction"]
+        cls = kwargs.pop('cls', None)  # type: ClsType["_models.PetAction"]
         error_map = {
             401: ClientAuthenticationError,
             404: ResourceNotFoundError,

--- a/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/operations/_pet_operations.py
@@ -65,7 +65,7 @@ class PetOperations(object):
             401: ClientAuthenticationError,
             409: ResourceExistsError,
             400: HttpResponseError,
-            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(models.NotFoundErrorBase, response)),
+            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(self.models.NotFoundErrorBase, response)),
             501: HttpResponseError,
         }
         error_map.update(kwargs.pop('error_map', {}))
@@ -124,7 +124,7 @@ class PetOperations(object):
             401: ClientAuthenticationError,
             404: ResourceNotFoundError,
             409: ResourceExistsError,
-            500: lambda response: HttpResponseError(response=response, model=self._deserialize(models.PetActionError, response)),
+            500: lambda response: HttpResponseError(response=response, model=self._deserialize(self.models.PetActionError, response)),
         }
         error_map.update(kwargs.pop('error_map', {}))
         accept = "application/json"
@@ -149,7 +149,7 @@ class PetOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(models.PetActionError, response)
+            error = self._deserialize(self.models.PetActionError, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAction', pipeline_response)

--- a/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/operations/_pet_operations.py
+++ b/test/vanilla/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/operations/_pet_operations.py
@@ -13,7 +13,7 @@ from azure.core.pipeline import PipelineResponse
 from azure.core.pipeline.transport import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
-from .. import models
+from .. import models as _models
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
@@ -36,7 +36,7 @@ class PetOperations(object):
     :param deserializer: An object model deserializer.
     """
 
-    models = models
+    models = _models
 
     def __init__(self, client, config, serializer, deserializer):
         self._client = client
@@ -65,7 +65,7 @@ class PetOperations(object):
             401: ClientAuthenticationError,
             409: ResourceExistsError,
             400: HttpResponseError,
-            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(self.models.NotFoundErrorBase, response)),
+            404: lambda response: ResourceNotFoundError(response=response, model=self._deserialize(_models.NotFoundErrorBase, response)),
             501: HttpResponseError,
         }
         error_map.update(kwargs.pop('error_map', {}))
@@ -124,7 +124,7 @@ class PetOperations(object):
             401: ClientAuthenticationError,
             404: ResourceNotFoundError,
             409: ResourceExistsError,
-            500: lambda response: HttpResponseError(response=response, model=self._deserialize(self.models.PetActionError, response)),
+            500: lambda response: HttpResponseError(response=response, model=self._deserialize(_models.PetActionError, response)),
         }
         error_map.update(kwargs.pop('error_map', {}))
         accept = "application/json"
@@ -149,7 +149,7 @@ class PetOperations(object):
 
         if response.status_code not in [200]:
             map_error(status_code=response.status_code, response=response, error_map=error_map)
-            error = self._deserialize(self.models.PetActionError, response)
+            error = self._deserialize(_models.PetActionError, response)
             raise HttpResponseError(response=response, model=error)
 
         deserialized = self._deserialize('PetAction', pipeline_response)


### PR DESCRIPTION
this will avoid errors when the operation has a parameter called `model`

don't want to block this PR on testserver, here're the tests I'm adding in a separate PR https://github.com/Azure/autorest.python/pull/820