### PR TITLE
make content_type param required with no default if streaming with no application/octet-stream

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
 **Breaking Changes in Version Tolerant**
 
 - No longer allow users to specify `api_version` on the method level  #1281
+- Make `content_type` param required with no default if streaming with no `application/octet-stream`  #1269
 
 ### 2022-xx-xx - 5.17.1
 

--- a/autorest/codegen/serializers/builder_serializer.py
+++ b/autorest/codegen/serializers/builder_serializer.py
@@ -699,6 +699,15 @@ class _OperationSerializer(
         body_kwarg_name = builder.request_builder.parameters.body_parameter.client_name
         if isinstance(body_param.type, BinaryType):
             retval.append(f"_{body_kwarg_name} = {body_param.client_name}")
+            if not body_param.default_content_type:
+                content_types = "'" + "', '".join(body_param.content_types) + "'"
+                retval.extend(
+                    [
+                        "if not content_type:",
+                        f'    raise TypeError("Missing required keyword-only argument: content_type. '
+                        f'Known values are:" + "{content_types}")',
+                    ]
+                )
         else:
             retval.extend(self._serialize_body_parameter(builder))
         return retval

--- a/autorest/m4reformatter/__init__.py
+++ b/autorest/m4reformatter/__init__.py
@@ -444,7 +444,10 @@ def update_content_type_parameter(
         return yaml_data
     param = copy.deepcopy(yaml_data)
     param["schema"] = KNOWN_TYPES["string"]  # override to string type
-    param["required"] = False
+    if body_parameter["type"]["type"] == "binary" and not body_parameter["defaultContentType"]:
+        param["required"] = True
+    else:
+        param["required"] = False
     description = param["language"]["default"]["description"]
     if description and description[-1] != ".":
         description += "."

--- a/autorest/m4reformatter/__init__.py
+++ b/autorest/m4reformatter/__init__.py
@@ -444,7 +444,10 @@ def update_content_type_parameter(
         return yaml_data
     param = copy.deepcopy(yaml_data)
     param["schema"] = KNOWN_TYPES["string"]  # override to string type
-    if body_parameter["type"]["type"] == "binary" and not body_parameter["defaultContentType"]:
+    if (
+        body_parameter["type"]["type"] == "binary"
+        and not body_parameter["defaultContentType"]
+    ):
         param["required"] = True
     else:
         param["required"] = False

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -119,6 +119,8 @@ class OperationGroupTwoOperations:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -186,6 +186,8 @@ class OperationGroupTwoOperations(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders.py
+++ b/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders.py
@@ -208,12 +208,12 @@ def build_post_parameters_request(
     See https://aka.ms/azsdk/dpcodegen/python/send_request for how to incorporate this request
     builder into your code flow.
 
+    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+     Required.
+    :paramtype content_type: str
     :keyword content: I am a body parameter with a new content type. My only valid JSON entry is {
      url: "http://example.org/myimage.jpeg" }. Required.
     :paramtype content: IO
-    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
-    :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
      incorporate this response into your code flow.

--- a/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders_py3.py
+++ b/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders_py3.py
@@ -203,8 +203,8 @@ def build_post_parameters_request(
 @overload
 def build_post_parameters_request(
     *,
+    content_type: str,
     content: IO,
-    content_type: Optional[str] = None,
     **kwargs: Any
 ) -> HttpRequest:
     """POST a JSON or a JPEG.
@@ -212,12 +212,12 @@ def build_post_parameters_request(
     See https://aka.ms/azsdk/dpcodegen/python/send_request for how to incorporate this request
     builder into your code flow.
 
+    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+     Required.
+    :paramtype content_type: str
     :keyword content: I am a body parameter with a new content type. My only valid JSON entry is {
      url: "http://example.org/myimage.jpeg" }. Required.
     :paramtype content: IO
-    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
-    :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
      incorporate this response into your code flow.

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/aio/operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/aio/operations/_operations.py
@@ -237,14 +237,14 @@ class ParamsOperations:
         """
 
     @overload
-    async def post_parameters(self, parameter: IO, *, content_type: Optional[str] = None, **kwargs: Any) -> JSON:
+    async def post_parameters(self, parameter: IO, *, content_type: str, **kwargs: Any) -> JSON:
         """POST a JSON or a JPEG.
 
         :param parameter: I am a body parameter with a new content type. My only valid JSON entry is {
          url: "http://example.org/myimage.jpeg" }. Required.
         :type parameter: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :return: JSON
         :rtype: JSON
@@ -278,6 +278,10 @@ class ParamsOperations:
         _content = None
         if isinstance(parameter, (IO, bytes)):
             _content = parameter
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:" + "'image/jpeg'"
+                )
         else:
             _json = parameter
             content_type = content_type or "application/json"

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/operations/_operations.py
@@ -358,14 +358,14 @@ class ParamsOperations:
         """
 
     @overload
-    def post_parameters(self, parameter: IO, *, content_type: Optional[str] = None, **kwargs: Any) -> JSON:
+    def post_parameters(self, parameter: IO, *, content_type: str, **kwargs: Any) -> JSON:
         """POST a JSON or a JPEG.
 
         :param parameter: I am a body parameter with a new content type. My only valid JSON entry is {
          url: "http://example.org/myimage.jpeg" }. Required.
         :type parameter: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :return: JSON
         :rtype: JSON
@@ -399,6 +399,10 @@ class ParamsOperations:
         _content = None
         if isinstance(parameter, (IO, bytes)):
             _content = parameter
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:" + "'image/jpeg'"
+                )
         else:
             _json = parameter
             content_type = content_type or "application/json"

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -119,6 +119,8 @@ class OperationGroupTwoOperations:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -186,6 +186,8 @@ class OperationGroupTwoOperations(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -119,6 +119,8 @@ class OperationGroupTwoOperations:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -186,6 +186,8 @@ class OperationGroupTwoOperations(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
@@ -67,7 +67,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -75,7 +75,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -118,6 +118,8 @@ class OperationGroupTwoOperations:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
@@ -141,7 +141,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -185,6 +185,8 @@ class OperationGroupTwoOperations(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -186,6 +186,8 @@ class OperationGroupTwoOperations(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,7 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -119,6 +119,8 @@ class OperationGroupTwoOperations:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,7 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -186,6 +186,8 @@ class OperationGroupTwoOperations(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError("Missing required keyword-only argument: content_type. Known values are:" + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'")
         else:
             if input is not None:
                 _json = self._serialize.body(input, 'SourcePath')

--- a/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
+++ b/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
@@ -55,15 +55,13 @@ class MediaTypesClientOperationsMixin:
         """
 
     @overload
-    async def analyze_body(
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
-    ) -> str:
+    async def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
@@ -98,6 +96,11 @@ class MediaTypesClientOperationsMixin:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = self._serialize.body(input, "SourcePath")
@@ -155,7 +158,7 @@ class MediaTypesClientOperationsMixin:
 
     @overload
     async def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -163,7 +166,7 @@ class MediaTypesClientOperationsMixin:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -201,6 +204,11 @@ class MediaTypesClientOperationsMixin:
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = self._serialize.body(input, "SourcePath")

--- a/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -217,7 +217,7 @@ class MediaTypesClientOperationsMixin(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
@@ -257,6 +257,11 @@ class MediaTypesClientOperationsMixin(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = self._serialize.body(input, "SourcePath")
@@ -328,7 +333,7 @@ class MediaTypesClientOperationsMixin(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)
@@ -369,6 +374,11 @@ class MediaTypesClientOperationsMixin(object):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = self._serialize.body(input, "SourcePath")

--- a/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders.py
+++ b/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders.py
@@ -65,7 +65,7 @@ def build_analyze_body_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO
@@ -160,7 +160,7 @@ def build_analyze_body_no_accept_header_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO

--- a/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders_py3.py
+++ b/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders_py3.py
@@ -59,7 +59,7 @@ def build_analyze_body_request(
 @overload
 def build_analyze_body_request(
     *,
-    content_type: Optional[str] = None,
+    content_type: str,
     content: Optional[IO] = None,
     **kwargs: Any
 ) -> HttpRequest:
@@ -69,7 +69,7 @@ def build_analyze_body_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO
@@ -156,7 +156,7 @@ def build_analyze_body_no_accept_header_request(
 @overload
 def build_analyze_body_no_accept_header_request(
     *,
-    content_type: Optional[str] = None,
+    content_type: str,
     content: Optional[IO] = None,
     **kwargs: Any
 ) -> HttpRequest:
@@ -167,7 +167,7 @@ def build_analyze_body_no_accept_header_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO

--- a/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_operations/_operations.py
+++ b/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_operations/_operations.py
@@ -163,13 +163,13 @@ class MediaTypesClientOperationsMixin(MixinABC):
         """
 
     @overload
-    def analyze_body(self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any) -> str:
+    def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :return: str
         :rtype: str
@@ -202,6 +202,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input
@@ -265,7 +270,7 @@ class MediaTypesClientOperationsMixin(MixinABC):
 
     @overload
     def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -273,7 +278,7 @@ class MediaTypesClientOperationsMixin(MixinABC):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :return: None
         :rtype: None
@@ -309,6 +314,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input

--- a/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/aio/_operations/_operations.py
+++ b/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/aio/_operations/_operations.py
@@ -67,15 +67,13 @@ class MediaTypesClientOperationsMixin(MixinABC):
         """
 
     @overload
-    async def analyze_body(
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
-    ) -> str:
+    async def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :return: str
         :rtype: str
@@ -108,6 +106,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input
@@ -171,7 +174,7 @@ class MediaTypesClientOperationsMixin(MixinABC):
 
     @overload
     async def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -179,7 +182,7 @@ class MediaTypesClientOperationsMixin(MixinABC):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Required.
         :paramtype content_type: str
         :return: None
         :rtype: None
@@ -215,6 +218,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input


### PR DESCRIPTION
fix https://github.com/Azure/autorest.python/issues/1262