### PR TITLE
make `content_type` param required with no default if streaming with no `application/octet-stream`(updated)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
 **Breaking Changes in Version Tolerant**
 
 - No longer allow users to specify `api_version` on the method level  #1281
+- Make `content_type` param required with no default if streaming with no `application/octet-stream`
 
 ### 2022-xx-xx - 5.17.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@
 **Breaking Changes in Version Tolerant**
 
 - No longer allow users to specify `api_version` on the method level  #1281
-- Make `content_type` param required with no default if streaming with no `application/octet-stream`
+- Make `content_type` param required with no default if streaming with no `application/octet-stream`  #1288
 
 ### 2022-xx-xx - 5.17.1
 

--- a/autorest/codegen/serializers/builder_serializer.py
+++ b/autorest/codegen/serializers/builder_serializer.py
@@ -701,7 +701,9 @@ class _OperationSerializer(
             retval.append(f"_{body_kwarg_name} = {body_param.client_name}")
             if (
                 not body_param.default_content_type
-                and builder.code_model.options["version_tolerant"]
+                and not next(
+                    p for p in builder.parameters if p.rest_api_name == "Content-Type"
+                ).optional
             ):
                 content_types = "'" + "', '".join(body_param.content_types) + "'"
                 retval.extend(

--- a/autorest/codegen/serializers/builder_serializer.py
+++ b/autorest/codegen/serializers/builder_serializer.py
@@ -699,6 +699,18 @@ class _OperationSerializer(
         body_kwarg_name = builder.request_builder.parameters.body_parameter.client_name
         if isinstance(body_param.type, BinaryType):
             retval.append(f"_{body_kwarg_name} = {body_param.client_name}")
+            if (
+                not body_param.default_content_type
+                and builder.code_model.options["version_tolerant"]
+            ):
+                content_types = "'" + "', '".join(body_param.content_types) + "'"
+                retval.extend(
+                    [
+                        "if not content_type:",
+                        f'    raise TypeError("Missing required keyword-only argument: content_type. '
+                        f'Known values are:" + "{content_types}")',
+                    ]
+                )
         else:
             retval.extend(self._serialize_body_parameter(builder))
         return retval

--- a/autorest/m4reformatter/__init__.py
+++ b/autorest/m4reformatter/__init__.py
@@ -431,47 +431,6 @@ def update_client_url(yaml_data: Dict[str, Any]) -> str:
     ]["uri"]
 
 
-def update_content_type_parameter(
-    yaml_data: Dict[str, Any],
-    body_parameter: Optional[Dict[str, Any]],
-    request_media_types: List[str],
-    *,
-    in_overload: bool = False,
-    in_overriden: bool = False,
-) -> Dict[str, Any]:
-    # override content type type to string
-    if not body_parameter:
-        return yaml_data
-    param = copy.deepcopy(yaml_data)
-    param["schema"] = KNOWN_TYPES["string"]  # override to string type
-    if (
-        body_parameter["type"]["type"] == "binary"
-        and not body_parameter["defaultContentType"]
-    ):
-        param["required"] = True
-    else:
-        param["required"] = False
-    description = param["language"]["default"]["description"]
-    if description and description[-1] != ".":
-        description += "."
-    if not (in_overriden or in_overload):
-        param["inDocstring"] = False
-    elif in_overload:
-        description += (
-            " Content type parameter for "
-            f"{get_body_type_for_description(body_parameter)} body."
-        )
-    if not in_overload or (
-        body_parameter["type"]["type"] == "binary" and len(request_media_types) > 1
-    ):
-        content_types = "'" + "', '".join(request_media_types) + "'"
-        description += f" Known values are: {content_types}."
-    if not in_overload and not in_overriden:
-        param["clientDefaultValue"] = body_parameter["defaultContentType"]
-    param["language"]["default"]["description"] = description
-    return param
-
-
 class M4Reformatter(YamlUpdatePlugin):  # pylint: disable=too-many-public-methods
     """Add Python naming information."""
 
@@ -486,6 +445,10 @@ class M4Reformatter(YamlUpdatePlugin):  # pylint: disable=too-many-public-method
     @property
     def low_level_client(self) -> bool:
         return bool(self._autorestapi.get_boolean_value("low-level-client"))
+
+    @property
+    def legacy(self) -> bool:
+        return not (self.version_tolerant or self.low_level_client)
 
     @property
     def default_optional_constants_to_none(self) -> bool:
@@ -790,6 +753,48 @@ class M4Reformatter(YamlUpdatePlugin):  # pylint: disable=too-many-public-method
         param["inFlattenedBody"] = True
         return param
 
+    def _update_content_type_parameter(
+        self,
+        yaml_data: Dict[str, Any],
+        body_parameter: Optional[Dict[str, Any]],
+        request_media_types: List[str],
+        *,
+        in_overload: bool = False,
+        in_overriden: bool = False,
+    ) -> Dict[str, Any]:
+        # override content type type to string
+        if not body_parameter:
+            return yaml_data
+        param = copy.deepcopy(yaml_data)
+        param["schema"] = KNOWN_TYPES["string"]  # override to string type
+        if (
+            body_parameter["type"]["type"] == "binary"
+            and not body_parameter["defaultContentType"]
+            and not self.legacy
+        ):
+            param["required"] = True
+        else:
+            param["required"] = False
+        description = param["language"]["default"]["description"]
+        if description and description[-1] != ".":
+            description += "."
+        if not (in_overriden or in_overload):
+            param["inDocstring"] = False
+        elif in_overload:
+            description += (
+                " Content type parameter for "
+                f"{get_body_type_for_description(body_parameter)} body."
+            )
+        if not in_overload or (
+            body_parameter["type"]["type"] == "binary" and len(request_media_types) > 1
+        ):
+            content_types = "'" + "', '".join(request_media_types) + "'"
+            description += f" Known values are: {content_types}."
+        if not in_overload and not in_overriden:
+            param["clientDefaultValue"] = body_parameter["defaultContentType"]
+        param["language"]["default"]["description"] = description
+        return param
+
     def _update_parameters_helper(
         self,
         parameters: List[Dict[str, Any]],
@@ -811,7 +816,7 @@ class M4Reformatter(YamlUpdatePlugin):  # pylint: disable=too-many-public-method
                 continue
             if param.get("origin") == "modelerfour:synthesized/api-version":
                 param["inDocstring"] = False
-                if not (self.version_tolerant or self.low_level_client):
+                if self.legacy:
                     param["implementation"] = "Method"
                     param["checkClientInput"] = True
             if has_flattened_body and param.get("targetProperty"):
@@ -827,7 +832,7 @@ class M4Reformatter(YamlUpdatePlugin):  # pylint: disable=too-many-public-method
             if is_body(param):
                 continue
             if serialized_name == "Content-Type":
-                param = update_content_type_parameter(
+                param = self._update_content_type_parameter(
                     param,
                     body_parameter,
                     request_media_types,
@@ -942,11 +947,7 @@ class M4Reformatter(YamlUpdatePlugin):  # pylint: disable=too-many-public-method
             if name == "$host":
                 # I am the non-parameterized endpoint. Modify name based off of flag
 
-                client_name = (
-                    "endpoint"
-                    if (self.version_tolerant or self.low_level_client)
-                    else "base_url"
-                )
+                client_name = "base_url" if self.legacy else "endpoint"
                 global_parameter["language"]["default"]["description"] = "Service URL."
             global_params.append(
                 self.update_parameter(

--- a/autorest/m4reformatter/__init__.py
+++ b/autorest/m4reformatter/__init__.py
@@ -461,8 +461,9 @@ def update_content_type_parameter(
             " Content type parameter for "
             f"{get_body_type_for_description(body_parameter)} body."
         )
-    content_types = "'" + "', '".join(request_media_types) + "'"
-    description += f" Known values are: {content_types}."
+    if not in_overload or body_parameter["type"]["type"] == "binary":
+        content_types = "'" + "', '".join(request_media_types) + "'"
+        description += f" Known values are: {content_types}."
     if not in_overload and not in_overriden:
         param["clientDefaultValue"] = body_parameter["defaultContentType"]
     param["language"]["default"]["description"] = description

--- a/autorest/m4reformatter/__init__.py
+++ b/autorest/m4reformatter/__init__.py
@@ -461,7 +461,9 @@ def update_content_type_parameter(
             " Content type parameter for "
             f"{get_body_type_for_description(body_parameter)} body."
         )
-    if not in_overload or body_parameter["type"]["type"] == "binary":
+    if not in_overload or (
+        body_parameter["type"]["type"] == "binary" and len(request_media_types) > 1
+    ):
         content_types = "'" + "', '".join(request_media_types) + "'"
         description += f" Known values are: {content_types}."
     if not in_overload and not in_overriden:

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: str,
+        content_type: Optional[str] = None,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -77,7 +77,7 @@ class OperationGroupTwoOperations:
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,8 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,8 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
+++ b/docs/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
@@ -143,7 +143,7 @@ class OperationGroupTwoOperations(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/aio/operations/_storage_accounts_operations.py
@@ -97,7 +97,7 @@ class StorageAccountsOperations:
          lower-case letters only. Required.
         :type account_name: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: CheckNameAvailabilityResult or the result of cls(response)
@@ -300,7 +300,7 @@ class StorageAccountsOperations:
         :param parameters: The parameters to provide for the created account. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :keyword str continuation_token: A continuation token to restart a poller from a saved state.
@@ -581,7 +581,7 @@ class StorageAccountsOperations:
          changed at a time using this API. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: StorageAccount or the result of cls(response)

--- a/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
+++ b/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/operations/_storage_accounts_operations.py
@@ -433,7 +433,7 @@ class StorageAccountsOperations(object):
          lower-case letters only. Required.
         :type account_name: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: CheckNameAvailabilityResult or the result of cls(response)
@@ -638,7 +638,7 @@ class StorageAccountsOperations(object):
         :param parameters: The parameters to provide for the created account. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :keyword str continuation_token: A continuation token to restart a poller from a saved state.
@@ -926,7 +926,7 @@ class StorageAccountsOperations(object):
          changed at a time using this API. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: StorageAccount or the result of cls(response)

--- a/test/azure/low-level/Expected/AcceptanceTests/StorageManagementClientLowLevel/storagelowlevel/rest/storage_accounts/_request_builders.py
+++ b/test/azure/low-level/Expected/AcceptanceTests/StorageManagementClientLowLevel/storagelowlevel/rest/storage_accounts/_request_builders.py
@@ -83,7 +83,7 @@ def build_check_name_availability_request(
      letters only. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
@@ -236,7 +236,7 @@ def build_create_request(
     :keyword content: The parameters to provide for the created account. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
@@ -532,7 +532,7 @@ def build_update_request(
      changed at a time using this API. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
@@ -844,7 +844,7 @@ def build_regenerate_key_request(
     :keyword content: Specifies name of the key which should be regenerated. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to

--- a/test/azure/low-level/Expected/AcceptanceTests/StorageManagementClientLowLevel/storagelowlevel/rest/storage_accounts/_request_builders_py3.py
+++ b/test/azure/low-level/Expected/AcceptanceTests/StorageManagementClientLowLevel/storagelowlevel/rest/storage_accounts/_request_builders_py3.py
@@ -87,7 +87,7 @@ def build_check_name_availability_request(
      letters only. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
@@ -243,7 +243,7 @@ def build_create_request(
     :keyword content: The parameters to provide for the created account. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
@@ -540,7 +540,7 @@ def build_update_request(
      changed at a time using this API. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
@@ -852,7 +852,7 @@ def build_regenerate_key_request(
     :keyword content: Specifies name of the key which should be regenerated. Required.
     :paramtype content: IO
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'text/json'. Default value is None.
     :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/aio/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/aio/operations/_operations.py
@@ -117,7 +117,7 @@ class StorageAccountsOperations:
          lower-case letters only. Required.
         :type account_name: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :return: JSON object
         :rtype: JSON
@@ -422,7 +422,7 @@ class StorageAccountsOperations:
         :param parameters: The parameters to provide for the created account. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword str continuation_token: A continuation token to restart a poller from a saved state.
         :keyword polling: By default, your polling method will be AsyncARMPolling. Pass in False for
@@ -988,7 +988,7 @@ class StorageAccountsOperations:
          changed at a time using this API. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :return: JSON object
         :rtype: JSON
@@ -1608,7 +1608,7 @@ class StorageAccountsOperations:
         :param regenerate_key: Specifies name of the key which should be regenerated. Required.
         :type regenerate_key: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :return: JSON object
         :rtype: JSON

--- a/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/operations/_operations.py
+++ b/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/operations/_operations.py
@@ -385,7 +385,7 @@ class StorageAccountsOperations:
          lower-case letters only. Required.
         :type account_name: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :return: JSON object
         :rtype: JSON
@@ -690,7 +690,7 @@ class StorageAccountsOperations:
         :param parameters: The parameters to provide for the created account. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :keyword str continuation_token: A continuation token to restart a poller from a saved state.
         :keyword polling: By default, your polling method will be ARMPolling. Pass in False for this
@@ -1256,7 +1256,7 @@ class StorageAccountsOperations:
          changed at a time using this API. Required.
         :type parameters: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :return: JSON object
         :rtype: JSON
@@ -1874,7 +1874,7 @@ class StorageAccountsOperations:
         :param regenerate_key: Specifies name of the key which should be regenerated. Required.
         :type regenerate_key: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
+         Known values are: 'application/json', 'text/json'. Default value is "application/json".
         :paramtype content_type: str
         :return: JSON object
         :rtype: JSON

--- a/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders.py
+++ b/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders.py
@@ -208,12 +208,12 @@ def build_post_parameters_request(
     See https://aka.ms/azsdk/dpcodegen/python/send_request for how to incorporate this request
     builder into your code flow.
 
+    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+     Known values are: 'application/json', 'image/jpeg'. Required.
+    :paramtype content_type: str
     :keyword content: I am a body parameter with a new content type. My only valid JSON entry is {
      url: "http://example.org/myimage.jpeg" }. Required.
     :paramtype content: IO
-    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
-    :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
      incorporate this response into your code flow.

--- a/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders_py3.py
+++ b/test/dpg/low-level/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneLowLevel/dpgservicedrivenupdateonelowlevel/rest/params/_request_builders_py3.py
@@ -203,8 +203,8 @@ def build_post_parameters_request(
 @overload
 def build_post_parameters_request(
     *,
+    content_type: str,
     content: IO,
-    content_type: Optional[str] = None,
     **kwargs: Any
 ) -> HttpRequest:
     """POST a JSON or a JPEG.
@@ -212,12 +212,12 @@ def build_post_parameters_request(
     See https://aka.ms/azsdk/dpcodegen/python/send_request for how to incorporate this request
     builder into your code flow.
 
+    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+     Known values are: 'application/json', 'image/jpeg'. Required.
+    :paramtype content_type: str
     :keyword content: I am a body parameter with a new content type. My only valid JSON entry is {
      url: "http://example.org/myimage.jpeg" }. Required.
     :paramtype content: IO
-    :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
-    :paramtype content_type: str
     :return: Returns an :class:`~azure.core.rest.HttpRequest` that you will pass to the client's
      `send_request` method. See https://aka.ms/azsdk/dpcodegen/python/send_request for how to
      incorporate this response into your code flow.

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/aio/operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/aio/operations/_operations.py
@@ -237,14 +237,14 @@ class ParamsOperations:
         """
 
     @overload
-    async def post_parameters(self, parameter: IO, *, content_type: Optional[str] = None, **kwargs: Any) -> JSON:
+    async def post_parameters(self, parameter: IO, *, content_type: str, **kwargs: Any) -> JSON:
         """POST a JSON or a JPEG.
 
         :param parameter: I am a body parameter with a new content type. My only valid JSON entry is {
          url: "http://example.org/myimage.jpeg" }. Required.
         :type parameter: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'image/jpeg'. Required.
         :paramtype content_type: str
         :return: JSON
         :rtype: JSON
@@ -278,6 +278,11 @@ class ParamsOperations:
         _content = None
         if isinstance(parameter, (IO, bytes)):
             _content = parameter
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/json', 'image/jpeg'"
+                )
         else:
             _json = parameter
             content_type = content_type or "application/json"

--- a/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/operations/_operations.py
+++ b/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/operations/_operations.py
@@ -358,14 +358,14 @@ class ParamsOperations:
         """
 
     @overload
-    def post_parameters(self, parameter: IO, *, content_type: Optional[str] = None, **kwargs: Any) -> JSON:
+    def post_parameters(self, parameter: IO, *, content_type: str, **kwargs: Any) -> JSON:
         """POST a JSON or a JPEG.
 
         :param parameter: I am a body parameter with a new content type. My only valid JSON entry is {
          url: "http://example.org/myimage.jpeg" }. Required.
         :type parameter: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'image/jpeg'. Required.
         :paramtype content_type: str
         :return: JSON
         :rtype: JSON
@@ -399,6 +399,11 @@ class ParamsOperations:
         _content = None
         if isinstance(parameter, (IO, bytes)):
             _content = parameter
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/json', 'image/jpeg'"
+                )
         else:
             _json = parameter
             content_type = content_type or "application/json"

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: str,
+        content_type: Optional[str] = None,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -77,7 +77,7 @@ class OperationGroupTwoOperations:
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,8 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,8 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/operations/_operation_group_two_operations.py
@@ -143,7 +143,7 @@ class OperationGroupTwoOperations(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: str,
+        content_type: Optional[str] = None,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -77,7 +77,7 @@ class OperationGroupTwoOperations:
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,8 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,8 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/operations/_operation_group_two_operations.py
@@ -143,7 +143,7 @@ class OperationGroupTwoOperations(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
@@ -67,7 +67,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: str,
+        content_type: Optional[str] = None,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,7 @@ class OperationGroupTwoOperations:
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/aio/operations/_operation_group_two_operations.py
@@ -67,7 +67,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -75,7 +75,8 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,7 @@ class OperationGroupTwoOperations(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/operations/_operation_group_two_operations.py
@@ -141,7 +141,8 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,8 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/operations/_operation_group_two_operations.py
@@ -143,7 +143,7 @@ class OperationGroupTwoOperations(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: str,
+        content_type: Optional[str] = None,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -77,7 +77,7 @@ class OperationGroupTwoOperations:
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/aio/operations/_operation_group_two_operations.py
@@ -68,7 +68,7 @@ class OperationGroupTwoOperations:
         self,
         input: Optional[IO] = None,
         *,
-        content_type: Optional[str] = None,
+        content_type: str,
         **kwargs: Any
     ) -> None:
         """TestFour should be in OperationGroupTwoOperations.
@@ -76,7 +76,8 @@ class OperationGroupTwoOperations:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -142,7 +142,8 @@ class OperationGroupTwoOperations(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
+++ b/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/operations/_operation_group_two_operations.py
@@ -143,7 +143,7 @@ class OperationGroupTwoOperations(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
+++ b/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
@@ -55,15 +55,14 @@ class MediaTypesClientOperationsMixin:
         """
 
     @overload
-    async def analyze_body(
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
-    ) -> str:
+    async def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
@@ -155,7 +154,7 @@ class MediaTypesClientOperationsMixin:
 
     @overload
     async def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -163,7 +162,8 @@ class MediaTypesClientOperationsMixin:
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
+++ b/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/aio/operations/_media_types_client_operations.py
@@ -55,14 +55,16 @@ class MediaTypesClientOperationsMixin:
         """
 
     @overload
-    async def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
+    async def analyze_body(
+        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+    ) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
@@ -154,7 +156,7 @@ class MediaTypesClientOperationsMixin:
 
     @overload
     async def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -163,7 +165,7 @@ class MediaTypesClientOperationsMixin:
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -218,7 +218,7 @@ class MediaTypesClientOperationsMixin(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
@@ -330,7 +330,7 @@ class MediaTypesClientOperationsMixin(object):
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
-         'image/tiff'. Required.
+         'image/tiff'. Default value is None.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
+++ b/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/operations/_media_types_client_operations.py
@@ -217,7 +217,8 @@ class MediaTypesClientOperationsMixin(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: str or the result of cls(response)
@@ -328,7 +329,8 @@ class MediaTypesClientOperationsMixin(object):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :keyword callable cls: A custom type or function that will be passed the direct response
         :return: None or the result of cls(response)

--- a/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders.py
+++ b/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders.py
@@ -65,7 +65,8 @@ def build_analyze_body_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+     'image/tiff'. Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO
@@ -160,7 +161,8 @@ def build_analyze_body_no_accept_header_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+     'image/tiff'. Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO

--- a/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders_py3.py
+++ b/test/vanilla/low-level/Expected/AcceptanceTests/MediaTypesLowLevel/mediatypeslowlevel/rest/_request_builders_py3.py
@@ -59,7 +59,7 @@ def build_analyze_body_request(
 @overload
 def build_analyze_body_request(
     *,
-    content_type: Optional[str] = None,
+    content_type: str,
     content: Optional[IO] = None,
     **kwargs: Any
 ) -> HttpRequest:
@@ -69,7 +69,8 @@ def build_analyze_body_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+     'image/tiff'. Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO
@@ -156,7 +157,7 @@ def build_analyze_body_no_accept_header_request(
 @overload
 def build_analyze_body_no_accept_header_request(
     *,
-    content_type: Optional[str] = None,
+    content_type: str,
     content: Optional[IO] = None,
     **kwargs: Any
 ) -> HttpRequest:
@@ -167,7 +168,8 @@ def build_analyze_body_no_accept_header_request(
     builder into your code flow.
 
     :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-     Default value is None.
+     Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+     'image/tiff'. Required.
     :paramtype content_type: str
     :keyword content: Input parameter. Default value is None.
     :paramtype content: IO

--- a/test/vanilla/version-tolerant/AcceptanceTests/asynctests/test_media_types.py
+++ b/test/vanilla/version-tolerant/AcceptanceTests/asynctests/test_media_types.py
@@ -40,6 +40,8 @@ async def client():
 async def test_pdf(client):
     result = await client.analyze_body(input=b"PDF", content_type="application/pdf")
     assert result == "Nice job with PDF"
+    with pytest.raises(TypeError):
+        await client.analyze_body(input=b"PDF")
 
 @pytest.mark.asyncio
 async def test_json(client):

--- a/test/vanilla/version-tolerant/AcceptanceTests/test_media_types.py
+++ b/test/vanilla/version-tolerant/AcceptanceTests/test_media_types.py
@@ -36,6 +36,8 @@ def client():
 def test_pdf(client):
     result = client.analyze_body(input=b"PDF", content_type="application/pdf")
     assert result == "Nice job with PDF"
+    with pytest.raises(TypeError):
+        client.analyze_body(input=b"PDF")
 
 def test_json(client):
     json_input = json.loads('{"source":"foo"}')

--- a/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_operations/_operations.py
+++ b/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_operations/_operations.py
@@ -163,13 +163,14 @@ class MediaTypesClientOperationsMixin(MixinABC):
         """
 
     @overload
-    def analyze_body(self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any) -> str:
+    def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :return: str
         :rtype: str
@@ -202,6 +203,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/json', 'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input
@@ -265,7 +271,7 @@ class MediaTypesClientOperationsMixin(MixinABC):
 
     @overload
     def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -273,7 +279,8 @@ class MediaTypesClientOperationsMixin(MixinABC):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :return: None
         :rtype: None
@@ -309,6 +316,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/json', 'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input

--- a/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/aio/_operations/_operations.py
+++ b/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/aio/_operations/_operations.py
@@ -67,15 +67,14 @@ class MediaTypesClientOperationsMixin(MixinABC):
         """
 
     @overload
-    async def analyze_body(
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
-    ) -> str:
+    async def analyze_body(self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any) -> str:
         """Analyze body, that could be different media types.
 
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :return: str
         :rtype: str
@@ -108,6 +107,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/json', 'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input
@@ -171,7 +175,7 @@ class MediaTypesClientOperationsMixin(MixinABC):
 
     @overload
     async def analyze_body_no_accept_header(  # pylint: disable=inconsistent-return-statements
-        self, input: Optional[IO] = None, *, content_type: Optional[str] = None, **kwargs: Any
+        self, input: Optional[IO] = None, *, content_type: str, **kwargs: Any
     ) -> None:
         """Analyze body, that could be different media types. Adds to AnalyzeBody by not having an accept
         type.
@@ -179,7 +183,8 @@ class MediaTypesClientOperationsMixin(MixinABC):
         :param input: Input parameter. Default value is None.
         :type input: IO
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is None.
+         Known values are: 'application/json', 'application/pdf', 'image/jpeg', 'image/png',
+         'image/tiff'. Required.
         :paramtype content_type: str
         :return: None
         :rtype: None
@@ -215,6 +220,11 @@ class MediaTypesClientOperationsMixin(MixinABC):
         _content = None
         if isinstance(input, (IO, bytes)):
             _content = input
+            if not content_type:
+                raise TypeError(
+                    "Missing required keyword-only argument: content_type. Known values are:"
+                    + "'application/json', 'application/pdf', 'image/jpeg', 'image/png', 'image/tiff'"
+                )
         else:
             if input is not None:
                 _json = input


### PR DESCRIPTION
fix: https://github.com/Azure/autorest.python/issues/1262, https://github.com/Azure/autorest.python/issues/1287