### PR TITLE
Feature: Add help-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,39 @@ scope-black/emitter:
 output-artifact: python-files
 ```
 
+# Help
+
+```yaml
+help-content:
+  python: # type: Help as defined in autorest-core/help.ts
+    activationScope: python
+    categoryFriendlyName: Python Generator
+    settings:
+      - key: python-sdks-folder
+        description: The path to the root directory of your azure-sdk-for-python clone. Be sure to note that we include `sdk` in the folder path.
+      - key: black
+        description: Runs black formatting on your generated files. Defaults to `false`.
+        type: string
+      - key: basic-setup-py
+        description: Whether to generate a build script for setuptools to package your SDK.  Defaults to `false`, generally not suggested if you are going to wrap the generated code
+        type: bool
+      - key: multiapi
+        description: Whether to generate a multiapi client.
+        type: bool
+      - key: default-api
+        description: In the case of `--multiapi`, you can override the default service API version with this flag. If not specified, we use the latest GA service version as the default API.
+        type: string
+      - key: no-namespace-folders
+        description: Specify if you don't want pkgutil-style namespace folders. Defaults to `false`.
+        type: bool
+      - key: credential-default-policy-type
+        description: Specify the default credential policy (authentication policy) for your client. Use in conjunction with `--add-credential`. Currently only supports `BearerTokenCredentialPolicy` and `AzureKeyCredentialPolicy`. Default value is `BearerTokenCredentialPolicy`. `--credential-scopes` is tied with `BearerTokenCredentialPolicy`, do not pass them in if you want `AzureKeyCredentialPolicy`.
+        type: string
+      - key: credential-key-header-name
+        description: The name of the header which will pass the credential. Use if you have `--credential-default-policy-type` set to `AzureKeyCredentialPolicy`. For example, if generating cognitive services code, you might use `--credential-key-header-name=Ocp-Apim-Subscription-Key`
+        type: string
+```
+
 <!-- LINKS -->
 
 [python_docs]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/readme.md


### PR DESCRIPTION
Seems like this used to be in `master` but got removed at some point.  

Used flags defined in the documentation here https://github.com/Azure/autorest/blob/master/docs/generate/flags.md

Result when loading this extension with `--help`
![image](https://user-images.githubusercontent.com/1031227/109704066-087b6400-7b4b-11eb-8ab1-046ac1a5dfaa.png)
