### PR TITLE
Only required constant should be declared as a class variable

### DIFF
--- a/autorest/codegen/templates/model.py.jinja2
+++ b/autorest/codegen/templates/model.py.jinja2
@@ -59,9 +59,9 @@ class {{ model.name }}(msrest.serialization.Model):
         {{ model.xml_map_content() }}
     }
     {% endif %}
-    {% if (model.properties | selectattr('constant') | first) is defined %}
+    {% if (model.properties | selectattr('constant') | selectattr('required') | first) is defined %}
 
-        {% for p in model.properties | selectattr('constant')%}
+        {% for p in model.properties | selectattr('constant') | selectattr('required') %}
     {{ p.name }} = {{ p.constant_declaration }}
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
Resolve https://github.com/Azure/azure-rest-api-specs/issues/14305

Add a condition `required`.

Property is defined in https://github.com/Azure/autorest.python/blob/autorestv3/autorest/codegen/models/property.py

`constant` is defined by following code in https://github.com/Azure/autorest/blob/master/packages/extensions/modelerfour/src/modeler/modelerfour.ts
```
    if (!alwaysSeal && xmse?.modelAsString !== true && choices.length === 1) {
      const constVal = choices[0].value;

      return this.codeModel.schemas.add(
        new ConstantSchema(name, this.interpret.getDescription(``, schema), {
          extensions: this.interpret.getExtensionProperties(schema),
          summary: schema.title,
          defaultValue: schema.default,
          deprecated: this.interpret.getDeprecation(schema),
          apiVersions: this.interpret.getApiVersions(schema),
          example: this.interpret.getExample(schema),
          externalDocs: this.interpret.getExternalDocs(schema),
          serialization: this.interpret.getSerialization(schema),
          valueType: type,
          value: new ConstantValue(this.interpret.getConstantValue(schema, constVal)),
        }),
      );
    }
```