### PR TITLE
Fix: Loading 'python' nested config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 pass-thru:
   - model-deduplicator
   - subset-reducer
-version: ^3.0.6372
+version: ^3.1.0
 use-extension:
   "@autorest/modelerfour": ^4.15.456
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ modelerfour:
 
 pipeline:
   python:
-    # doesn't process anything, just makes it so that the 'python:' config section loads early.
+    # Doesn't process anything, just makes it so that the 'python:' config section is loaded and available for the next plugins.
     pass-thru: true
     input: modelerfour/identity
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,10 @@ pipeline:
   python:
     # doesn't process anything, just makes it so that the 'python:' config section loads early.
     pass-thru: true
-    input: openapi-document/multi-api/identity
-
-  modelerfour:
-    # in order that the modelerfour/flattener/grouper/etc picks up
-    # configuration nested under python: in the user's config,
-    # we have to make modeler four pull from the 'python' task.
-    input: python
+    input: modelerfour/identity
 
   python/m2r:
-    input: modelerfour/identity
+    input: python
 
   python/namer:
     input: python/m2r

--- a/docs/generate/directives.md
+++ b/docs/generate/directives.md
@@ -7,9 +7,9 @@ These directives all start out with this general skeleton of a directive:
 ````
 ```yaml
 directive:
-    from: swagger-document
-    where: ...
-    transform: ...
+    - from: swagger-document
+      where: ...
+      transform: ...
 ```
 ````
 
@@ -42,9 +42,9 @@ We use `$["x-python-custom-poller-sync"]` and `$["x-python-custom-poller-async"]
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/polling"].put'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/polling"].put'
+      transform: >
         $["x-python-custom-poller-sync"] = "my.library.CustomPoller";
         $["x-python-custom-poller-async"] = "my.library.aio.AsyncCustomPoller"
 ```
@@ -72,9 +72,9 @@ We use `$["x-python-custom-default-polling-method-sync"]` and `$["x-python-custo
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/polling"].put'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/polling"].put'
+      transform: >
         $["x-python-custom-default-polling-method-sync"] = "my.library.CustomDefaultPollingMethod";
         $["x-python-custom-default-polling-method-async"] = "my.library.aio.AsyncCustomDefaultPollingMethod"
 ```
@@ -101,9 +101,9 @@ We use `$["x-python-custom-pager-sync"]` and `$["x-python-custom-pager-async"]` 
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/paging"].get'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/paging"].get'
+      transform: >
         $["x-python-custom-pager-sync"] = "my.library.CustomPager";
         $["x-python-custom-pager-async"] = "my.library.aio.AsyncCustomPager"
 ```
@@ -130,9 +130,9 @@ We use `$["x-python-custom-default-paging-method]` to specify our default  pagin
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/paging"].get'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/paging"].get'
+      transform: >
         $["x-python-custom-default-paging-method"] = "my.library.CustomDefaultPagingMethod";
 ```
 

--- a/docs/samples/specification/directives/readme.md
+++ b/docs/samples/specification/directives/readme.md
@@ -16,9 +16,9 @@ clear-output-folder: true
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/polling"].put'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/polling"].put'
+      transform: >
         $["x-python-custom-poller-sync"] = "my.library.CustomPoller";
         $["x-python-custom-poller-async"] = "my.library.aio.AsyncCustomPoller"
 ```
@@ -27,9 +27,9 @@ directive:
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/polling"].put'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/polling"].put'
+      transform: >
         $["x-python-custom-default-polling-method-sync"] = "my.library.CustomDefaultPollingMethod";
         $["x-python-custom-default-polling-method-async"] = "my.library.aio.AsyncCustomDefaultPollingMethod"
 ```
@@ -39,9 +39,9 @@ directive:
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/paging"].get'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/paging"].get'
+      transform: >
         $["x-python-custom-pager-sync"] = "my.library.CustomPager";
         $["x-python-custom-pager-async"] = "my.library.aio.AsyncCustomPager"
 ```
@@ -50,8 +50,8 @@ directive:
 
 ```yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/basic/paging"].get'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/basic/paging"].get'
+      transform: >
         $["x-python-custom-default-paging-method"] = "my.library.CustomDefaultPagingMethod";
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "homepage": "https://github.com/Azure/autorest.python/blob/autorestv3/README.md",
     "dependencies": {
-        "@azure-tools/extension": "^3.0.249"
+        "@azure-tools/extension": "~3.2.1"
     },
     "devDependencies": {
         "@autorest/autorest": "^3.0.0",

--- a/test/azure/specification/custompollerpager/README.md
+++ b/test/azure/specification/custompollerpager/README.md
@@ -20,9 +20,9 @@ clear-output-folder: true
 ### Override ItemPaged to custom Pager
 ``` yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/paging/single"].get'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/paging/single"].get'
+      transform: >
         $["x-python-custom-pager-sync"] = "custompollerpagerdefinitions.CustomPager";
         $["x-python-custom-pager-async"] = "custompollerpagerdefinitions.aio.AsyncCustomPager"
 ```
@@ -30,9 +30,9 @@ directive:
 ### Override LROPoller to custom Poller
 ``` yaml
 directive:
-    from: swagger-document
-    where: '$.paths["/paging/multiple/lro"].post'
-    transform: >
+    - from: swagger-document
+      where: '$.paths["/paging/multiple/lro"].post'
+      transform: >
         $["x-python-custom-poller-sync"] = "custompollerpagerdefinitions.CustomPoller";
         $["x-python-custom-poller-async"] = "custompollerpagerdefinitions.aio.AsyncCustomPoller"
 ```


### PR DESCRIPTION
So the issue seems to have appear in release [5.0.0-preview.4](https://github.com/Azure/autorest.python/releases/tag/v5.1.0-preview.4) when m4 was updated. The change in m4 was the addition of prechecker which changed the pipeline loading order and broke this hack.

Change here is to forget about loading the `python:` nested configuration before modelerfour(This shouldn't be expected anyway) but just loading it before all the other plugins so it is available.


```yaml
# This will work:
python: 
  output-folder: ./my-python-override

# But here modelerfour won't be able to use that  some-m4-config value
python: 
  modelerfour: 
    some-m4-config: foo
```

To achieve #2, you should be doing:
````md
```yaml $(python)
modelerfour: 
  some-m4-config: foo
```
````

Using `python:` is meant to pass configuration only for the python plugin not if `--python` has been passed