### PR TITLE
fix windows: clean the outputFolderUri 

### DIFF
--- a/autorest/black/__init__.py
+++ b/autorest/black/__init__.py
@@ -5,8 +5,8 @@
 # --------------------------------------------------------------------------
 import logging
 from pathlib import Path
-import black
 import os
+import black
 
 from .. import Plugin
 

--- a/autorest/black/__init__.py
+++ b/autorest/black/__init__.py
@@ -21,6 +21,8 @@ class BlackScriptPlugin(Plugin):
         output_folder_uri = self._autorestapi.get_value("outputFolderUri")
         if output_folder_uri.startswith("file:"):
             output_folder_uri = output_folder_uri[5:]
+        if output_folder_uri.startswith("///"):
+            output_folder_uri = output_folder_uri[3:]
         self.output_folder = Path(output_folder_uri)
 
     def process(self) -> bool:

--- a/autorest/black/__init__.py
+++ b/autorest/black/__init__.py
@@ -6,6 +6,7 @@
 import logging
 from pathlib import Path
 import black
+import os
 
 from .. import Plugin
 
@@ -21,7 +22,7 @@ class BlackScriptPlugin(Plugin):
         output_folder_uri = self._autorestapi.get_value("outputFolderUri")
         if output_folder_uri.startswith("file:"):
             output_folder_uri = output_folder_uri[5:]
-        if output_folder_uri.startswith("///"):
+        if os.name == 'nt' and output_folder_uri.startswith("///"):
             output_folder_uri = output_folder_uri[3:]
         self.output_folder = Path(output_folder_uri)
 


### PR DESCRIPTION
The outputFolderUri  (autorest 3.6.6) in Windows is like below:
```
 \\\D:\\projects\\codegen\\autorest.python\\test\\vanilla\\legacy\\Expected\\AcceptanceTests\\Xml
```