### PR TITLE
Remove autorest cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,9 @@
     },
     "homepage": "https://github.com/Azure/autorest.python/blob/autorestv3/README.md",
     "dependencies": {
-        "@azure-tools/extension": "~3.2.1",
-        "autorest": "^3.2.0"
+        "@azure-tools/extension": "~3.2.1"
     },
     "devDependencies": {
-        "@autorest/autorest": "^3.0.0",
         "@microsoft.azure/autorest.testserver": "^3.0.35"
     },
     "files": [


### PR DESCRIPTION
Don't believe this is should be required
- `autorest` is the cli
- `@autorest/autorest` I think is an outdated package from the original v3 migration