### PR TITLE
change name for lro operation request builders

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 # Change Log
 
+### 2022-xx-xx - 5.17.0
+
+| Library                                                                 | Min Version |
+| ----------------------------------------------------------------------- | ----------- |
+| `@autorest/core`                                                        | `3.6.2`     |
+| `@autorest/modelerfour`                                                 | `4.19.1`    |
+| `azure-core` dep of generated code                                      | `1.23.0`    |
+| `msrest` dep of generated code                                          | `0.6.21`    |
+| `azure-mgmt-core` dep of generated code (If generating mgmt plane code) | `1.3.0`     |
+
+**Breaking Changes in Request Builders**
+
+- Request builders for LRO operations have the `_initial` suffix removed from their name  #1241
+
 ### 2022-04-18 - 5.16.0
 
 | Library                                                                 | Min Version |

--- a/autorest/codegen/models/code_model.py
+++ b/autorest/codegen/models/code_model.py
@@ -393,8 +393,6 @@ class CodeModel:  # pylint: disable=too-many-instance-attributes, too-many-publi
         for operation_group in self.operation_groups:
             for operation in operation_group.operations:
                 request_builder = operation.request_builder
-                if isinstance(operation, LROOperation):
-                    request_builder.name = request_builder.name + "_initial"
                 operation.request_builder = request_builder
                 operation.link_body_kwargs_to_body_params()
 

--- a/docs/samples/specification/directives/generated/azure/directives/sample/aio/operations/_polling_paging_example_operations.py
+++ b/docs/samples/specification/directives/generated/azure/directives/sample/aio/operations/_polling_paging_example_operations.py
@@ -21,7 +21,7 @@ from my.library.aio import AsyncCustomDefaultPollingMethod, AsyncCustomPager, As
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._polling_paging_example_operations import build_basic_paging_request, build_basic_polling_request_initial
+from ...operations._polling_paging_example_operations import build_basic_paging_request, build_basic_polling_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -48,7 +48,7 @@ class PollingPagingExampleOperationsMixin:
         else:
             _json = None
 
