### PR TITLE
Upgrade `@autorest/modelerfour` to `4.15.442`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ### 2020-xx-xx - 5.6.0
 Autorest core version: 3.0.6318
 
-Modelerfour version: 4.15.421
+Modelerfour version: 4.15.442
 
 **New Features**
 
@@ -12,6 +12,7 @@ Modelerfour version: 4.15.421
 **Bug Fixes**
 
 - Wrap individual enum descriptions  #844
+- Bump `Modelerfour` minimum version to `4.15.442` to fix [circular reference error](https://github.com/Azure/autorest/issues/3630)  #865
 
 ### 2020-11-12 - 5.5.0
 Autorest core version: 3.0.6318

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pass-thru:
   - subset-reducer
 version: ^3.0.6318
 use-extension:
-  "@autorest/modelerfour": 4.15.432
+  "@autorest/modelerfour": 4.15.442
 
 modelerfour:
   group-parameters: true


### PR DESCRIPTION
Upgrading `@autorest/modelerfour` to `4.15.442` to address this issue https://github.com/Azure/autorest/issues/3630