-        request = build_basic_polling_request_initial(
+        request = build_basic_polling_request(
             content_type=content_type,
             json=_json,
             template_url=self._basic_polling_initial.metadata['url'],

--- a/docs/samples/specification/directives/generated/azure/directives/sample/operations/_polling_paging_example_operations.py
+++ b/docs/samples/specification/directives/generated/azure/directives/sample/operations/_polling_paging_example_operations.py
@@ -32,7 +32,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 # fmt: off
 
-def build_basic_polling_request_initial(
+def build_basic_polling_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -103,7 +103,7 @@ class PollingPagingExampleOperationsMixin(object):
         else:
             _json = None
 
-        request = build_basic_polling_request_initial(
+        request = build_basic_polling_request(
             content_type=content_type,
             json=_json,
             template_url=self._basic_polling_initial.metadata['url'],

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v1/aio/operations/_multiapi_service_client_operations.py
@@ -22,7 +22,7 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request_initial, build_test_lro_request_initial, build_test_one_request
+from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request, build_test_lro_request, build_test_one_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -109,7 +109,7 @@ class MultiapiServiceClientOperationsMixin:
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -237,7 +237,7 @@ class MultiapiServiceClientOperationsMixin:
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -315,7 +315,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -333,7 +333,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v1/operations/_multiapi_service_client_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v1/operations/_multiapi_service_client_operations.py
@@ -67,7 +67,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -92,7 +92,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -238,7 +238,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -367,7 +367,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -446,7 +446,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -464,7 +464,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/aio/operations/_paging_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/aio/operations/_paging_operations.py
@@ -23,7 +23,7 @@ from custompollerpagerdefinitions.aio import AsyncCustomPager, AsyncCustomPoller
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._paging_operations import build_duplicate_params_request, build_first_response_empty_request, build_get_multiple_pages_failure_request, build_get_multiple_pages_failure_uri_request, build_get_multiple_pages_fragment_next_link_request, build_get_multiple_pages_fragment_with_grouping_next_link_request, build_get_multiple_pages_lro_request_initial, build_get_multiple_pages_request, build_get_multiple_pages_retry_first_request, build_get_multiple_pages_retry_second_request, build_get_multiple_pages_with_offset_request, build_get_no_item_name_pages_request, build_get_null_next_link_name_pages_request, build_get_odata_multiple_pages_request, build_get_paging_model_with_item_name_with_xms_client_name_request, build_get_single_pages_failure_request, build_get_single_pages_request, build_get_with_query_params_request, build_next_fragment_request, build_next_fragment_with_grouping_request, build_next_operation_with_query_params_request
+from ...operations._paging_operations import build_duplicate_params_request, build_first_response_empty_request, build_get_multiple_pages_failure_request, build_get_multiple_pages_failure_uri_request, build_get_multiple_pages_fragment_next_link_request, build_get_multiple_pages_fragment_with_grouping_next_link_request, build_get_multiple_pages_lro_request, build_get_multiple_pages_request, build_get_multiple_pages_retry_first_request, build_get_multiple_pages_retry_second_request, build_get_multiple_pages_with_offset_request, build_get_no_item_name_pages_request, build_get_null_next_link_name_pages_request, build_get_odata_multiple_pages_request, build_get_paging_model_with_item_name_with_xms_client_name_request, build_get_single_pages_failure_request, build_get_single_pages_request, build_get_with_query_params_request, build_next_fragment_request, build_next_fragment_with_grouping_request, build_next_operation_with_query_params_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -1365,7 +1365,7 @@ class PagingOperations:
             _maxresults = paging_get_multiple_pages_lro_options.maxresults
             _timeout = paging_get_multiple_pages_lro_options.timeout
 
-        request = build_get_multiple_pages_lro_request_initial(
+        request = build_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -1444,7 +1444,7 @@ class PagingOperations:
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
                 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -1462,7 +1462,7 @@ class PagingOperations:
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
                 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/operations/_paging_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/operations/_paging_operations.py
@@ -487,7 +487,7 @@ def build_get_multiple_pages_fragment_with_grouping_next_link_request(
     )
 
 
-def build_get_multiple_pages_lro_request_initial(
+def build_get_multiple_pages_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -1966,7 +1966,7 @@ class PagingOperations(object):
             _maxresults = paging_get_multiple_pages_lro_options.maxresults
             _timeout = paging_get_multiple_pages_lro_options.timeout
 
-        request = build_get_multiple_pages_lro_request_initial(
+        request = build_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -2046,7 +2046,7 @@ class PagingOperations(object):
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
                 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -2064,7 +2064,7 @@ class PagingOperations(object):
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
                 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lr_os_custom_header_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lr_os_custom_header_operations.py
@@ -27,10 +27,10 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 from ... import models as _models
 from ..._vendor import _convert_request
 from ...operations._lr_os_custom_header_operations import (
-    build_post202_retry200_request_initial,
-    build_post_async_retry_succeeded_request_initial,
-    build_put201_creating_succeeded200_request_initial,
-    build_put_async_retry_succeeded_request_initial,
+    build_post202_retry200_request,
+    build_post_async_retry_succeeded_request,
+    build_put201_creating_succeeded200_request,
+    build_put_async_retry_succeeded_request,
 )
 
 T = TypeVar("T")
@@ -75,7 +75,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_put_async_retry_succeeded_request_initial(
+        request = build_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_retry_succeeded_initial.metadata["url"],
@@ -206,7 +206,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_put201_creating_succeeded200_request_initial(
+        request = build_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_succeeded200_initial.metadata["url"],
@@ -326,7 +326,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_post202_retry200_request_initial(
+        request = build_post202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry200_initial.metadata["url"],
@@ -438,7 +438,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_post_async_retry_succeeded_request_initial(
+        request = build_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retry_succeeded_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lro_retrys_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lro_retrys_operations.py
@@ -27,13 +27,13 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 from ... import models as _models
 from ..._vendor import _convert_request
 from ...operations._lro_retrys_operations import (
-    build_delete202_retry200_request_initial,
-    build_delete_async_relative_retry_succeeded_request_initial,
-    build_delete_provisioning202_accepted200_succeeded_request_initial,
-    build_post202_retry200_request_initial,
-    build_post_async_relative_retry_succeeded_request_initial,
-    build_put201_creating_succeeded200_request_initial,
-    build_put_async_relative_retry_succeeded_request_initial,
+    build_delete202_retry200_request,
+    build_delete_async_relative_retry_succeeded_request,
+    build_delete_provisioning202_accepted200_succeeded_request,
+    build_post202_retry200_request,
+    build_post_async_relative_retry_succeeded_request,
+    build_put201_creating_succeeded200_request,
+    build_put_async_relative_retry_succeeded_request,
 )
 
 T = TypeVar("T")
@@ -78,7 +78,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_put201_creating_succeeded200_request_initial(
+        request = build_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_succeeded200_initial.metadata["url"],
@@ -197,7 +197,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_put_async_relative_retry_succeeded_request_initial(
+        request = build_put_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_succeeded_initial.metadata["url"],
@@ -317,7 +317,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_delete_provisioning202_accepted200_succeeded_request(
             template_url=self._delete_provisioning202_accepted200_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -420,7 +420,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete202_retry200_request_initial(
+        request = build_delete202_retry200_request(
             template_url=self._delete202_retry200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -511,7 +511,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_succeeded_request_initial(
+        request = build_delete_async_relative_retry_succeeded_request(
             template_url=self._delete_async_relative_retry_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -613,7 +613,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_post202_retry200_request_initial(
+        request = build_post202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry200_initial.metadata["url"],
@@ -724,7 +724,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_post_async_relative_retry_succeeded_request_initial(
+        request = build_post_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_succeeded_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lros_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lros_operations.py
@@ -27,50 +27,50 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 from ... import models as _models
 from ..._vendor import _convert_request
 from ...operations._lros_operations import (
-    build_delete202_no_retry204_request_initial,
-    build_delete202_retry200_request_initial,
-    build_delete204_succeeded_request_initial,
-    build_delete_async_no_header_in_retry_request_initial,
-    build_delete_async_no_retry_succeeded_request_initial,
-    build_delete_async_retry_failed_request_initial,
-    build_delete_async_retry_succeeded_request_initial,
-    build_delete_async_retrycanceled_request_initial,
-    build_delete_no_header_in_retry_request_initial,
-    build_delete_provisioning202_accepted200_succeeded_request_initial,
-    build_delete_provisioning202_deleting_failed200_request_initial,
-    build_delete_provisioning202_deletingcanceled200_request_initial,
-    build_patch200_succeeded_ignore_headers_request_initial,
-    build_patch201_retry_with_async_header_request_initial,
-    build_patch202_retry_with_async_and_location_header_request_initial,
-    build_post200_with_payload_request_initial,
-    build_post202_list_request_initial,
-    build_post202_no_retry204_request_initial,
-    build_post202_retry200_request_initial,
-    build_post_async_no_retry_succeeded_request_initial,
-    build_post_async_retry_failed_request_initial,
-    build_post_async_retry_succeeded_request_initial,
-    build_post_async_retrycanceled_request_initial,
-    build_post_double_headers_final_azure_header_get_default_request_initial,
-    build_post_double_headers_final_azure_header_get_request_initial,
-    build_post_double_headers_final_location_get_request_initial,
-    build_put200_acceptedcanceled200_request_initial,
-    build_put200_succeeded_no_state_request_initial,
-    build_put200_succeeded_request_initial,
-    build_put200_updating_succeeded204_request_initial,
-    build_put201_creating_failed200_request_initial,
-    build_put201_creating_succeeded200_request_initial,
-    build_put201_succeeded_request_initial,
-    build_put202_retry200_request_initial,
-    build_put_async_no_header_in_retry_request_initial,
-    build_put_async_no_retry_succeeded_request_initial,
-    build_put_async_no_retrycanceled_request_initial,
-    build_put_async_non_resource_request_initial,
-    build_put_async_retry_failed_request_initial,
-    build_put_async_retry_succeeded_request_initial,
-    build_put_async_sub_resource_request_initial,
-    build_put_no_header_in_retry_request_initial,
-    build_put_non_resource_request_initial,
-    build_put_sub_resource_request_initial,
+    build_delete202_no_retry204_request,
+    build_delete202_retry200_request,
+    build_delete204_succeeded_request,
+    build_delete_async_no_header_in_retry_request,
+    build_delete_async_no_retry_succeeded_request,
+    build_delete_async_retry_failed_request,
+    build_delete_async_retry_succeeded_request,
+    build_delete_async_retrycanceled_request,
+    build_delete_no_header_in_retry_request,
+    build_delete_provisioning202_accepted200_succeeded_request,
+    build_delete_provisioning202_deleting_failed200_request,
+    build_delete_provisioning202_deletingcanceled200_request,
+    build_patch200_succeeded_ignore_headers_request,
+    build_patch201_retry_with_async_header_request,
+    build_patch202_retry_with_async_and_location_header_request,
+    build_post200_with_payload_request,
+    build_post202_list_request,
+    build_post202_no_retry204_request,
+    build_post202_retry200_request,
+    build_post_async_no_retry_succeeded_request,
+    build_post_async_retry_failed_request,
+    build_post_async_retry_succeeded_request,
+    build_post_async_retrycanceled_request,
+    build_post_double_headers_final_azure_header_get_default_request,
+    build_post_double_headers_final_azure_header_get_request,
+    build_post_double_headers_final_location_get_request,
+    build_put200_acceptedcanceled200_request,
+    build_put200_succeeded_no_state_request,
+    build_put200_succeeded_request,
+    build_put200_updating_succeeded204_request,
+    build_put201_creating_failed200_request,
+    build_put201_creating_succeeded200_request,
+    build_put201_succeeded_request,
+    build_put202_retry200_request,
+    build_put_async_no_header_in_retry_request,
+    build_put_async_no_retry_succeeded_request,
+    build_put_async_no_retrycanceled_request,
+    build_put_async_non_resource_request,
+    build_put_async_retry_failed_request,
+    build_put_async_retry_succeeded_request,
+    build_put_async_sub_resource_request,
+    build_put_no_header_in_retry_request,
+    build_put_non_resource_request,
+    build_put_sub_resource_request,
 )
 
 T = TypeVar("T")
@@ -115,7 +115,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_succeeded_request_initial(
+        request = build_put200_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_succeeded_initial.metadata["url"],
@@ -231,7 +231,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_patch200_succeeded_ignore_headers_request_initial(
+        request = build_patch200_succeeded_ignore_headers_request(
             content_type=content_type,
             json=_json,
             template_url=self._patch200_succeeded_ignore_headers_initial.metadata["url"],
@@ -356,7 +356,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_patch201_retry_with_async_header_request_initial(
+        request = build_patch201_retry_with_async_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._patch201_retry_with_async_header_initial.metadata["url"],
@@ -481,7 +481,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_patch202_retry_with_async_and_location_header_request_initial(
+        request = build_patch202_retry_with_async_and_location_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._patch202_retry_with_async_and_location_header_initial.metadata["url"],
@@ -605,7 +605,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put201_succeeded_request_initial(
+        request = build_put201_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_succeeded_initial.metadata["url"],
@@ -709,7 +709,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[List[_models.Product]]]
 
-        request = build_post202_list_request_initial(
+        request = build_post202_list_request(
             template_url=self._post202_list_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -818,7 +818,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_succeeded_no_state_request_initial(
+        request = build_put200_succeeded_no_state_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_succeeded_no_state_initial.metadata["url"],
@@ -932,7 +932,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put202_retry200_request_initial(
+        request = build_put202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put202_retry200_initial.metadata["url"],
@@ -1047,7 +1047,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put201_creating_succeeded200_request_initial(
+        request = build_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_succeeded200_initial.metadata["url"],
@@ -1166,7 +1166,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_updating_succeeded204_request_initial(
+        request = build_put200_updating_succeeded204_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_updating_succeeded204_initial.metadata["url"],
@@ -1281,7 +1281,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put201_creating_failed200_request_initial(
+        request = build_put201_creating_failed200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_failed200_initial.metadata["url"],
@@ -1400,7 +1400,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_acceptedcanceled200_request_initial(
+        request = build_put200_acceptedcanceled200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_acceptedcanceled200_initial.metadata["url"],
@@ -1515,7 +1515,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_no_header_in_retry_request_initial(
+        request = build_put_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_no_header_in_retry_initial.metadata["url"],
@@ -1636,7 +1636,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_retry_succeeded_request_initial(
+        request = build_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_retry_succeeded_initial.metadata["url"],
@@ -1766,7 +1766,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_no_retry_succeeded_request_initial(
+        request = build_put_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_no_retry_succeeded_initial.metadata["url"],
@@ -1894,7 +1894,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_retry_failed_request_initial(
+        request = build_put_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_retry_failed_initial.metadata["url"],
@@ -2024,7 +2024,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_no_retrycanceled_request_initial(
+        request = build_put_async_no_retrycanceled_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_no_retrycanceled_initial.metadata["url"],
@@ -2152,7 +2152,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_no_header_in_retry_request_initial(
+        request = build_put_async_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_no_header_in_retry_initial.metadata["url"],
@@ -2276,7 +2276,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_resource_request_initial(
+        request = build_put_non_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_resource_initial.metadata["url"],
@@ -2381,7 +2381,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_non_resource_request_initial(
+        request = build_put_async_non_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_non_resource_initial.metadata["url"],
@@ -2489,7 +2489,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_sub_resource_request_initial(
+        request = build_put_sub_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_sub_resource_initial.metadata["url"],
@@ -2603,7 +2603,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_sub_resource_request_initial(
+        request = build_put_async_sub_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_sub_resource_initial.metadata["url"],
@@ -2706,7 +2706,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_delete_provisioning202_accepted200_succeeded_request(
             template_url=self._delete_provisioning202_accepted200_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2807,7 +2807,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_deleting_failed200_request_initial(
+        request = build_delete_provisioning202_deleting_failed200_request(
             template_url=self._delete_provisioning202_deleting_failed200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2906,7 +2906,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_deletingcanceled200_request_initial(
+        request = build_delete_provisioning202_deletingcanceled200_request(
             template_url=self._delete_provisioning202_deletingcanceled200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3007,7 +3007,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete204_succeeded_request_initial(
+        request = build_delete204_succeeded_request(
             template_url=self._delete204_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3091,7 +3091,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[_models.Product]]
 
-        request = build_delete202_retry200_request_initial(
+        request = build_delete202_retry200_request(
             template_url=self._delete202_retry200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3188,7 +3188,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[_models.Product]]
 
-        request = build_delete202_no_retry204_request_initial(
+        request = build_delete202_no_retry204_request(
             template_url=self._delete202_no_retry204_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3287,7 +3287,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_no_header_in_retry_request_initial(
+        request = build_delete_no_header_in_retry_request(
             template_url=self._delete_no_header_in_retry_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3378,7 +3378,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_no_header_in_retry_request_initial(
+        request = build_delete_async_no_header_in_retry_request(
             template_url=self._delete_async_no_header_in_retry_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3469,7 +3469,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_retry_succeeded_request_initial(
+        request = build_delete_async_retry_succeeded_request(
             template_url=self._delete_async_retry_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3563,7 +3563,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_no_retry_succeeded_request_initial(
+        request = build_delete_async_no_retry_succeeded_request(
             template_url=self._delete_async_no_retry_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3657,7 +3657,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_retry_failed_request_initial(
+        request = build_delete_async_retry_failed_request(
             template_url=self._delete_async_retry_failed_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3751,7 +3751,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_retrycanceled_request_initial(
+        request = build_delete_async_retrycanceled_request(
             template_url=self._delete_async_retrycanceled_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3843,7 +3843,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Sku]
 
-        request = build_post200_with_payload_request_initial(
+        request = build_post200_with_payload_request(
             template_url=self._post200_with_payload_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3946,7 +3946,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_retry200_request_initial(
+        request = build_post202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry200_initial.metadata["url"],
@@ -4057,7 +4057,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_no_retry204_request_initial(
+        request = build_post202_no_retry204_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_no_retry204_initial.metadata["url"],
@@ -4170,7 +4170,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_post_double_headers_final_location_get_request_initial(
+        request = build_post_double_headers_final_location_get_request(
             template_url=self._post_double_headers_final_location_get_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4263,7 +4263,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_post_double_headers_final_azure_header_get_request_initial(
+        request = build_post_double_headers_final_azure_header_get_request(
             template_url=self._post_double_headers_final_azure_header_get_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4357,7 +4357,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_post_double_headers_final_azure_header_get_default_request_initial(
+        request = build_post_double_headers_final_azure_header_get_default_request(
             template_url=self._post_double_headers_final_azure_header_get_default_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4460,7 +4460,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_retry_succeeded_request_initial(
+        request = build_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retry_succeeded_initial.metadata["url"],
@@ -4585,7 +4585,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_no_retry_succeeded_request_initial(
+        request = build_post_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_no_retry_succeeded_initial.metadata["url"],
@@ -4710,7 +4710,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_retry_failed_request_initial(
+        request = build_post_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retry_failed_initial.metadata["url"],
@@ -4825,7 +4825,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_retrycanceled_request_initial(
+        request = build_post_async_retrycanceled_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retrycanceled_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lrosads_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/aio/operations/_lrosads_operations.py
@@ -27,32 +27,32 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 from ... import models as _models
 from ..._vendor import _convert_request
 from ...operations._lrosads_operations import (
-    build_delete202_non_retry400_request_initial,
-    build_delete202_retry_invalid_header_request_initial,
-    build_delete204_succeeded_request_initial,
-    build_delete_async_relative_retry400_request_initial,
-    build_delete_async_relative_retry_invalid_header_request_initial,
-    build_delete_async_relative_retry_invalid_json_polling_request_initial,
-    build_delete_async_relative_retry_no_status_request_initial,
-    build_delete_non_retry400_request_initial,
-    build_post202_no_location_request_initial,
-    build_post202_non_retry400_request_initial,
-    build_post202_retry_invalid_header_request_initial,
-    build_post_async_relative_retry400_request_initial,
-    build_post_async_relative_retry_invalid_header_request_initial,
-    build_post_async_relative_retry_invalid_json_polling_request_initial,
-    build_post_async_relative_retry_no_payload_request_initial,
-    build_post_non_retry400_request_initial,
-    build_put200_invalid_json_request_initial,
-    build_put_async_relative_retry400_request_initial,
-    build_put_async_relative_retry_invalid_header_request_initial,
-    build_put_async_relative_retry_invalid_json_polling_request_initial,
-    build_put_async_relative_retry_no_status_payload_request_initial,
-    build_put_async_relative_retry_no_status_request_initial,
-    build_put_error201_no_provisioning_state_payload_request_initial,
-    build_put_non_retry201_creating400_invalid_json_request_initial,
-    build_put_non_retry201_creating400_request_initial,
-    build_put_non_retry400_request_initial,
+    build_delete202_non_retry400_request,
+    build_delete202_retry_invalid_header_request,
+    build_delete204_succeeded_request,
+    build_delete_async_relative_retry400_request,
+    build_delete_async_relative_retry_invalid_header_request,
+    build_delete_async_relative_retry_invalid_json_polling_request,
+    build_delete_async_relative_retry_no_status_request,
+    build_delete_non_retry400_request,
+    build_post202_no_location_request,
+    build_post202_non_retry400_request,
+    build_post202_retry_invalid_header_request,
+    build_post_async_relative_retry400_request,
+    build_post_async_relative_retry_invalid_header_request,
+    build_post_async_relative_retry_invalid_json_polling_request,
+    build_post_async_relative_retry_no_payload_request,
+    build_post_non_retry400_request,
+    build_put200_invalid_json_request,
+    build_put_async_relative_retry400_request,
+    build_put_async_relative_retry_invalid_header_request,
+    build_put_async_relative_retry_invalid_json_polling_request,
+    build_put_async_relative_retry_no_status_payload_request,
+    build_put_async_relative_retry_no_status_request,
+    build_put_error201_no_provisioning_state_payload_request,
+    build_put_non_retry201_creating400_invalid_json_request,
+    build_put_non_retry201_creating400_request,
+    build_put_non_retry400_request,
 )
 
 T = TypeVar("T")
@@ -97,7 +97,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_retry400_request_initial(
+        request = build_put_non_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_retry400_initial.metadata["url"],
@@ -214,7 +214,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_retry201_creating400_request_initial(
+        request = build_put_non_retry201_creating400_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_retry201_creating400_initial.metadata["url"],
@@ -332,7 +332,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_retry201_creating400_invalid_json_request_initial(
+        request = build_put_non_retry201_creating400_invalid_json_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_retry201_creating400_invalid_json_initial.metadata["url"],
@@ -450,7 +450,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry400_request_initial(
+        request = build_put_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry400_initial.metadata["url"],
@@ -571,7 +571,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_non_retry400_request_initial(
+        request = build_delete_non_retry400_request(
             template_url=self._delete_non_retry400_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -661,7 +661,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete202_non_retry400_request_initial(
+        request = build_delete202_non_retry400_request(
             template_url=self._delete202_non_retry400_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -751,7 +751,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry400_request_initial(
+        request = build_delete_async_relative_retry400_request(
             template_url=self._delete_async_relative_retry400_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -853,7 +853,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_non_retry400_request_initial(
+        request = build_post_non_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_non_retry400_initial.metadata["url"],
@@ -963,7 +963,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_non_retry400_request_initial(
+        request = build_post202_non_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_non_retry400_initial.metadata["url"],
@@ -1073,7 +1073,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry400_request_initial(
+        request = build_post_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry400_initial.metadata["url"],
@@ -1187,7 +1187,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_error201_no_provisioning_state_payload_request_initial(
+        request = build_put_error201_no_provisioning_state_payload_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_error201_no_provisioning_state_payload_initial.metadata["url"],
@@ -1304,7 +1304,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_no_status_request_initial(
+        request = build_put_async_relative_retry_no_status_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_no_status_initial.metadata["url"],
@@ -1434,7 +1434,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_no_status_payload_request_initial(
+        request = build_put_async_relative_retry_no_status_payload_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_no_status_payload_initial.metadata["url"],
@@ -1556,7 +1556,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete204_succeeded_request_initial(
+        request = build_delete204_succeeded_request(
             template_url=self._delete204_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -1642,7 +1642,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_no_status_request_initial(
+        request = build_delete_async_relative_retry_no_status_request(
             template_url=self._delete_async_relative_retry_no_status_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -1744,7 +1744,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_no_location_request_initial(
+        request = build_post202_no_location_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_no_location_initial.metadata["url"],
@@ -1855,7 +1855,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry_no_payload_request_initial(
+        request = build_post_async_relative_retry_no_payload_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_no_payload_initial.metadata["url"],
@@ -1970,7 +1970,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_invalid_json_request_initial(
+        request = build_put200_invalid_json_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_invalid_json_initial.metadata["url"],
@@ -2086,7 +2086,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_invalid_header_request_initial(
+        request = build_put_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_invalid_header_initial.metadata["url"],
@@ -2216,7 +2216,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_put_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_invalid_json_polling_initial.metadata["url"],
@@ -2338,7 +2338,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete202_retry_invalid_header_request_initial(
+        request = build_delete202_retry_invalid_header_request(
             template_url=self._delete202_retry_invalid_header_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2429,7 +2429,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_invalid_header_request_initial(
+        request = build_delete_async_relative_retry_invalid_header_request(
             template_url=self._delete_async_relative_retry_invalid_header_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2523,7 +2523,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_delete_async_relative_retry_invalid_json_polling_request(
             template_url=self._delete_async_relative_retry_invalid_json_polling_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2625,7 +2625,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_retry_invalid_header_request_initial(
+        request = build_post202_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry_invalid_header_initial.metadata["url"],
@@ -2736,7 +2736,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry_invalid_header_request_initial(
+        request = build_post_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_invalid_header_initial.metadata["url"],
@@ -2851,7 +2851,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_post_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_invalid_json_polling_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lr_os_custom_header_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lr_os_custom_header_operations.py
@@ -40,7 +40,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 # fmt: off
 
-def build_put_async_retry_succeeded_request_initial(
+def build_put_async_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -65,7 +65,7 @@ def build_put_async_retry_succeeded_request_initial(
     )
 
 
-def build_put201_creating_succeeded200_request_initial(
+def build_put201_creating_succeeded200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -90,7 +90,7 @@ def build_put201_creating_succeeded200_request_initial(
     )
 
 
-def build_post202_retry200_request_initial(
+def build_post202_retry200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -115,7 +115,7 @@ def build_post202_retry200_request_initial(
     )
 
 
-def build_post_async_retry_succeeded_request_initial(
+def build_post_async_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -181,7 +181,7 @@ class LROsCustomHeaderOperations(object):
         else:
             _json = None
 
-        request = build_put_async_retry_succeeded_request_initial(
+        request = build_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_retry_succeeded_initial.metadata["url"],
@@ -317,7 +317,7 @@ class LROsCustomHeaderOperations(object):
         else:
             _json = None
 
-        request = build_put201_creating_succeeded200_request_initial(
+        request = build_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_succeeded200_initial.metadata["url"],
@@ -442,7 +442,7 @@ class LROsCustomHeaderOperations(object):
         else:
             _json = None
 
-        request = build_post202_retry200_request_initial(
+        request = build_post202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry200_initial.metadata["url"],
@@ -560,7 +560,7 @@ class LROsCustomHeaderOperations(object):
         else:
             _json = None
 
-        request = build_post_async_retry_succeeded_request_initial(
+        request = build_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retry_succeeded_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lro_retrys_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lro_retrys_operations.py
@@ -40,7 +40,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 # fmt: off
 
-def build_put201_creating_succeeded200_request_initial(
+def build_put201_creating_succeeded200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -65,7 +65,7 @@ def build_put201_creating_succeeded200_request_initial(
     )
 
 
-def build_put_async_relative_retry_succeeded_request_initial(
+def build_put_async_relative_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -90,7 +90,7 @@ def build_put_async_relative_retry_succeeded_request_initial(
     )
 
 
-def build_delete_provisioning202_accepted200_succeeded_request_initial(
+def build_delete_provisioning202_accepted200_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -112,7 +112,7 @@ def build_delete_provisioning202_accepted200_succeeded_request_initial(
     )
 
 
-def build_delete202_retry200_request_initial(
+def build_delete202_retry200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -134,7 +134,7 @@ def build_delete202_retry200_request_initial(
     )
 
 
-def build_delete_async_relative_retry_succeeded_request_initial(
+def build_delete_async_relative_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -156,7 +156,7 @@ def build_delete_async_relative_retry_succeeded_request_initial(
     )
 
 
-def build_post202_retry200_request_initial(
+def build_post202_retry200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -181,7 +181,7 @@ def build_post202_retry200_request_initial(
     )
 
 
-def build_post_async_relative_retry_succeeded_request_initial(
+def build_post_async_relative_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -247,7 +247,7 @@ class LRORetrysOperations(object):
         else:
             _json = None
 
-        request = build_put201_creating_succeeded200_request_initial(
+        request = build_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_succeeded200_initial.metadata["url"],
@@ -371,7 +371,7 @@ class LRORetrysOperations(object):
         else:
             _json = None
 
-        request = build_put_async_relative_retry_succeeded_request_initial(
+        request = build_put_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_succeeded_initial.metadata["url"],
@@ -496,7 +496,7 @@ class LRORetrysOperations(object):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_delete_provisioning202_accepted200_succeeded_request(
             template_url=self._delete_provisioning202_accepted200_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -600,7 +600,7 @@ class LRORetrysOperations(object):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete202_retry200_request_initial(
+        request = build_delete202_retry200_request(
             template_url=self._delete202_retry200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -693,7 +693,7 @@ class LRORetrysOperations(object):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_succeeded_request_initial(
+        request = build_delete_async_relative_retry_succeeded_request(
             template_url=self._delete_async_relative_retry_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -799,7 +799,7 @@ class LRORetrysOperations(object):
         else:
             _json = None
 
-        request = build_post202_retry200_request_initial(
+        request = build_post202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry200_initial.metadata["url"],
@@ -916,7 +916,7 @@ class LRORetrysOperations(object):
         else:
             _json = None
 
-        request = build_post_async_relative_retry_succeeded_request_initial(
+        request = build_post_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_succeeded_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lros_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lros_operations.py
@@ -40,7 +40,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 # fmt: off
 
-def build_put200_succeeded_request_initial(
+def build_put200_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -65,7 +65,7 @@ def build_put200_succeeded_request_initial(
     )
 
 
-def build_patch200_succeeded_ignore_headers_request_initial(
+def build_patch200_succeeded_ignore_headers_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -90,7 +90,7 @@ def build_patch200_succeeded_ignore_headers_request_initial(
     )
 
 
-def build_patch201_retry_with_async_header_request_initial(
+def build_patch201_retry_with_async_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -115,7 +115,7 @@ def build_patch201_retry_with_async_header_request_initial(
     )
 
 
-def build_patch202_retry_with_async_and_location_header_request_initial(
+def build_patch202_retry_with_async_and_location_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -140,7 +140,7 @@ def build_patch202_retry_with_async_and_location_header_request_initial(
     )
 
 
-def build_put201_succeeded_request_initial(
+def build_put201_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -165,7 +165,7 @@ def build_put201_succeeded_request_initial(
     )
 
 
-def build_post202_list_request_initial(
+def build_post202_list_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -187,7 +187,7 @@ def build_post202_list_request_initial(
     )
 
 
-def build_put200_succeeded_no_state_request_initial(
+def build_put200_succeeded_no_state_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -212,7 +212,7 @@ def build_put200_succeeded_no_state_request_initial(
     )
 
 
-def build_put202_retry200_request_initial(
+def build_put202_retry200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -237,7 +237,7 @@ def build_put202_retry200_request_initial(
     )
 
 
-def build_put201_creating_succeeded200_request_initial(
+def build_put201_creating_succeeded200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -262,7 +262,7 @@ def build_put201_creating_succeeded200_request_initial(
     )
 
 
-def build_put200_updating_succeeded204_request_initial(
+def build_put200_updating_succeeded204_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -287,7 +287,7 @@ def build_put200_updating_succeeded204_request_initial(
     )
 
 
-def build_put201_creating_failed200_request_initial(
+def build_put201_creating_failed200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -312,7 +312,7 @@ def build_put201_creating_failed200_request_initial(
     )
 
 
-def build_put200_acceptedcanceled200_request_initial(
+def build_put200_acceptedcanceled200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -337,7 +337,7 @@ def build_put200_acceptedcanceled200_request_initial(
     )
 
 
-def build_put_no_header_in_retry_request_initial(
+def build_put_no_header_in_retry_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -362,7 +362,7 @@ def build_put_no_header_in_retry_request_initial(
     )
 
 
-def build_put_async_retry_succeeded_request_initial(
+def build_put_async_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -387,7 +387,7 @@ def build_put_async_retry_succeeded_request_initial(
     )
 
 
-def build_put_async_no_retry_succeeded_request_initial(
+def build_put_async_no_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -412,7 +412,7 @@ def build_put_async_no_retry_succeeded_request_initial(
     )
 
 
-def build_put_async_retry_failed_request_initial(
+def build_put_async_retry_failed_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -437,7 +437,7 @@ def build_put_async_retry_failed_request_initial(
     )
 
 
-def build_put_async_no_retrycanceled_request_initial(
+def build_put_async_no_retrycanceled_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -462,7 +462,7 @@ def build_put_async_no_retrycanceled_request_initial(
     )
 
 
-def build_put_async_no_header_in_retry_request_initial(
+def build_put_async_no_header_in_retry_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -487,7 +487,7 @@ def build_put_async_no_header_in_retry_request_initial(
     )
 
 
-def build_put_non_resource_request_initial(
+def build_put_non_resource_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -512,7 +512,7 @@ def build_put_non_resource_request_initial(
     )
 
 
-def build_put_async_non_resource_request_initial(
+def build_put_async_non_resource_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -537,7 +537,7 @@ def build_put_async_non_resource_request_initial(
     )
 
 
-def build_put_sub_resource_request_initial(
+def build_put_sub_resource_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -562,7 +562,7 @@ def build_put_sub_resource_request_initial(
     )
 
 
-def build_put_async_sub_resource_request_initial(
+def build_put_async_sub_resource_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -587,7 +587,7 @@ def build_put_async_sub_resource_request_initial(
     )
 
 
-def build_delete_provisioning202_accepted200_succeeded_request_initial(
+def build_delete_provisioning202_accepted200_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -609,7 +609,7 @@ def build_delete_provisioning202_accepted200_succeeded_request_initial(
     )
 
 
-def build_delete_provisioning202_deleting_failed200_request_initial(
+def build_delete_provisioning202_deleting_failed200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -631,7 +631,7 @@ def build_delete_provisioning202_deleting_failed200_request_initial(
     )
 
 
-def build_delete_provisioning202_deletingcanceled200_request_initial(
+def build_delete_provisioning202_deletingcanceled200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -653,7 +653,7 @@ def build_delete_provisioning202_deletingcanceled200_request_initial(
     )
 
 
-def build_delete204_succeeded_request_initial(
+def build_delete204_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -675,7 +675,7 @@ def build_delete204_succeeded_request_initial(
     )
 
 
-def build_delete202_retry200_request_initial(
+def build_delete202_retry200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -697,7 +697,7 @@ def build_delete202_retry200_request_initial(
     )
 
 
-def build_delete202_no_retry204_request_initial(
+def build_delete202_no_retry204_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -719,7 +719,7 @@ def build_delete202_no_retry204_request_initial(
     )
 
 
-def build_delete_no_header_in_retry_request_initial(
+def build_delete_no_header_in_retry_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -741,7 +741,7 @@ def build_delete_no_header_in_retry_request_initial(
     )
 
 
-def build_delete_async_no_header_in_retry_request_initial(
+def build_delete_async_no_header_in_retry_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -763,7 +763,7 @@ def build_delete_async_no_header_in_retry_request_initial(
     )
 
 
-def build_delete_async_retry_succeeded_request_initial(
+def build_delete_async_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -785,7 +785,7 @@ def build_delete_async_retry_succeeded_request_initial(
     )
 
 
-def build_delete_async_no_retry_succeeded_request_initial(
+def build_delete_async_no_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -807,7 +807,7 @@ def build_delete_async_no_retry_succeeded_request_initial(
     )
 
 
-def build_delete_async_retry_failed_request_initial(
+def build_delete_async_retry_failed_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -829,7 +829,7 @@ def build_delete_async_retry_failed_request_initial(
     )
 
 
-def build_delete_async_retrycanceled_request_initial(
+def build_delete_async_retrycanceled_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -851,7 +851,7 @@ def build_delete_async_retrycanceled_request_initial(
     )
 
 
-def build_post200_with_payload_request_initial(
+def build_post200_with_payload_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -873,7 +873,7 @@ def build_post200_with_payload_request_initial(
     )
 
 
-def build_post202_retry200_request_initial(
+def build_post202_retry200_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -898,7 +898,7 @@ def build_post202_retry200_request_initial(
     )
 
 
-def build_post202_no_retry204_request_initial(
+def build_post202_no_retry204_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -923,7 +923,7 @@ def build_post202_no_retry204_request_initial(
     )
 
 
-def build_post_double_headers_final_location_get_request_initial(
+def build_post_double_headers_final_location_get_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -945,7 +945,7 @@ def build_post_double_headers_final_location_get_request_initial(
     )
 
 
-def build_post_double_headers_final_azure_header_get_request_initial(
+def build_post_double_headers_final_azure_header_get_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -967,7 +967,7 @@ def build_post_double_headers_final_azure_header_get_request_initial(
     )
 
 
-def build_post_double_headers_final_azure_header_get_default_request_initial(
+def build_post_double_headers_final_azure_header_get_default_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -989,7 +989,7 @@ def build_post_double_headers_final_azure_header_get_default_request_initial(
     )
 
 
-def build_post_async_retry_succeeded_request_initial(
+def build_post_async_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -1014,7 +1014,7 @@ def build_post_async_retry_succeeded_request_initial(
     )
 
 
-def build_post_async_no_retry_succeeded_request_initial(
+def build_post_async_no_retry_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -1039,7 +1039,7 @@ def build_post_async_no_retry_succeeded_request_initial(
     )
 
 
-def build_post_async_retry_failed_request_initial(
+def build_post_async_retry_failed_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -1064,7 +1064,7 @@ def build_post_async_retry_failed_request_initial(
     )
 
 
-def build_post_async_retrycanceled_request_initial(
+def build_post_async_retrycanceled_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -1130,7 +1130,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_succeeded_request_initial(
+        request = build_put200_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_succeeded_initial.metadata["url"],
@@ -1251,7 +1251,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_patch200_succeeded_ignore_headers_request_initial(
+        request = build_patch200_succeeded_ignore_headers_request(
             content_type=content_type,
             json=_json,
             template_url=self._patch200_succeeded_ignore_headers_initial.metadata["url"],
@@ -1381,7 +1381,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_patch201_retry_with_async_header_request_initial(
+        request = build_patch201_retry_with_async_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._patch201_retry_with_async_header_initial.metadata["url"],
@@ -1510,7 +1510,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_patch202_retry_with_async_and_location_header_request_initial(
+        request = build_patch202_retry_with_async_and_location_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._patch202_retry_with_async_and_location_header_initial.metadata["url"],
@@ -1639,7 +1639,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put201_succeeded_request_initial(
+        request = build_put201_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_succeeded_initial.metadata["url"],
@@ -1748,7 +1748,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[List[_models.Product]]]
 
-        request = build_post202_list_request_initial(
+        request = build_post202_list_request(
             template_url=self._post202_list_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -1863,7 +1863,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_succeeded_no_state_request_initial(
+        request = build_put200_succeeded_no_state_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_succeeded_no_state_initial.metadata["url"],
@@ -1982,7 +1982,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put202_retry200_request_initial(
+        request = build_put202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put202_retry200_initial.metadata["url"],
@@ -2102,7 +2102,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put201_creating_succeeded200_request_initial(
+        request = build_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_succeeded200_initial.metadata["url"],
@@ -2226,7 +2226,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_updating_succeeded204_request_initial(
+        request = build_put200_updating_succeeded204_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_updating_succeeded204_initial.metadata["url"],
@@ -2346,7 +2346,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put201_creating_failed200_request_initial(
+        request = build_put201_creating_failed200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put201_creating_failed200_initial.metadata["url"],
@@ -2470,7 +2470,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_acceptedcanceled200_request_initial(
+        request = build_put200_acceptedcanceled200_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_acceptedcanceled200_initial.metadata["url"],
@@ -2590,7 +2590,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_no_header_in_retry_request_initial(
+        request = build_put_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_no_header_in_retry_initial.metadata["url"],
@@ -2716,7 +2716,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_retry_succeeded_request_initial(
+        request = build_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_retry_succeeded_initial.metadata["url"],
@@ -2851,7 +2851,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_no_retry_succeeded_request_initial(
+        request = build_put_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_no_retry_succeeded_initial.metadata["url"],
@@ -2984,7 +2984,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_retry_failed_request_initial(
+        request = build_put_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_retry_failed_initial.metadata["url"],
@@ -3119,7 +3119,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_no_retrycanceled_request_initial(
+        request = build_put_async_no_retrycanceled_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_no_retrycanceled_initial.metadata["url"],
@@ -3252,7 +3252,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_no_header_in_retry_request_initial(
+        request = build_put_async_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_no_header_in_retry_initial.metadata["url"],
@@ -3383,7 +3383,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_resource_request_initial(
+        request = build_put_non_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_resource_initial.metadata["url"],
@@ -3496,7 +3496,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_non_resource_request_initial(
+        request = build_put_async_non_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_non_resource_initial.metadata["url"],
@@ -3610,7 +3610,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_sub_resource_request_initial(
+        request = build_put_sub_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_sub_resource_initial.metadata["url"],
@@ -3729,7 +3729,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_sub_resource_request_initial(
+        request = build_put_async_sub_resource_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_sub_resource_initial.metadata["url"],
@@ -3837,7 +3837,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_delete_provisioning202_accepted200_succeeded_request(
             template_url=self._delete_provisioning202_accepted200_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3941,7 +3941,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_deleting_failed200_request_initial(
+        request = build_delete_provisioning202_deleting_failed200_request(
             template_url=self._delete_provisioning202_deleting_failed200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4045,7 +4045,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_delete_provisioning202_deletingcanceled200_request_initial(
+        request = build_delete_provisioning202_deletingcanceled200_request(
             template_url=self._delete_provisioning202_deletingcanceled200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4149,7 +4149,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete204_succeeded_request_initial(
+        request = build_delete204_succeeded_request(
             template_url=self._delete204_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4237,7 +4237,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[_models.Product]]
 
-        request = build_delete202_retry200_request_initial(
+        request = build_delete202_retry200_request(
             template_url=self._delete202_retry200_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4339,7 +4339,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[_models.Product]]
 
-        request = build_delete202_no_retry204_request_initial(
+        request = build_delete202_no_retry204_request(
             template_url=self._delete202_no_retry204_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4441,7 +4441,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_no_header_in_retry_request_initial(
+        request = build_delete_no_header_in_retry_request(
             template_url=self._delete_no_header_in_retry_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4534,7 +4534,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_no_header_in_retry_request_initial(
+        request = build_delete_async_no_header_in_retry_request(
             template_url=self._delete_async_no_header_in_retry_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4627,7 +4627,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_retry_succeeded_request_initial(
+        request = build_delete_async_retry_succeeded_request(
             template_url=self._delete_async_retry_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4723,7 +4723,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_no_retry_succeeded_request_initial(
+        request = build_delete_async_no_retry_succeeded_request(
             template_url=self._delete_async_no_retry_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4819,7 +4819,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_retry_failed_request_initial(
+        request = build_delete_async_retry_failed_request(
             template_url=self._delete_async_retry_failed_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -4915,7 +4915,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_retrycanceled_request_initial(
+        request = build_delete_async_retrycanceled_request(
             template_url=self._delete_async_retrycanceled_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -5011,7 +5011,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Sku]
 
-        request = build_post200_with_payload_request_initial(
+        request = build_post200_with_payload_request(
             template_url=self._post200_with_payload_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -5120,7 +5120,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_retry200_request_initial(
+        request = build_post202_retry200_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry200_initial.metadata["url"],
@@ -5237,7 +5237,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_no_retry204_request_initial(
+        request = build_post202_no_retry204_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_no_retry204_initial.metadata["url"],
@@ -5355,7 +5355,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_post_double_headers_final_location_get_request_initial(
+        request = build_post_double_headers_final_location_get_request(
             template_url=self._post_double_headers_final_location_get_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -5453,7 +5453,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_post_double_headers_final_azure_header_get_request_initial(
+        request = build_post_double_headers_final_azure_header_get_request(
             template_url=self._post_double_headers_final_azure_header_get_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -5551,7 +5551,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.Product]
 
-        request = build_post_double_headers_final_azure_header_get_default_request_initial(
+        request = build_post_double_headers_final_azure_header_get_default_request(
             template_url=self._post_double_headers_final_azure_header_get_default_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -5657,7 +5657,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_retry_succeeded_request_initial(
+        request = build_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retry_succeeded_initial.metadata["url"],
@@ -5787,7 +5787,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_no_retry_succeeded_request_initial(
+        request = build_post_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_no_retry_succeeded_initial.metadata["url"],
@@ -5917,7 +5917,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_retry_failed_request_initial(
+        request = build_post_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retry_failed_initial.metadata["url"],
@@ -6038,7 +6038,7 @@ class LROsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_retrycanceled_request_initial(
+        request = build_post_async_retrycanceled_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_retrycanceled_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lrosads_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/operations/_lrosads_operations.py
@@ -40,7 +40,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 # fmt: off
 
-def build_put_non_retry400_request_initial(
+def build_put_non_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -65,7 +65,7 @@ def build_put_non_retry400_request_initial(
     )
 
 
-def build_put_non_retry201_creating400_request_initial(
+def build_put_non_retry201_creating400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -90,7 +90,7 @@ def build_put_non_retry201_creating400_request_initial(
     )
 
 
-def build_put_non_retry201_creating400_invalid_json_request_initial(
+def build_put_non_retry201_creating400_invalid_json_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -115,7 +115,7 @@ def build_put_non_retry201_creating400_invalid_json_request_initial(
     )
 
 
-def build_put_async_relative_retry400_request_initial(
+def build_put_async_relative_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -140,7 +140,7 @@ def build_put_async_relative_retry400_request_initial(
     )
 
 
-def build_delete_non_retry400_request_initial(
+def build_delete_non_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -162,7 +162,7 @@ def build_delete_non_retry400_request_initial(
     )
 
 
-def build_delete202_non_retry400_request_initial(
+def build_delete202_non_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -184,7 +184,7 @@ def build_delete202_non_retry400_request_initial(
     )
 
 
-def build_delete_async_relative_retry400_request_initial(
+def build_delete_async_relative_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -206,7 +206,7 @@ def build_delete_async_relative_retry400_request_initial(
     )
 
 
-def build_post_non_retry400_request_initial(
+def build_post_non_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -231,7 +231,7 @@ def build_post_non_retry400_request_initial(
     )
 
 
-def build_post202_non_retry400_request_initial(
+def build_post202_non_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -256,7 +256,7 @@ def build_post202_non_retry400_request_initial(
     )
 
 
-def build_post_async_relative_retry400_request_initial(
+def build_post_async_relative_retry400_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -281,7 +281,7 @@ def build_post_async_relative_retry400_request_initial(
     )
 
 
-def build_put_error201_no_provisioning_state_payload_request_initial(
+def build_put_error201_no_provisioning_state_payload_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -306,7 +306,7 @@ def build_put_error201_no_provisioning_state_payload_request_initial(
     )
 
 
-def build_put_async_relative_retry_no_status_request_initial(
+def build_put_async_relative_retry_no_status_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -331,7 +331,7 @@ def build_put_async_relative_retry_no_status_request_initial(
     )
 
 
-def build_put_async_relative_retry_no_status_payload_request_initial(
+def build_put_async_relative_retry_no_status_payload_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -356,7 +356,7 @@ def build_put_async_relative_retry_no_status_payload_request_initial(
     )
 
 
-def build_delete204_succeeded_request_initial(
+def build_delete204_succeeded_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -378,7 +378,7 @@ def build_delete204_succeeded_request_initial(
     )
 
 
-def build_delete_async_relative_retry_no_status_request_initial(
+def build_delete_async_relative_retry_no_status_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -400,7 +400,7 @@ def build_delete_async_relative_retry_no_status_request_initial(
     )
 
 
-def build_post202_no_location_request_initial(
+def build_post202_no_location_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -425,7 +425,7 @@ def build_post202_no_location_request_initial(
     )
 
 
-def build_post_async_relative_retry_no_payload_request_initial(
+def build_post_async_relative_retry_no_payload_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -450,7 +450,7 @@ def build_post_async_relative_retry_no_payload_request_initial(
     )
 
 
-def build_put200_invalid_json_request_initial(
+def build_put200_invalid_json_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -475,7 +475,7 @@ def build_put200_invalid_json_request_initial(
     )
 
 
-def build_put_async_relative_retry_invalid_header_request_initial(
+def build_put_async_relative_retry_invalid_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -500,7 +500,7 @@ def build_put_async_relative_retry_invalid_header_request_initial(
     )
 
 
-def build_put_async_relative_retry_invalid_json_polling_request_initial(
+def build_put_async_relative_retry_invalid_json_polling_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -525,7 +525,7 @@ def build_put_async_relative_retry_invalid_json_polling_request_initial(
     )
 
 
-def build_delete202_retry_invalid_header_request_initial(
+def build_delete202_retry_invalid_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -547,7 +547,7 @@ def build_delete202_retry_invalid_header_request_initial(
     )
 
 
-def build_delete_async_relative_retry_invalid_header_request_initial(
+def build_delete_async_relative_retry_invalid_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -569,7 +569,7 @@ def build_delete_async_relative_retry_invalid_header_request_initial(
     )
 
 
-def build_delete_async_relative_retry_invalid_json_polling_request_initial(
+def build_delete_async_relative_retry_invalid_json_polling_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -591,7 +591,7 @@ def build_delete_async_relative_retry_invalid_json_polling_request_initial(
     )
 
 
-def build_post202_retry_invalid_header_request_initial(
+def build_post202_retry_invalid_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -616,7 +616,7 @@ def build_post202_retry_invalid_header_request_initial(
     )
 
 
-def build_post_async_relative_retry_invalid_header_request_initial(
+def build_post_async_relative_retry_invalid_header_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -641,7 +641,7 @@ def build_post_async_relative_retry_invalid_header_request_initial(
     )
 
 
-def build_post_async_relative_retry_invalid_json_polling_request_initial(
+def build_post_async_relative_retry_invalid_json_polling_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -707,7 +707,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_retry400_request_initial(
+        request = build_put_non_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_retry400_initial.metadata["url"],
@@ -829,7 +829,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_retry201_creating400_request_initial(
+        request = build_put_non_retry201_creating400_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_retry201_creating400_initial.metadata["url"],
@@ -952,7 +952,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_non_retry201_creating400_invalid_json_request_initial(
+        request = build_put_non_retry201_creating400_invalid_json_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_non_retry201_creating400_invalid_json_initial.metadata["url"],
@@ -1075,7 +1075,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry400_request_initial(
+        request = build_put_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry400_initial.metadata["url"],
@@ -1199,7 +1199,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_non_retry400_request_initial(
+        request = build_delete_non_retry400_request(
             template_url=self._delete_non_retry400_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -1291,7 +1291,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete202_non_retry400_request_initial(
+        request = build_delete202_non_retry400_request(
             template_url=self._delete202_non_retry400_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -1383,7 +1383,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry400_request_initial(
+        request = build_delete_async_relative_retry400_request(
             template_url=self._delete_async_relative_retry400_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -1489,7 +1489,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_non_retry400_request_initial(
+        request = build_post_non_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_non_retry400_initial.metadata["url"],
@@ -1605,7 +1605,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_non_retry400_request_initial(
+        request = build_post202_non_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_non_retry400_initial.metadata["url"],
@@ -1721,7 +1721,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry400_request_initial(
+        request = build_post_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry400_initial.metadata["url"],
@@ -1841,7 +1841,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_error201_no_provisioning_state_payload_request_initial(
+        request = build_put_error201_no_provisioning_state_payload_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_error201_no_provisioning_state_payload_initial.metadata["url"],
@@ -1963,7 +1963,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_no_status_request_initial(
+        request = build_put_async_relative_retry_no_status_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_no_status_initial.metadata["url"],
@@ -2098,7 +2098,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_no_status_payload_request_initial(
+        request = build_put_async_relative_retry_no_status_payload_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_no_status_payload_initial.metadata["url"],
@@ -2223,7 +2223,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete204_succeeded_request_initial(
+        request = build_delete204_succeeded_request(
             template_url=self._delete204_succeeded_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2311,7 +2311,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_no_status_request_initial(
+        request = build_delete_async_relative_retry_no_status_request(
             template_url=self._delete_async_relative_retry_no_status_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -2417,7 +2417,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_no_location_request_initial(
+        request = build_post202_no_location_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_no_location_initial.metadata["url"],
@@ -2534,7 +2534,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry_no_payload_request_initial(
+        request = build_post_async_relative_retry_no_payload_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_no_payload_initial.metadata["url"],
@@ -2655,7 +2655,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put200_invalid_json_request_initial(
+        request = build_put200_invalid_json_request(
             content_type=content_type,
             json=_json,
             template_url=self._put200_invalid_json_initial.metadata["url"],
@@ -2776,7 +2776,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_invalid_header_request_initial(
+        request = build_put_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_invalid_header_initial.metadata["url"],
@@ -2911,7 +2911,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_put_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_put_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             template_url=self._put_async_relative_retry_invalid_json_polling_initial.metadata["url"],
@@ -3036,7 +3036,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete202_retry_invalid_header_request_initial(
+        request = build_delete202_retry_invalid_header_request(
             template_url=self._delete202_retry_invalid_header_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3129,7 +3129,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_invalid_header_request_initial(
+        request = build_delete_async_relative_retry_invalid_header_request(
             template_url=self._delete_async_relative_retry_invalid_header_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3225,7 +3225,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_delete_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_delete_async_relative_retry_invalid_json_polling_request(
             template_url=self._delete_async_relative_retry_invalid_json_polling_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -3331,7 +3331,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post202_retry_invalid_header_request_initial(
+        request = build_post202_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._post202_retry_invalid_header_initial.metadata["url"],
@@ -3448,7 +3448,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry_invalid_header_request_initial(
+        request = build_post_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_invalid_header_initial.metadata["url"],
@@ -3569,7 +3569,7 @@ class LROSADsOperations(object):  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_post_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_post_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             template_url=self._post_async_relative_retry_invalid_json_polling_initial.metadata["url"],

--- a/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/aio/operations/_lro_with_paramaterized_endpoints_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/aio/operations/_lro_with_paramaterized_endpoints_operations.py
@@ -25,8 +25,8 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 from ... import models as _models
 from ..._vendor import _convert_request
 from ...operations._lro_with_paramaterized_endpoints_operations import (
-    build_poll_with_constant_parameterized_endpoints_request_initial,
-    build_poll_with_parameterized_endpoints_request_initial,
+    build_poll_with_constant_parameterized_endpoints_request,
+    build_poll_with_parameterized_endpoints_request,
 )
 
 T = TypeVar("T")
@@ -43,7 +43,7 @@ class LROWithParamaterizedEndpointsOperationsMixin:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_parameterized_endpoints_request_initial(
+        request = build_poll_with_parameterized_endpoints_request(
             template_url=self._poll_with_parameterized_endpoints_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -159,7 +159,7 @@ class LROWithParamaterizedEndpointsOperationsMixin:
         constant_parameter = kwargs.pop("constant_parameter", "iAmConstant")  # type: str
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_constant_parameterized_endpoints_request_initial(
+        request = build_poll_with_constant_parameterized_endpoints_request(
             constant_parameter=constant_parameter,
             template_url=self._poll_with_constant_parameterized_endpoints_initial.metadata["url"],
             headers=_headers,

--- a/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/operations/_lro_with_paramaterized_endpoints_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/operations/_lro_with_paramaterized_endpoints_operations.py
@@ -39,7 +39,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 # fmt: off
 
-def build_poll_with_parameterized_endpoints_request_initial(
+def build_poll_with_parameterized_endpoints_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -61,7 +61,7 @@ def build_poll_with_parameterized_endpoints_request_initial(
     )
 
 
-def build_poll_with_constant_parameterized_endpoints_request_initial(
+def build_poll_with_constant_parameterized_endpoints_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -104,7 +104,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(object):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_parameterized_endpoints_request_initial(
+        request = build_poll_with_parameterized_endpoints_request(
             template_url=self._poll_with_parameterized_endpoints_initial.metadata["url"],
             headers=_headers,
             params=_params,
@@ -228,7 +228,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(object):
         constant_parameter = kwargs.pop("constant_parameter", "iAmConstant")  # type: str
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_constant_parameterized_endpoints_request_initial(
+        request = build_poll_with_constant_parameterized_endpoints_request(
             constant_parameter=constant_parameter,
             template_url=self._poll_with_constant_parameterized_endpoints_initial.metadata["url"],
             headers=_headers,

--- a/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/aio/operations/_paging_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/aio/operations/_paging_operations.py
@@ -34,7 +34,7 @@ from ...operations._paging_operations import (
     build_get_multiple_pages_failure_uri_request,
     build_get_multiple_pages_fragment_next_link_request,
     build_get_multiple_pages_fragment_with_grouping_next_link_request,
-    build_get_multiple_pages_lro_request_initial,
+    build_get_multiple_pages_lro_request,
     build_get_multiple_pages_request,
     build_get_multiple_pages_retry_first_request,
     build_get_multiple_pages_retry_second_request,
@@ -1269,7 +1269,7 @@ class PagingOperations:
             _maxresults = paging_get_multiple_pages_lro_options.maxresults
             _timeout = paging_get_multiple_pages_lro_options.timeout
 
-        request = build_get_multiple_pages_lro_request_initial(
+        request = build_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -1343,7 +1343,7 @@ class PagingOperations:
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -1361,7 +1361,7 @@ class PagingOperations:
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/operations/_paging_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/operations/_paging_operations.py
@@ -492,7 +492,7 @@ def build_get_multiple_pages_fragment_with_grouping_next_link_request(
     )
 
 
-def build_get_multiple_pages_lro_request_initial(
+def build_get_multiple_pages_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -1877,7 +1877,7 @@ class PagingOperations(object):
             _maxresults = paging_get_multiple_pages_lro_options.maxresults
             _timeout = paging_get_multiple_pages_lro_options.timeout
 
-        request = build_get_multiple_pages_lro_request_initial(
+        request = build_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -1952,7 +1952,7 @@ class PagingOperations(object):
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -1970,7 +1970,7 @@ class PagingOperations(object):
                     _maxresults = paging_get_multiple_pages_lro_options.maxresults
                     _timeout = paging_get_multiple_pages_lro_options.timeout
 
-                request = build_get_multiple_pages_lro_request_initial(
+                request = build_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
@@ -30,7 +30,7 @@ from ... import models as _models
 from ..._vendor import _convert_request
 from ...operations._storage_accounts_operations import (
     build_check_name_availability_request,
-    build_create_request_initial,
+    build_create_request,
     build_delete_request,
     build_get_properties_request,
     build_list_by_resource_group_request,
@@ -147,7 +147,7 @@ class StorageAccountsOperations:
 
         _json = self._serialize.body(parameters, "StorageAccountCreateParameters")
 
-        request = build_create_request_initial(
+        request = build_create_request(
             resource_group_name=resource_group_name,
             account_name=account_name,
             subscription_id=self._config.subscription_id,

--- a/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
@@ -78,7 +78,7 @@ def build_check_name_availability_request(
     )
 
 
-def build_create_request_initial(
+def build_create_request(
     resource_group_name,  # type: str
     account_name,  # type: str
     subscription_id,  # type: str
@@ -485,7 +485,7 @@ class StorageAccountsOperations(object):
 
         _json = self._serialize.body(parameters, "StorageAccountCreateParameters")
 
-        request = build_create_request_initial(
+        request = build_create_request(
             resource_group_name=resource_group_name,
             account_name=account_name,
             subscription_id=self._config.subscription_id,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/aio/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/aio/operations/_operations.py
@@ -35,7 +35,7 @@ from ...operations._operations import (
     build_paging_get_multiple_pages_failure_uri_request,
     build_paging_get_multiple_pages_fragment_next_link_request,
     build_paging_get_multiple_pages_fragment_with_grouping_next_link_request,
-    build_paging_get_multiple_pages_lro_request_initial,
+    build_paging_get_multiple_pages_lro_request,
     build_paging_get_multiple_pages_request,
     build_paging_get_multiple_pages_retry_first_request,
     build_paging_get_multiple_pages_retry_second_request,
@@ -1388,7 +1388,7 @@ class PagingOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_paging_get_multiple_pages_lro_request_initial(
+        request = build_paging_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=maxresults,
             timeout=timeout,
@@ -1460,7 +1460,7 @@ class PagingOperations:
         def prepare_request(next_link=None):
             if not next_link:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,
@@ -1471,7 +1471,7 @@ class PagingOperations:
 
             else:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/operations/_operations.py
@@ -361,7 +361,7 @@ def build_paging_get_multiple_pages_fragment_with_grouping_next_link_request(
     return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_paging_get_multiple_pages_lro_request_initial(
+def build_paging_get_multiple_pages_lro_request(
     *,
     client_request_id: Optional[str] = None,
     maxresults: Optional[int] = None,
@@ -1776,7 +1776,7 @@ class PagingOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_paging_get_multiple_pages_lro_request_initial(
+        request = build_paging_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=maxresults,
             timeout=timeout,
@@ -1847,7 +1847,7 @@ class PagingOperations:
         def prepare_request(next_link=None):
             if not next_link:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,
@@ -1858,7 +1858,7 @@ class PagingOperations:
 
             else:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/aio/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/aio/operations/_operations.py
@@ -26,87 +26,87 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
 from ...operations._operations import (
-    build_lr_os_custom_header_post202_retry200_request_initial,
-    build_lr_os_custom_header_post_async_retry_succeeded_request_initial,
-    build_lr_os_custom_header_put201_creating_succeeded200_request_initial,
-    build_lr_os_custom_header_put_async_retry_succeeded_request_initial,
-    build_lro_retrys_delete202_retry200_request_initial,
-    build_lro_retrys_delete_async_relative_retry_succeeded_request_initial,
-    build_lro_retrys_delete_provisioning202_accepted200_succeeded_request_initial,
-    build_lro_retrys_post202_retry200_request_initial,
-    build_lro_retrys_post_async_relative_retry_succeeded_request_initial,
-    build_lro_retrys_put201_creating_succeeded200_request_initial,
-    build_lro_retrys_put_async_relative_retry_succeeded_request_initial,
-    build_lros_delete202_no_retry204_request_initial,
-    build_lros_delete202_retry200_request_initial,
-    build_lros_delete204_succeeded_request_initial,
-    build_lros_delete_async_no_header_in_retry_request_initial,
-    build_lros_delete_async_no_retry_succeeded_request_initial,
-    build_lros_delete_async_retry_failed_request_initial,
-    build_lros_delete_async_retry_succeeded_request_initial,
-    build_lros_delete_async_retrycanceled_request_initial,
-    build_lros_delete_no_header_in_retry_request_initial,
-    build_lros_delete_provisioning202_accepted200_succeeded_request_initial,
-    build_lros_delete_provisioning202_deleting_failed200_request_initial,
-    build_lros_delete_provisioning202_deletingcanceled200_request_initial,
-    build_lros_patch200_succeeded_ignore_headers_request_initial,
-    build_lros_patch201_retry_with_async_header_request_initial,
-    build_lros_patch202_retry_with_async_and_location_header_request_initial,
-    build_lros_post200_with_payload_request_initial,
-    build_lros_post202_list_request_initial,
-    build_lros_post202_no_retry204_request_initial,
-    build_lros_post202_retry200_request_initial,
-    build_lros_post_async_no_retry_succeeded_request_initial,
-    build_lros_post_async_retry_failed_request_initial,
-    build_lros_post_async_retry_succeeded_request_initial,
-    build_lros_post_async_retrycanceled_request_initial,
-    build_lros_post_double_headers_final_azure_header_get_default_request_initial,
-    build_lros_post_double_headers_final_azure_header_get_request_initial,
-    build_lros_post_double_headers_final_location_get_request_initial,
-    build_lros_put200_acceptedcanceled200_request_initial,
-    build_lros_put200_succeeded_no_state_request_initial,
-    build_lros_put200_succeeded_request_initial,
-    build_lros_put200_updating_succeeded204_request_initial,
-    build_lros_put201_creating_failed200_request_initial,
-    build_lros_put201_creating_succeeded200_request_initial,
-    build_lros_put201_succeeded_request_initial,
-    build_lros_put202_retry200_request_initial,
-    build_lros_put_async_no_header_in_retry_request_initial,
-    build_lros_put_async_no_retry_succeeded_request_initial,
-    build_lros_put_async_no_retrycanceled_request_initial,
-    build_lros_put_async_non_resource_request_initial,
-    build_lros_put_async_retry_failed_request_initial,
-    build_lros_put_async_retry_succeeded_request_initial,
-    build_lros_put_async_sub_resource_request_initial,
-    build_lros_put_no_header_in_retry_request_initial,
-    build_lros_put_non_resource_request_initial,
-    build_lros_put_sub_resource_request_initial,
-    build_lrosads_delete202_non_retry400_request_initial,
-    build_lrosads_delete202_retry_invalid_header_request_initial,
-    build_lrosads_delete204_succeeded_request_initial,
-    build_lrosads_delete_async_relative_retry400_request_initial,
-    build_lrosads_delete_async_relative_retry_invalid_header_request_initial,
-    build_lrosads_delete_async_relative_retry_invalid_json_polling_request_initial,
-    build_lrosads_delete_async_relative_retry_no_status_request_initial,
-    build_lrosads_delete_non_retry400_request_initial,
-    build_lrosads_post202_no_location_request_initial,
-    build_lrosads_post202_non_retry400_request_initial,
-    build_lrosads_post202_retry_invalid_header_request_initial,
-    build_lrosads_post_async_relative_retry400_request_initial,
-    build_lrosads_post_async_relative_retry_invalid_header_request_initial,
-    build_lrosads_post_async_relative_retry_invalid_json_polling_request_initial,
-    build_lrosads_post_async_relative_retry_no_payload_request_initial,
-    build_lrosads_post_non_retry400_request_initial,
-    build_lrosads_put200_invalid_json_request_initial,
-    build_lrosads_put_async_relative_retry400_request_initial,
-    build_lrosads_put_async_relative_retry_invalid_header_request_initial,
-    build_lrosads_put_async_relative_retry_invalid_json_polling_request_initial,
-    build_lrosads_put_async_relative_retry_no_status_payload_request_initial,
-    build_lrosads_put_async_relative_retry_no_status_request_initial,
-    build_lrosads_put_error201_no_provisioning_state_payload_request_initial,
-    build_lrosads_put_non_retry201_creating400_invalid_json_request_initial,
-    build_lrosads_put_non_retry201_creating400_request_initial,
-    build_lrosads_put_non_retry400_request_initial,
+    build_lr_os_custom_header_post202_retry200_request,
+    build_lr_os_custom_header_post_async_retry_succeeded_request,
+    build_lr_os_custom_header_put201_creating_succeeded200_request,
+    build_lr_os_custom_header_put_async_retry_succeeded_request,
+    build_lro_retrys_delete202_retry200_request,
+    build_lro_retrys_delete_async_relative_retry_succeeded_request,
+    build_lro_retrys_delete_provisioning202_accepted200_succeeded_request,
+    build_lro_retrys_post202_retry200_request,
+    build_lro_retrys_post_async_relative_retry_succeeded_request,
+    build_lro_retrys_put201_creating_succeeded200_request,
+    build_lro_retrys_put_async_relative_retry_succeeded_request,
+    build_lros_delete202_no_retry204_request,
+    build_lros_delete202_retry200_request,
+    build_lros_delete204_succeeded_request,
+    build_lros_delete_async_no_header_in_retry_request,
+    build_lros_delete_async_no_retry_succeeded_request,
+    build_lros_delete_async_retry_failed_request,
+    build_lros_delete_async_retry_succeeded_request,
+    build_lros_delete_async_retrycanceled_request,
+    build_lros_delete_no_header_in_retry_request,
+    build_lros_delete_provisioning202_accepted200_succeeded_request,
+    build_lros_delete_provisioning202_deleting_failed200_request,
+    build_lros_delete_provisioning202_deletingcanceled200_request,
+    build_lros_patch200_succeeded_ignore_headers_request,
+    build_lros_patch201_retry_with_async_header_request,
+    build_lros_patch202_retry_with_async_and_location_header_request,
+    build_lros_post200_with_payload_request,
+    build_lros_post202_list_request,
+    build_lros_post202_no_retry204_request,
+    build_lros_post202_retry200_request,
+    build_lros_post_async_no_retry_succeeded_request,
+    build_lros_post_async_retry_failed_request,
+    build_lros_post_async_retry_succeeded_request,
+    build_lros_post_async_retrycanceled_request,
+    build_lros_post_double_headers_final_azure_header_get_default_request,
+    build_lros_post_double_headers_final_azure_header_get_request,
+    build_lros_post_double_headers_final_location_get_request,
+    build_lros_put200_acceptedcanceled200_request,
+    build_lros_put200_succeeded_no_state_request,
+    build_lros_put200_succeeded_request,
+    build_lros_put200_updating_succeeded204_request,
+    build_lros_put201_creating_failed200_request,
+    build_lros_put201_creating_succeeded200_request,
+    build_lros_put201_succeeded_request,
+    build_lros_put202_retry200_request,
+    build_lros_put_async_no_header_in_retry_request,
+    build_lros_put_async_no_retry_succeeded_request,
+    build_lros_put_async_no_retrycanceled_request,
+    build_lros_put_async_non_resource_request,
+    build_lros_put_async_retry_failed_request,
+    build_lros_put_async_retry_succeeded_request,
+    build_lros_put_async_sub_resource_request,
+    build_lros_put_no_header_in_retry_request,
+    build_lros_put_non_resource_request,
+    build_lros_put_sub_resource_request,
+    build_lrosads_delete202_non_retry400_request,
+    build_lrosads_delete202_retry_invalid_header_request,
+    build_lrosads_delete204_succeeded_request,
+    build_lrosads_delete_async_relative_retry400_request,
+    build_lrosads_delete_async_relative_retry_invalid_header_request,
+    build_lrosads_delete_async_relative_retry_invalid_json_polling_request,
+    build_lrosads_delete_async_relative_retry_no_status_request,
+    build_lrosads_delete_non_retry400_request,
+    build_lrosads_post202_no_location_request,
+    build_lrosads_post202_non_retry400_request,
+    build_lrosads_post202_retry_invalid_header_request,
+    build_lrosads_post_async_relative_retry400_request,
+    build_lrosads_post_async_relative_retry_invalid_header_request,
+    build_lrosads_post_async_relative_retry_invalid_json_polling_request,
+    build_lrosads_post_async_relative_retry_no_payload_request,
+    build_lrosads_post_non_retry400_request,
+    build_lrosads_put200_invalid_json_request,
+    build_lrosads_put_async_relative_retry400_request,
+    build_lrosads_put_async_relative_retry_invalid_header_request,
+    build_lrosads_put_async_relative_retry_invalid_json_polling_request,
+    build_lrosads_put_async_relative_retry_no_status_payload_request,
+    build_lrosads_put_async_relative_retry_no_status_request,
+    build_lrosads_put_error201_no_provisioning_state_payload_request,
+    build_lrosads_put_non_retry201_creating400_invalid_json_request,
+    build_lrosads_put_non_retry201_creating400_request,
+    build_lrosads_put_non_retry400_request,
 )
 
 if sys.version_info >= (3, 9):
@@ -152,7 +152,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_succeeded_request_initial(
+        request = build_lros_put200_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -302,7 +302,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_patch200_succeeded_ignore_headers_request_initial(
+        request = build_lros_patch200_succeeded_ignore_headers_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -462,7 +462,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_patch201_retry_with_async_header_request_initial(
+        request = build_lros_patch201_retry_with_async_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -628,7 +628,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_patch202_retry_with_async_and_location_header_request_initial(
+        request = build_lros_patch202_retry_with_async_and_location_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -791,7 +791,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put201_succeeded_request_initial(
+        request = build_lros_put201_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -931,7 +931,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[List[JSON]]]
 
-        request = build_lros_post202_list_request_initial(
+        request = build_lros_post202_list_request(
             headers=_headers,
             params=_params,
         )
@@ -1060,7 +1060,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_succeeded_no_state_request_initial(
+        request = build_lros_put200_succeeded_no_state_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1210,7 +1210,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put202_retry200_request_initial(
+        request = build_lros_put202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1359,7 +1359,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put201_creating_succeeded200_request_initial(
+        request = build_lros_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1517,7 +1517,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_updating_succeeded204_request_initial(
+        request = build_lros_put200_updating_succeeded204_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1668,7 +1668,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put201_creating_failed200_request_initial(
+        request = build_lros_put201_creating_failed200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1826,7 +1826,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_acceptedcanceled200_request_initial(
+        request = build_lros_put200_acceptedcanceled200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1977,7 +1977,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_no_header_in_retry_request_initial(
+        request = build_lros_put_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2131,7 +2131,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_retry_succeeded_request_initial(
+        request = build_lros_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2296,7 +2296,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_no_retry_succeeded_request_initial(
+        request = build_lros_put_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2459,7 +2459,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_retry_failed_request_initial(
+        request = build_lros_put_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2622,7 +2622,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_no_retrycanceled_request_initial(
+        request = build_lros_put_async_no_retrycanceled_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2785,7 +2785,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_no_header_in_retry_request_initial(
+        request = build_lros_put_async_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2946,7 +2946,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_non_resource_request_initial(
+        request = build_lros_put_non_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3064,7 +3064,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_non_resource_request_initial(
+        request = build_lros_put_async_non_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3182,7 +3182,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_sub_resource_request_initial(
+        request = build_lros_put_sub_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3315,7 +3315,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_sub_resource_request_initial(
+        request = build_lros_put_async_sub_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3440,7 +3440,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_lros_delete_provisioning202_accepted200_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -3562,7 +3562,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_delete_provisioning202_deleting_failed200_request_initial(
+        request = build_lros_delete_provisioning202_deleting_failed200_request(
             headers=_headers,
             params=_params,
         )
@@ -3684,7 +3684,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_delete_provisioning202_deletingcanceled200_request_initial(
+        request = build_lros_delete_provisioning202_deletingcanceled200_request(
             headers=_headers,
             params=_params,
         )
@@ -3808,7 +3808,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete204_succeeded_request_initial(
+        request = build_lros_delete204_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -3885,7 +3885,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[JSON]]
 
-        request = build_lros_delete202_retry200_request_initial(
+        request = build_lros_delete202_retry200_request(
             headers=_headers,
             params=_params,
         )
@@ -4002,7 +4002,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[JSON]]
 
-        request = build_lros_delete202_no_retry204_request_initial(
+        request = build_lros_delete202_no_retry204_request(
             headers=_headers,
             params=_params,
         )
@@ -4121,7 +4121,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_no_header_in_retry_request_initial(
+        request = build_lros_delete_no_header_in_retry_request(
             headers=_headers,
             params=_params,
         )
@@ -4205,7 +4205,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_no_header_in_retry_request_initial(
+        request = build_lros_delete_async_no_header_in_retry_request(
             headers=_headers,
             params=_params,
         )
@@ -4289,7 +4289,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_retry_succeeded_request_initial(
+        request = build_lros_delete_async_retry_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -4376,7 +4376,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_no_retry_succeeded_request_initial(
+        request = build_lros_delete_async_no_retry_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -4463,7 +4463,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_retry_failed_request_initial(
+        request = build_lros_delete_async_retry_failed_request(
             headers=_headers,
             params=_params,
         )
@@ -4550,7 +4550,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_retrycanceled_request_initial(
+        request = build_lros_delete_async_retrycanceled_request(
             headers=_headers,
             params=_params,
         )
@@ -4635,7 +4635,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post200_with_payload_request_initial(
+        request = build_lros_post200_with_payload_request(
             headers=_headers,
             params=_params,
         )
@@ -4750,7 +4750,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post202_retry200_request_initial(
+        request = build_lros_post202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4873,7 +4873,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post202_no_retry204_request_initial(
+        request = build_lros_post202_no_retry204_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -5021,7 +5021,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post_double_headers_final_location_get_request_initial(
+        request = build_lros_post_double_headers_final_location_get_request(
             headers=_headers,
             params=_params,
         )
@@ -5134,7 +5134,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post_double_headers_final_azure_header_get_request_initial(
+        request = build_lros_post_double_headers_final_azure_header_get_request(
             headers=_headers,
             params=_params,
         )
@@ -5248,7 +5248,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post_double_headers_final_azure_header_get_default_request_initial(
+        request = build_lros_post_double_headers_final_azure_header_get_default_request(
             headers=_headers,
             params=_params,
         )
@@ -5369,7 +5369,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_retry_succeeded_request_initial(
+        request = build_lros_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -5532,7 +5532,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_no_retry_succeeded_request_initial(
+        request = build_lros_post_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -5695,7 +5695,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_retry_failed_request_initial(
+        request = build_lros_post_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -5824,7 +5824,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_retrycanceled_request_initial(
+        request = build_lros_post_async_retrycanceled_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -5969,7 +5969,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_put201_creating_succeeded200_request_initial(
+        request = build_lro_retrys_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6127,7 +6127,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_put_async_relative_retry_succeeded_request_initial(
+        request = build_lro_retrys_put_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6284,7 +6284,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lro_retrys_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_lro_retrys_delete_provisioning202_accepted200_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -6408,7 +6408,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lro_retrys_delete202_retry200_request_initial(
+        request = build_lro_retrys_delete202_retry200_request(
             headers=_headers,
             params=_params,
         )
@@ -6492,7 +6492,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lro_retrys_delete_async_relative_retry_succeeded_request_initial(
+        request = build_lro_retrys_delete_async_relative_retry_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -6587,7 +6587,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_post202_retry200_request_initial(
+        request = build_lro_retrys_post202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6712,7 +6712,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_post_async_relative_retry_succeeded_request_initial(
+        request = build_lro_retrys_post_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6857,7 +6857,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_non_retry400_request_initial(
+        request = build_lrosads_put_non_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7011,7 +7011,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_non_retry201_creating400_request_initial(
+        request = build_lrosads_put_non_retry201_creating400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7170,7 +7170,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_non_retry201_creating400_invalid_json_request_initial(
+        request = build_lrosads_put_non_retry201_creating400_invalid_json_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7327,7 +7327,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry400_request_initial(
+        request = build_lrosads_put_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7485,7 +7485,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_non_retry400_request_initial(
+        request = build_lrosads_delete_non_retry400_request(
             headers=_headers,
             params=_params,
         )
@@ -7568,7 +7568,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete202_non_retry400_request_initial(
+        request = build_lrosads_delete202_non_retry400_request(
             headers=_headers,
             params=_params,
         )
@@ -7651,7 +7651,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry400_request_initial(
+        request = build_lrosads_delete_async_relative_retry400_request(
             headers=_headers,
             params=_params,
         )
@@ -7746,7 +7746,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_non_retry400_request_initial(
+        request = build_lrosads_post_non_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7870,7 +7870,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post202_non_retry400_request_initial(
+        request = build_lrosads_post202_non_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7994,7 +7994,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry400_request_initial(
+        request = build_lrosads_post_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8122,7 +8122,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_error201_no_provisioning_state_payload_request_initial(
+        request = build_lrosads_put_error201_no_provisioning_state_payload_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8278,7 +8278,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_no_status_request_initial(
+        request = build_lrosads_put_async_relative_retry_no_status_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8445,7 +8445,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_no_status_payload_request_initial(
+        request = build_lrosads_put_async_relative_retry_no_status_payload_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8604,7 +8604,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete204_succeeded_request_initial(
+        request = build_lrosads_delete204_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -8683,7 +8683,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry_no_status_request_initial(
+        request = build_lrosads_delete_async_relative_retry_no_status_request(
             headers=_headers,
             params=_params,
         )
@@ -8778,7 +8778,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post202_no_location_request_initial(
+        request = build_lrosads_post202_no_location_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8903,7 +8903,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry_no_payload_request_initial(
+        request = build_lrosads_post_async_relative_retry_no_payload_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9030,7 +9030,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put200_invalid_json_request_initial(
+        request = build_lrosads_put200_invalid_json_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9182,7 +9182,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_invalid_header_request_initial(
+        request = build_lrosads_put_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9349,7 +9349,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_lrosads_put_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9508,7 +9508,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete202_retry_invalid_header_request_initial(
+        request = build_lrosads_delete202_retry_invalid_header_request(
             headers=_headers,
             params=_params,
         )
@@ -9592,7 +9592,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry_invalid_header_request_initial(
+        request = build_lrosads_delete_async_relative_retry_invalid_header_request(
             headers=_headers,
             params=_params,
         )
@@ -9679,7 +9679,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_lrosads_delete_async_relative_retry_invalid_json_polling_request(
             headers=_headers,
             params=_params,
         )
@@ -9774,7 +9774,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post202_retry_invalid_header_request_initial(
+        request = build_lrosads_post202_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9899,7 +9899,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry_invalid_header_request_initial(
+        request = build_lrosads_post_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10028,7 +10028,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_lrosads_post_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10173,7 +10173,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_put_async_retry_succeeded_request_initial(
+        request = build_lr_os_custom_header_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10339,7 +10339,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_put201_creating_succeeded200_request_initial(
+        request = build_lr_os_custom_header_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10500,7 +10500,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_post202_retry200_request_initial(
+        request = build_lr_os_custom_header_post202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10626,7 +10626,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_post_async_retry_succeeded_request_initial(
+        request = build_lr_os_custom_header_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/operations/_operations.py
@@ -39,7 +39,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 
 
-def build_lros_put200_succeeded_request_initial(
+def build_lros_put200_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -58,7 +58,7 @@ def build_lros_put200_succeeded_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_patch200_succeeded_ignore_headers_request_initial(
+def build_lros_patch200_succeeded_ignore_headers_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -77,7 +77,7 @@ def build_lros_patch200_succeeded_ignore_headers_request_initial(
     return HttpRequest(method="PATCH", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_patch201_retry_with_async_header_request_initial(
+def build_lros_patch201_retry_with_async_header_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -96,7 +96,7 @@ def build_lros_patch201_retry_with_async_header_request_initial(
     return HttpRequest(method="PATCH", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_patch202_retry_with_async_and_location_header_request_initial(
+def build_lros_patch202_retry_with_async_and_location_header_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -115,7 +115,7 @@ def build_lros_patch202_retry_with_async_and_location_header_request_initial(
     return HttpRequest(method="PATCH", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put201_succeeded_request_initial(
+def build_lros_put201_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -134,7 +134,7 @@ def build_lros_put201_succeeded_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_post202_list_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_post202_list_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -148,7 +148,7 @@ def build_lros_post202_list_request_initial(**kwargs: Any) -> HttpRequest:
     return HttpRequest(method="POST", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_put200_succeeded_no_state_request_initial(
+def build_lros_put200_succeeded_no_state_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -167,7 +167,7 @@ def build_lros_put200_succeeded_no_state_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put202_retry200_request_initial(
+def build_lros_put202_retry200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -186,7 +186,7 @@ def build_lros_put202_retry200_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put201_creating_succeeded200_request_initial(
+def build_lros_put201_creating_succeeded200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -205,7 +205,7 @@ def build_lros_put201_creating_succeeded200_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put200_updating_succeeded204_request_initial(
+def build_lros_put200_updating_succeeded204_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -224,7 +224,7 @@ def build_lros_put200_updating_succeeded204_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put201_creating_failed200_request_initial(
+def build_lros_put201_creating_failed200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -243,7 +243,7 @@ def build_lros_put201_creating_failed200_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put200_acceptedcanceled200_request_initial(
+def build_lros_put200_acceptedcanceled200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -262,7 +262,7 @@ def build_lros_put200_acceptedcanceled200_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_no_header_in_retry_request_initial(
+def build_lros_put_no_header_in_retry_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -281,7 +281,7 @@ def build_lros_put_no_header_in_retry_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_retry_succeeded_request_initial(
+def build_lros_put_async_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -300,7 +300,7 @@ def build_lros_put_async_retry_succeeded_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_no_retry_succeeded_request_initial(
+def build_lros_put_async_no_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -319,7 +319,7 @@ def build_lros_put_async_no_retry_succeeded_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_retry_failed_request_initial(
+def build_lros_put_async_retry_failed_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -338,7 +338,7 @@ def build_lros_put_async_retry_failed_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_no_retrycanceled_request_initial(
+def build_lros_put_async_no_retrycanceled_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -357,7 +357,7 @@ def build_lros_put_async_no_retrycanceled_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_no_header_in_retry_request_initial(
+def build_lros_put_async_no_header_in_retry_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -376,7 +376,7 @@ def build_lros_put_async_no_header_in_retry_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_non_resource_request_initial(
+def build_lros_put_non_resource_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -395,7 +395,7 @@ def build_lros_put_non_resource_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_non_resource_request_initial(
+def build_lros_put_async_non_resource_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -414,7 +414,7 @@ def build_lros_put_async_non_resource_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_sub_resource_request_initial(
+def build_lros_put_sub_resource_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -433,7 +433,7 @@ def build_lros_put_sub_resource_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_put_async_sub_resource_request_initial(
+def build_lros_put_async_sub_resource_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -452,7 +452,7 @@ def build_lros_put_async_sub_resource_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_delete_provisioning202_accepted200_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_provisioning202_accepted200_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -466,7 +466,7 @@ def build_lros_delete_provisioning202_accepted200_succeeded_request_initial(**kw
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_provisioning202_deleting_failed200_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_provisioning202_deleting_failed200_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -480,7 +480,7 @@ def build_lros_delete_provisioning202_deleting_failed200_request_initial(**kwarg
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_provisioning202_deletingcanceled200_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_provisioning202_deletingcanceled200_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -494,7 +494,7 @@ def build_lros_delete_provisioning202_deletingcanceled200_request_initial(**kwar
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete204_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete204_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -508,7 +508,7 @@ def build_lros_delete204_succeeded_request_initial(**kwargs: Any) -> HttpRequest
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete202_retry200_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete202_retry200_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -522,7 +522,7 @@ def build_lros_delete202_retry200_request_initial(**kwargs: Any) -> HttpRequest:
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete202_no_retry204_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete202_no_retry204_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -536,7 +536,7 @@ def build_lros_delete202_no_retry204_request_initial(**kwargs: Any) -> HttpReque
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_no_header_in_retry_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_no_header_in_retry_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -550,7 +550,7 @@ def build_lros_delete_no_header_in_retry_request_initial(**kwargs: Any) -> HttpR
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_async_no_header_in_retry_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_async_no_header_in_retry_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -564,7 +564,7 @@ def build_lros_delete_async_no_header_in_retry_request_initial(**kwargs: Any) ->
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_async_retry_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_async_retry_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -578,7 +578,7 @@ def build_lros_delete_async_retry_succeeded_request_initial(**kwargs: Any) -> Ht
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_async_no_retry_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_async_no_retry_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -592,7 +592,7 @@ def build_lros_delete_async_no_retry_succeeded_request_initial(**kwargs: Any) ->
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_async_retry_failed_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_async_retry_failed_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -606,7 +606,7 @@ def build_lros_delete_async_retry_failed_request_initial(**kwargs: Any) -> HttpR
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_delete_async_retrycanceled_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_delete_async_retrycanceled_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -620,7 +620,7 @@ def build_lros_delete_async_retrycanceled_request_initial(**kwargs: Any) -> Http
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_post200_with_payload_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_post200_with_payload_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -634,7 +634,7 @@ def build_lros_post200_with_payload_request_initial(**kwargs: Any) -> HttpReques
     return HttpRequest(method="POST", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_post202_retry200_request_initial(
+def build_lros_post202_retry200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -653,7 +653,7 @@ def build_lros_post202_retry200_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_post202_no_retry204_request_initial(
+def build_lros_post202_no_retry204_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -672,7 +672,7 @@ def build_lros_post202_no_retry204_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_post_double_headers_final_location_get_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_post_double_headers_final_location_get_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -686,7 +686,7 @@ def build_lros_post_double_headers_final_location_get_request_initial(**kwargs: 
     return HttpRequest(method="POST", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_post_double_headers_final_azure_header_get_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_post_double_headers_final_azure_header_get_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -700,7 +700,7 @@ def build_lros_post_double_headers_final_azure_header_get_request_initial(**kwar
     return HttpRequest(method="POST", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_post_double_headers_final_azure_header_get_default_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lros_post_double_headers_final_azure_header_get_default_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -714,7 +714,7 @@ def build_lros_post_double_headers_final_azure_header_get_default_request_initia
     return HttpRequest(method="POST", url=_url, headers=_headers, **kwargs)
 
 
-def build_lros_post_async_retry_succeeded_request_initial(
+def build_lros_post_async_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -733,7 +733,7 @@ def build_lros_post_async_retry_succeeded_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_post_async_no_retry_succeeded_request_initial(
+def build_lros_post_async_no_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -752,7 +752,7 @@ def build_lros_post_async_no_retry_succeeded_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_post_async_retry_failed_request_initial(
+def build_lros_post_async_retry_failed_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -771,7 +771,7 @@ def build_lros_post_async_retry_failed_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lros_post_async_retrycanceled_request_initial(
+def build_lros_post_async_retrycanceled_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -790,7 +790,7 @@ def build_lros_post_async_retrycanceled_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lro_retrys_put201_creating_succeeded200_request_initial(
+def build_lro_retrys_put201_creating_succeeded200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -809,7 +809,7 @@ def build_lro_retrys_put201_creating_succeeded200_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lro_retrys_put_async_relative_retry_succeeded_request_initial(
+def build_lro_retrys_put_async_relative_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -828,7 +828,7 @@ def build_lro_retrys_put_async_relative_retry_succeeded_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lro_retrys_delete_provisioning202_accepted200_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lro_retrys_delete_provisioning202_accepted200_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -842,7 +842,7 @@ def build_lro_retrys_delete_provisioning202_accepted200_succeeded_request_initia
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lro_retrys_delete202_retry200_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lro_retrys_delete202_retry200_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -856,7 +856,7 @@ def build_lro_retrys_delete202_retry200_request_initial(**kwargs: Any) -> HttpRe
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lro_retrys_delete_async_relative_retry_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lro_retrys_delete_async_relative_retry_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -870,7 +870,7 @@ def build_lro_retrys_delete_async_relative_retry_succeeded_request_initial(**kwa
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lro_retrys_post202_retry200_request_initial(
+def build_lro_retrys_post202_retry200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -889,7 +889,7 @@ def build_lro_retrys_post202_retry200_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lro_retrys_post_async_relative_retry_succeeded_request_initial(
+def build_lro_retrys_post_async_relative_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -908,7 +908,7 @@ def build_lro_retrys_post_async_relative_retry_succeeded_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_non_retry400_request_initial(
+def build_lrosads_put_non_retry400_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -927,7 +927,7 @@ def build_lrosads_put_non_retry400_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_non_retry201_creating400_request_initial(
+def build_lrosads_put_non_retry201_creating400_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -946,7 +946,7 @@ def build_lrosads_put_non_retry201_creating400_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_non_retry201_creating400_invalid_json_request_initial(
+def build_lrosads_put_non_retry201_creating400_invalid_json_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -965,7 +965,7 @@ def build_lrosads_put_non_retry201_creating400_invalid_json_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_async_relative_retry400_request_initial(
+def build_lrosads_put_async_relative_retry400_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -984,7 +984,7 @@ def build_lrosads_put_async_relative_retry400_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_delete_non_retry400_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete_non_retry400_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -998,7 +998,7 @@ def build_lrosads_delete_non_retry400_request_initial(**kwargs: Any) -> HttpRequ
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_delete202_non_retry400_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete202_non_retry400_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1012,7 +1012,7 @@ def build_lrosads_delete202_non_retry400_request_initial(**kwargs: Any) -> HttpR
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_delete_async_relative_retry400_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete_async_relative_retry400_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1026,7 +1026,7 @@ def build_lrosads_delete_async_relative_retry400_request_initial(**kwargs: Any) 
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_post_non_retry400_request_initial(
+def build_lrosads_post_non_retry400_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1045,7 +1045,7 @@ def build_lrosads_post_non_retry400_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_post202_non_retry400_request_initial(
+def build_lrosads_post202_non_retry400_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1064,7 +1064,7 @@ def build_lrosads_post202_non_retry400_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_post_async_relative_retry400_request_initial(
+def build_lrosads_post_async_relative_retry400_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1083,7 +1083,7 @@ def build_lrosads_post_async_relative_retry400_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_error201_no_provisioning_state_payload_request_initial(
+def build_lrosads_put_error201_no_provisioning_state_payload_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1102,7 +1102,7 @@ def build_lrosads_put_error201_no_provisioning_state_payload_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_async_relative_retry_no_status_request_initial(
+def build_lrosads_put_async_relative_retry_no_status_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1121,7 +1121,7 @@ def build_lrosads_put_async_relative_retry_no_status_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_async_relative_retry_no_status_payload_request_initial(
+def build_lrosads_put_async_relative_retry_no_status_payload_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1140,7 +1140,7 @@ def build_lrosads_put_async_relative_retry_no_status_payload_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_delete204_succeeded_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete204_succeeded_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1154,7 +1154,7 @@ def build_lrosads_delete204_succeeded_request_initial(**kwargs: Any) -> HttpRequ
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_delete_async_relative_retry_no_status_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete_async_relative_retry_no_status_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1168,7 +1168,7 @@ def build_lrosads_delete_async_relative_retry_no_status_request_initial(**kwargs
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_post202_no_location_request_initial(
+def build_lrosads_post202_no_location_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1187,7 +1187,7 @@ def build_lrosads_post202_no_location_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_post_async_relative_retry_no_payload_request_initial(
+def build_lrosads_post_async_relative_retry_no_payload_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1206,7 +1206,7 @@ def build_lrosads_post_async_relative_retry_no_payload_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put200_invalid_json_request_initial(
+def build_lrosads_put200_invalid_json_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1225,7 +1225,7 @@ def build_lrosads_put200_invalid_json_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_async_relative_retry_invalid_header_request_initial(
+def build_lrosads_put_async_relative_retry_invalid_header_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1244,7 +1244,7 @@ def build_lrosads_put_async_relative_retry_invalid_header_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_put_async_relative_retry_invalid_json_polling_request_initial(
+def build_lrosads_put_async_relative_retry_invalid_json_polling_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1263,7 +1263,7 @@ def build_lrosads_put_async_relative_retry_invalid_json_polling_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_delete202_retry_invalid_header_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete202_retry_invalid_header_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1277,7 +1277,7 @@ def build_lrosads_delete202_retry_invalid_header_request_initial(**kwargs: Any) 
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_delete_async_relative_retry_invalid_header_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete_async_relative_retry_invalid_header_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1291,7 +1291,7 @@ def build_lrosads_delete_async_relative_retry_invalid_header_request_initial(**k
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_delete_async_relative_retry_invalid_json_polling_request_initial(**kwargs: Any) -> HttpRequest:
+def build_lrosads_delete_async_relative_retry_invalid_json_polling_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -1305,7 +1305,7 @@ def build_lrosads_delete_async_relative_retry_invalid_json_polling_request_initi
     return HttpRequest(method="DELETE", url=_url, headers=_headers, **kwargs)
 
 
-def build_lrosads_post202_retry_invalid_header_request_initial(
+def build_lrosads_post202_retry_invalid_header_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1324,7 +1324,7 @@ def build_lrosads_post202_retry_invalid_header_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_post_async_relative_retry_invalid_header_request_initial(
+def build_lrosads_post_async_relative_retry_invalid_header_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1343,7 +1343,7 @@ def build_lrosads_post_async_relative_retry_invalid_header_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lrosads_post_async_relative_retry_invalid_json_polling_request_initial(
+def build_lrosads_post_async_relative_retry_invalid_json_polling_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1362,7 +1362,7 @@ def build_lrosads_post_async_relative_retry_invalid_json_polling_request_initial
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lr_os_custom_header_put_async_retry_succeeded_request_initial(
+def build_lr_os_custom_header_put_async_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1381,7 +1381,7 @@ def build_lr_os_custom_header_put_async_retry_succeeded_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lr_os_custom_header_put201_creating_succeeded200_request_initial(
+def build_lr_os_custom_header_put201_creating_succeeded200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1400,7 +1400,7 @@ def build_lr_os_custom_header_put201_creating_succeeded200_request_initial(
     return HttpRequest(method="PUT", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lr_os_custom_header_post202_retry200_request_initial(
+def build_lr_os_custom_header_post202_retry200_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1419,7 +1419,7 @@ def build_lr_os_custom_header_post202_retry200_request_initial(
     return HttpRequest(method="POST", url=_url, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_lr_os_custom_header_post_async_retry_succeeded_request_initial(
+def build_lr_os_custom_header_post_async_retry_succeeded_request(
     *, json: Optional[JSON] = None, content: Any = None, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1472,7 +1472,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_succeeded_request_initial(
+        request = build_lros_put200_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1622,7 +1622,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_patch200_succeeded_ignore_headers_request_initial(
+        request = build_lros_patch200_succeeded_ignore_headers_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1780,7 +1780,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_patch201_retry_with_async_header_request_initial(
+        request = build_lros_patch201_retry_with_async_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -1943,7 +1943,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_patch202_retry_with_async_and_location_header_request_initial(
+        request = build_lros_patch202_retry_with_async_and_location_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2106,7 +2106,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put201_succeeded_request_initial(
+        request = build_lros_put201_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2246,7 +2246,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[List[JSON]]]
 
-        request = build_lros_post202_list_request_initial(
+        request = build_lros_post202_list_request(
             headers=_headers,
             params=_params,
         )
@@ -2375,7 +2375,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_succeeded_no_state_request_initial(
+        request = build_lros_put200_succeeded_no_state_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2523,7 +2523,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put202_retry200_request_initial(
+        request = build_lros_put202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2672,7 +2672,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put201_creating_succeeded200_request_initial(
+        request = build_lros_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2828,7 +2828,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_updating_succeeded204_request_initial(
+        request = build_lros_put200_updating_succeeded204_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -2977,7 +2977,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put201_creating_failed200_request_initial(
+        request = build_lros_put201_creating_failed200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3133,7 +3133,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put200_acceptedcanceled200_request_initial(
+        request = build_lros_put200_acceptedcanceled200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3282,7 +3282,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_no_header_in_retry_request_initial(
+        request = build_lros_put_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3436,7 +3436,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_retry_succeeded_request_initial(
+        request = build_lros_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3599,7 +3599,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_no_retry_succeeded_request_initial(
+        request = build_lros_put_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3760,7 +3760,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_retry_failed_request_initial(
+        request = build_lros_put_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -3923,7 +3923,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_no_retrycanceled_request_initial(
+        request = build_lros_put_async_no_retrycanceled_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4084,7 +4084,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_no_header_in_retry_request_initial(
+        request = build_lros_put_async_no_header_in_retry_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4243,7 +4243,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_non_resource_request_initial(
+        request = build_lros_put_non_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4361,7 +4361,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_non_resource_request_initial(
+        request = build_lros_put_async_non_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4479,7 +4479,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_sub_resource_request_initial(
+        request = build_lros_put_sub_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4612,7 +4612,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_put_async_sub_resource_request_initial(
+        request = build_lros_put_async_sub_resource_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -4737,7 +4737,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_lros_delete_provisioning202_accepted200_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -4859,7 +4859,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_delete_provisioning202_deleting_failed200_request_initial(
+        request = build_lros_delete_provisioning202_deleting_failed200_request(
             headers=_headers,
             params=_params,
         )
@@ -4981,7 +4981,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_delete_provisioning202_deletingcanceled200_request_initial(
+        request = build_lros_delete_provisioning202_deletingcanceled200_request(
             headers=_headers,
             params=_params,
         )
@@ -5103,7 +5103,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete204_succeeded_request_initial(
+        request = build_lros_delete204_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -5180,7 +5180,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[JSON]]
 
-        request = build_lros_delete202_retry200_request_initial(
+        request = build_lros_delete202_retry200_request(
             headers=_headers,
             params=_params,
         )
@@ -5297,7 +5297,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[JSON]]
 
-        request = build_lros_delete202_no_retry204_request_initial(
+        request = build_lros_delete202_no_retry204_request(
             headers=_headers,
             params=_params,
         )
@@ -5416,7 +5416,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_no_header_in_retry_request_initial(
+        request = build_lros_delete_no_header_in_retry_request(
             headers=_headers,
             params=_params,
         )
@@ -5500,7 +5500,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_no_header_in_retry_request_initial(
+        request = build_lros_delete_async_no_header_in_retry_request(
             headers=_headers,
             params=_params,
         )
@@ -5584,7 +5584,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_retry_succeeded_request_initial(
+        request = build_lros_delete_async_retry_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -5671,7 +5671,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_no_retry_succeeded_request_initial(
+        request = build_lros_delete_async_no_retry_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -5758,7 +5758,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_retry_failed_request_initial(
+        request = build_lros_delete_async_retry_failed_request(
             headers=_headers,
             params=_params,
         )
@@ -5845,7 +5845,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lros_delete_async_retrycanceled_request_initial(
+        request = build_lros_delete_async_retrycanceled_request(
             headers=_headers,
             params=_params,
         )
@@ -5930,7 +5930,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post200_with_payload_request_initial(
+        request = build_lros_post200_with_payload_request(
             headers=_headers,
             params=_params,
         )
@@ -6045,7 +6045,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post202_retry200_request_initial(
+        request = build_lros_post202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6168,7 +6168,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post202_no_retry204_request_initial(
+        request = build_lros_post202_no_retry204_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6316,7 +6316,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post_double_headers_final_location_get_request_initial(
+        request = build_lros_post_double_headers_final_location_get_request(
             headers=_headers,
             params=_params,
         )
@@ -6429,7 +6429,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post_double_headers_final_azure_header_get_request_initial(
+        request = build_lros_post_double_headers_final_azure_header_get_request(
             headers=_headers,
             params=_params,
         )
@@ -6542,7 +6542,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lros_post_double_headers_final_azure_header_get_default_request_initial(
+        request = build_lros_post_double_headers_final_azure_header_get_default_request(
             headers=_headers,
             params=_params,
         )
@@ -6661,7 +6661,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_retry_succeeded_request_initial(
+        request = build_lros_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6820,7 +6820,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_no_retry_succeeded_request_initial(
+        request = build_lros_post_async_no_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -6981,7 +6981,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_retry_failed_request_initial(
+        request = build_lros_post_async_retry_failed_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7110,7 +7110,7 @@ class LROsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lros_post_async_retrycanceled_request_initial(
+        request = build_lros_post_async_retrycanceled_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7255,7 +7255,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_put201_creating_succeeded200_request_initial(
+        request = build_lro_retrys_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7411,7 +7411,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_put_async_relative_retry_succeeded_request_initial(
+        request = build_lro_retrys_put_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7568,7 +7568,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lro_retrys_delete_provisioning202_accepted200_succeeded_request_initial(
+        request = build_lro_retrys_delete_provisioning202_accepted200_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -7690,7 +7690,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lro_retrys_delete202_retry200_request_initial(
+        request = build_lro_retrys_delete202_retry200_request(
             headers=_headers,
             params=_params,
         )
@@ -7774,7 +7774,7 @@ class LRORetrysOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lro_retrys_delete_async_relative_retry_succeeded_request_initial(
+        request = build_lro_retrys_delete_async_relative_retry_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -7869,7 +7869,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_post202_retry200_request_initial(
+        request = build_lro_retrys_post202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -7994,7 +7994,7 @@ class LRORetrysOperations:
         else:
             _json = None
 
-        request = build_lro_retrys_post_async_relative_retry_succeeded_request_initial(
+        request = build_lro_retrys_post_async_relative_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8139,7 +8139,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_non_retry400_request_initial(
+        request = build_lrosads_put_non_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8293,7 +8293,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_non_retry201_creating400_request_initial(
+        request = build_lrosads_put_non_retry201_creating400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8448,7 +8448,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_non_retry201_creating400_invalid_json_request_initial(
+        request = build_lrosads_put_non_retry201_creating400_invalid_json_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8605,7 +8605,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry400_request_initial(
+        request = build_lrosads_put_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -8759,7 +8759,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_non_retry400_request_initial(
+        request = build_lrosads_delete_non_retry400_request(
             headers=_headers,
             params=_params,
         )
@@ -8840,7 +8840,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete202_non_retry400_request_initial(
+        request = build_lrosads_delete202_non_retry400_request(
             headers=_headers,
             params=_params,
         )
@@ -8923,7 +8923,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry400_request_initial(
+        request = build_lrosads_delete_async_relative_retry400_request(
             headers=_headers,
             params=_params,
         )
@@ -9018,7 +9018,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_non_retry400_request_initial(
+        request = build_lrosads_post_non_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9142,7 +9142,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post202_non_retry400_request_initial(
+        request = build_lrosads_post202_non_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9266,7 +9266,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry400_request_initial(
+        request = build_lrosads_post_async_relative_retry400_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9394,7 +9394,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_error201_no_provisioning_state_payload_request_initial(
+        request = build_lrosads_put_error201_no_provisioning_state_payload_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9550,7 +9550,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_no_status_request_initial(
+        request = build_lrosads_put_async_relative_retry_no_status_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9717,7 +9717,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_no_status_payload_request_initial(
+        request = build_lrosads_put_async_relative_retry_no_status_payload_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -9874,7 +9874,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete204_succeeded_request_initial(
+        request = build_lrosads_delete204_succeeded_request(
             headers=_headers,
             params=_params,
         )
@@ -9953,7 +9953,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry_no_status_request_initial(
+        request = build_lrosads_delete_async_relative_retry_no_status_request(
             headers=_headers,
             params=_params,
         )
@@ -10048,7 +10048,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post202_no_location_request_initial(
+        request = build_lrosads_post202_no_location_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10173,7 +10173,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry_no_payload_request_initial(
+        request = build_lrosads_post_async_relative_retry_no_payload_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10300,7 +10300,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put200_invalid_json_request_initial(
+        request = build_lrosads_put200_invalid_json_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10450,7 +10450,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_invalid_header_request_initial(
+        request = build_lrosads_put_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10617,7 +10617,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_put_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_lrosads_put_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -10776,7 +10776,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete202_retry_invalid_header_request_initial(
+        request = build_lrosads_delete202_retry_invalid_header_request(
             headers=_headers,
             params=_params,
         )
@@ -10860,7 +10860,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry_invalid_header_request_initial(
+        request = build_lrosads_delete_async_relative_retry_invalid_header_request(
             headers=_headers,
             params=_params,
         )
@@ -10947,7 +10947,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
 
         cls = kwargs.pop("cls", None)  # type: ClsType[None]
 
-        request = build_lrosads_delete_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_lrosads_delete_async_relative_retry_invalid_json_polling_request(
             headers=_headers,
             params=_params,
         )
@@ -11042,7 +11042,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post202_retry_invalid_header_request_initial(
+        request = build_lrosads_post202_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -11167,7 +11167,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry_invalid_header_request_initial(
+        request = build_lrosads_post_async_relative_retry_invalid_header_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -11296,7 +11296,7 @@ class LROSADsOperations:  # pylint: disable=too-many-public-methods
         else:
             _json = None
 
-        request = build_lrosads_post_async_relative_retry_invalid_json_polling_request_initial(
+        request = build_lrosads_post_async_relative_retry_invalid_json_polling_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -11441,7 +11441,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_put_async_retry_succeeded_request_initial(
+        request = build_lr_os_custom_header_put_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -11605,7 +11605,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_put201_creating_succeeded200_request_initial(
+        request = build_lr_os_custom_header_put201_creating_succeeded200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -11764,7 +11764,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_post202_retry200_request_initial(
+        request = build_lr_os_custom_header_post202_retry200_request(
             content_type=content_type,
             json=_json,
             headers=_headers,
@@ -11890,7 +11890,7 @@ class LROsCustomHeaderOperations:
         else:
             _json = None
 
-        request = build_lr_os_custom_header_post_async_retry_succeeded_request_initial(
+        request = build_lr_os_custom_header_post_async_retry_succeeded_request(
             content_type=content_type,
             json=_json,
             headers=_headers,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/_operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/_operations/_operations.py
@@ -34,7 +34,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 
 
-def build_poll_with_parameterized_endpoints_request_initial(**kwargs: Any) -> HttpRequest:
+def build_poll_with_parameterized_endpoints_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -48,7 +48,7 @@ def build_poll_with_parameterized_endpoints_request_initial(**kwargs: Any) -> Ht
     return HttpRequest(method="POST", url=_url, headers=_headers, **kwargs)
 
 
-def build_poll_with_constant_parameterized_endpoints_request_initial(**kwargs: Any) -> HttpRequest:
+def build_poll_with_constant_parameterized_endpoints_request(**kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     constant_parameter = kwargs.pop("constant_parameter", "iAmConstant")  # type: str
@@ -78,7 +78,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_parameterized_endpoints_request_initial(
+        request = build_poll_with_parameterized_endpoints_request(
             headers=_headers,
             params=_params,
         )
@@ -192,7 +192,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(MixinABC):
         constant_parameter = kwargs.pop("constant_parameter", "iAmConstant")  # type: str
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_constant_parameterized_endpoints_request_initial(
+        request = build_poll_with_constant_parameterized_endpoints_request(
             constant_parameter=constant_parameter,
             headers=_headers,
             params=_params,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/aio/_operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/aio/_operations/_operations.py
@@ -23,8 +23,8 @@ from azure.core.rest import HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from ..._operations._operations import (
-    build_poll_with_constant_parameterized_endpoints_request_initial,
-    build_poll_with_parameterized_endpoints_request_initial,
+    build_poll_with_constant_parameterized_endpoints_request,
+    build_poll_with_parameterized_endpoints_request,
 )
 from .._vendor import MixinABC
 
@@ -42,7 +42,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_parameterized_endpoints_request_initial(
+        request = build_poll_with_parameterized_endpoints_request(
             headers=_headers,
             params=_params,
         )
@@ -158,7 +158,7 @@ class LROWithParamaterizedEndpointsOperationsMixin(MixinABC):
         constant_parameter = kwargs.pop("constant_parameter", "iAmConstant")  # type: str
         cls = kwargs.pop("cls", None)  # type: ClsType[Optional[str]]
 
-        request = build_poll_with_constant_parameterized_endpoints_request_initial(
+        request = build_poll_with_constant_parameterized_endpoints_request(
             constant_parameter=constant_parameter,
             headers=_headers,
             params=_params,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/aio/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/aio/operations/_operations.py
@@ -33,7 +33,7 @@ from ...operations._operations import (
     build_paging_get_multiple_pages_failure_uri_request,
     build_paging_get_multiple_pages_fragment_next_link_request,
     build_paging_get_multiple_pages_fragment_with_grouping_next_link_request,
-    build_paging_get_multiple_pages_lro_request_initial,
+    build_paging_get_multiple_pages_lro_request,
     build_paging_get_multiple_pages_request,
     build_paging_get_multiple_pages_retry_first_request,
     build_paging_get_multiple_pages_retry_second_request,
@@ -1386,7 +1386,7 @@ class PagingOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_paging_get_multiple_pages_lro_request_initial(
+        request = build_paging_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=maxresults,
             timeout=timeout,
@@ -1457,7 +1457,7 @@ class PagingOperations:
         def prepare_request(next_link=None):
             if not next_link:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,
@@ -1468,7 +1468,7 @@ class PagingOperations:
 
             else:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/operations/_operations.py
@@ -359,7 +359,7 @@ def build_paging_get_multiple_pages_fragment_with_grouping_next_link_request(
     return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_paging_get_multiple_pages_lro_request_initial(
+def build_paging_get_multiple_pages_lro_request(
     *,
     client_request_id: Optional[str] = None,
     maxresults: Optional[int] = None,
@@ -1774,7 +1774,7 @@ class PagingOperations:
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_paging_get_multiple_pages_lro_request_initial(
+        request = build_paging_get_multiple_pages_lro_request(
             client_request_id=client_request_id,
             maxresults=maxresults,
             timeout=timeout,
@@ -1845,7 +1845,7 @@ class PagingOperations:
         def prepare_request(next_link=None):
             if not next_link:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,
@@ -1856,7 +1856,7 @@ class PagingOperations:
 
             else:
 
-                request = build_paging_get_multiple_pages_lro_request_initial(
+                request = build_paging_get_multiple_pages_lro_request(
                     client_request_id=client_request_id,
                     maxresults=maxresults,
                     timeout=timeout,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/aio/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/aio/operations/_operations.py
@@ -29,7 +29,7 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
 from ...operations._operations import (
     build_storage_accounts_check_name_availability_request,
-    build_storage_accounts_create_request_initial,
+    build_storage_accounts_create_request,
     build_storage_accounts_delete_request,
     build_storage_accounts_get_properties_request,
     build_storage_accounts_list_by_resource_group_request,
@@ -166,7 +166,7 @@ class StorageAccountsOperations:
 
         _json = parameters
 
-        request = build_storage_accounts_create_request_initial(
+        request = build_storage_accounts_create_request(
             resource_group_name=resource_group_name,
             account_name=account_name,
             subscription_id=self._config.subscription_id,

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/operations/_operations.py
@@ -71,7 +71,7 @@ def build_storage_accounts_check_name_availability_request(
     return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, json=json, content=content, **kwargs)
 
 
-def build_storage_accounts_create_request_initial(
+def build_storage_accounts_create_request(
     resource_group_name: str,
     account_name: str,
     subscription_id: str,
@@ -454,7 +454,7 @@ class StorageAccountsOperations:
 
         _json = parameters
 
-        request = build_storage_accounts_create_request_initial(
+        request = build_storage_accounts_create_request(
             resource_group_name=resource_group_name,
             account_name=account_name,
             subscription_id=self._config.subscription_id,

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/_operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/_operations/_operations.py
@@ -103,7 +103,7 @@ def build_get_pages_request(mode: str, **kwargs: Any) -> HttpRequest:
     return HttpRequest(method="GET", url=_url, headers=_headers, **kwargs)
 
 
-def build_lro_request_initial(mode: str, **kwargs: Any) -> HttpRequest:
+def build_lro_request(mode: str, **kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -337,7 +337,7 @@ class DPGClientOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lro_request_initial(
+        request = build_lro_request(
             mode=mode,
             headers=_headers,
             params=_params,

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/aio/_operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/aio/_operations/_operations.py
@@ -29,7 +29,7 @@ from azure.core.utils import case_insensitive_dict
 from ..._operations._operations import (
     build_get_model_request,
     build_get_pages_request,
-    build_lro_request_initial,
+    build_lro_request,
     build_post_model_request,
 )
 from .._vendor import MixinABC
@@ -258,7 +258,7 @@ class DPGClientOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lro_request_initial(
+        request = build_lro_request(
             mode=mode,
             headers=_headers,
             params=_params,

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/_operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/_operations/_operations.py
@@ -103,7 +103,7 @@ def build_get_pages_request(mode: str, **kwargs: Any) -> HttpRequest:
     return HttpRequest(method="GET", url=_url, headers=_headers, **kwargs)
 
 
-def build_lro_request_initial(mode: str, **kwargs: Any) -> HttpRequest:
+def build_lro_request(mode: str, **kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -337,7 +337,7 @@ class DPGClientOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lro_request_initial(
+        request = build_lro_request(
             mode=mode,
             headers=_headers,
             params=_params,

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/aio/_operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/aio/_operations/_operations.py
@@ -29,7 +29,7 @@ from azure.core.utils import case_insensitive_dict
 from ..._operations._operations import (
     build_get_model_request,
     build_get_pages_request,
-    build_lro_request_initial,
+    build_lro_request,
     build_post_model_request,
 )
 from .._vendor import MixinABC
@@ -258,7 +258,7 @@ class DPGClientOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[JSON]
 
-        request = build_lro_request_initial(
+        request = build_lro_request(
             mode=mode,
             headers=_headers,
             params=_params,

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/_operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/_operations/_operations.py
@@ -98,7 +98,7 @@ def build_get_pages_request(mode: str, **kwargs: Any) -> HttpRequest:
     return HttpRequest(method="GET", url=_url, headers=_headers, **kwargs)
 
 
-def build_lro_request_initial(mode: str, **kwargs: Any) -> HttpRequest:
+def build_lro_request(mode: str, **kwargs: Any) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
 
     accept = _headers.pop("Accept", "application/json")
@@ -291,7 +291,7 @@ class DPGClientOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.LROProduct]
 
-        request = build_lro_request_initial(
+        request = build_lro_request(
             mode=mode,
             headers=_headers,
             params=_params,

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/aio/_operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/aio/_operations/_operations.py
@@ -29,7 +29,7 @@ from ... import models as _models
 from ..._operations._operations import (
     build_get_model_request,
     build_get_pages_request,
-    build_lro_request_initial,
+    build_lro_request,
     build_post_model_request,
 )
 from .._vendor import MixinABC
@@ -213,7 +213,7 @@ class DPGClientOperationsMixin(MixinABC):
 
         cls = kwargs.pop("cls", None)  # type: ClsType[_models.LROProduct]
 
-        request = build_lro_request_initial(
+        request = build_lro_request(
             mode=mode,
             headers=_headers,
             params=_params,

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/aio/operations/_multiapi_service_client_operations.py
@@ -22,7 +22,7 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request_initial, build_test_lro_request_initial, build_test_one_request
+from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request, build_test_lro_request, build_test_one_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -109,7 +109,7 @@ class MultiapiServiceClientOperationsMixin:
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -237,7 +237,7 @@ class MultiapiServiceClientOperationsMixin:
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -315,7 +315,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -333,7 +333,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/operations/_multiapi_service_client_operations.py
@@ -67,7 +67,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -92,7 +92,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -238,7 +238,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -367,7 +367,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -446,7 +446,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -464,7 +464,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/aio/operations/_multiapi_service_client_operations.py
@@ -22,7 +22,7 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request_initial, build_test_lro_request_initial, build_test_one_request
+from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request, build_test_lro_request, build_test_one_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -109,7 +109,7 @@ class MultiapiServiceClientOperationsMixin:
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -237,7 +237,7 @@ class MultiapiServiceClientOperationsMixin:
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -316,7 +316,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -334,7 +334,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/operations/_multiapi_service_client_operations.py
@@ -67,7 +67,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -92,7 +92,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -238,7 +238,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -367,7 +367,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -447,7 +447,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -465,7 +465,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/aio/operations/_multiapi_service_client_operations.py
@@ -21,7 +21,7 @@ from azure.core.utils import case_insensitive_dict
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request_initial, build_test_lro_request_initial, build_test_one_request
+from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request, build_test_lro_request, build_test_one_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -108,7 +108,7 @@ class MultiapiServiceClientOperationsMixin:
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -236,7 +236,7 @@ class MultiapiServiceClientOperationsMixin:
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -314,7 +314,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -332,7 +332,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/operations/_multiapi_service_client_operations.py
@@ -66,7 +66,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -91,7 +91,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -237,7 +237,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -366,7 +366,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -445,7 +445,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -463,7 +463,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/operations/_multiapi_service_client_operations.py
@@ -67,7 +67,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -92,7 +92,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -238,7 +238,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -367,7 +367,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -446,7 +446,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -464,7 +464,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/v1/aio/operations/_multiapi_service_client_operations.py
@@ -21,7 +21,7 @@ from azure.core.utils import case_insensitive_dict
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request_initial, build_test_lro_request_initial, build_test_one_request
+from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request, build_test_lro_request, build_test_one_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -108,7 +108,7 @@ class MultiapiServiceClientOperationsMixin:
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -236,7 +236,7 @@ class MultiapiServiceClientOperationsMixin:
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -314,7 +314,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -332,7 +332,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/v1/operations/_multiapi_service_client_operations.py
@@ -66,7 +66,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -91,7 +91,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -237,7 +237,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -366,7 +366,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -445,7 +445,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -463,7 +463,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/aio/operations/_multiapi_service_client_operations.py
@@ -22,7 +22,7 @@ from azure.mgmt.core.polling.async_arm_polling import AsyncARMPolling
 
 from ... import models as _models
 from ..._vendor import _convert_request
-from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request_initial, build_test_lro_request_initial, build_test_one_request
+from ...operations._multiapi_service_client_operations import build_test_different_calls_request, build_test_lro_and_paging_request, build_test_lro_request, build_test_one_request
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
 
@@ -109,7 +109,7 @@ class MultiapiServiceClientOperationsMixin:
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -237,7 +237,7 @@ class MultiapiServiceClientOperationsMixin:
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -316,7 +316,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -334,7 +334,7 @@ class MultiapiServiceClientOperationsMixin:
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/operations/_multiapi_service_client_operations.py
@@ -67,7 +67,7 @@ def build_test_one_request(
     )
 
 
-def build_test_lro_request_initial(
+def build_test_lro_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -92,7 +92,7 @@ def build_test_lro_request_initial(
     )
 
 
-def build_test_lro_and_paging_request_initial(
+def build_test_lro_and_paging_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
@@ -238,7 +238,7 @@ class MultiapiServiceClientOperationsMixin(object):
         else:
             _json = None
 
-        request = build_test_lro_request_initial(
+        request = build_test_lro_request(
             content_type=content_type,
             json=_json,
             template_url=self._test_lro_initial.metadata['url'],
@@ -367,7 +367,7 @@ class MultiapiServiceClientOperationsMixin(object):
             _maxresults = test_lro_and_paging_options.maxresults
             _timeout = test_lro_and_paging_options.timeout
 
-        request = build_test_lro_and_paging_request_initial(
+        request = build_test_lro_and_paging_request(
             client_request_id=client_request_id,
             maxresults=_maxresults,
             timeout=_timeout,
@@ -447,7 +447,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,
@@ -465,7 +465,7 @@ class MultiapiServiceClientOperationsMixin(object):
                     _maxresults = test_lro_and_paging_options.maxresults
                     _timeout = test_lro_and_paging_options.timeout
                 
-                request = build_test_lro_and_paging_request_initial(
+                request = build_test_lro_and_paging_request(
                     client_request_id=client_request_id,
                     maxresults=_maxresults,
                     timeout=_timeout,


### PR DESCRIPTION
Currently, we generated request builders for LRO operations with the suffix `_initial`. To clean up code and shorten names, we are removing the `_initial` suffix. This will technically be a breaking change, but since request builders are hidden, it shouldn't have any impact