### PR TITLE
add cadlflags plugin

### DIFF
--- a/packages/autorest.python/autorest/black/__init__.py
+++ b/packages/autorest.python/autorest/black/__init__.py
@@ -33,11 +33,7 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
         list(
             map(
                 self.format_file,
-                [
-                    f
-                    for f in self.output_folder.glob("**/*")
-                    if f.is_file() and f.suffix == ".py"
-                ],
+                [f for f in self.output_folder.glob("**/*") if f.is_file()],
             )
         )
         return True
@@ -45,6 +41,9 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
     def format_file(self, full_path) -> None:
         file = full_path.relative_to(self.output_folder)
         file_content = self.read_file(file)
+        if not file.suffix == ".py":
+            self.write_file(file, file_content)
+            return
         try:
             file_content = black.format_file_contents(
                 file_content, fast=True, mode=_BLACK_MODE

--- a/packages/autorest.python/autorest/black/__init__.py
+++ b/packages/autorest.python/autorest/black/__init__.py
@@ -33,7 +33,11 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
         list(
             map(
                 self.format_file,
-                [f for f in self.output_folder.glob("**/*") if f.is_file()],
+                [
+                    f
+                    for f in self.output_folder.glob("**/*")
+                    if f.is_file() and f.suffix == ".py"
+                ],
             )
         )
         return True
@@ -41,9 +45,6 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
     def format_file(self, full_path) -> None:
         file = full_path.relative_to(self.output_folder)
         file_content = self.read_file(file)
-        if not file.suffix == ".py":
-            self.write_file(file, file_content)
-            return
         try:
             file_content = black.format_file_contents(
                 file_content, fast=True, mode=_BLACK_MODE

--- a/packages/autorest.python/autorest/cadlflags/__init__.py
+++ b/packages/autorest.python/autorest/cadlflags/__init__.py
@@ -1,0 +1,126 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import logging
+from typing import Any, Dict, List
+from .. import YamlUpdatePlugin
+from .._utils import parse_args
+
+_LOGGER = logging.getLogger(__name__)
+
+OAUTH_TYPE = "OAuth2"
+KEY_TYPE = "Key"
+
+
+def get_azure_key_credential(key: str) -> Dict[str, Any]:
+    return {
+        "type": KEY_TYPE,
+        "policy": {"type": "AzureKeyCredentialPolicy", "key": key},
+    }
+
+
+class CadlFlags(YamlUpdatePlugin):  # pylint: disable=abstract-method
+    """A plugin to apply flags from backdoor python.json into cadl yaml file"""
+
+    def update_yaml(self, yaml_data: Dict[str, Any]) -> None:
+        """Convert in place the YAML str."""
+        if self.options.get("add-credential"):
+            self.update_credential(yaml_data)
+        if self.options.get("namespace"):
+            yaml_data["client"]["namespace"] = self.options["namespace"]
+
+    def get_credential_scopes_from_flags(self, auth_policy: str) -> List[str]:
+        if self.options.get("azure-arm"):
+            return ["https://management.azure.com/.default"]
+        credential_scopes_temp = self.options.get("credential-scopes")
+        credential_scopes = (
+            credential_scopes_temp.split(",") if credential_scopes_temp else None
+        )
+        if self.options.get("credential-scopes", False) and not credential_scopes:
+            raise ValueError(
+                "--credential-scopes takes a list of scopes in comma separated format. "
+                "For example: --credential-scopes=https://cognitiveservices.azure.com/.default"
+            )
+        if not credential_scopes:
+            _LOGGER.warning(
+                "You have default credential policy %s "
+                "but not the --credential-scopes flag set while generating non-management plane code. "
+                "This is not recommend because it forces the customer to pass credential scopes "
+                "through kwargs if they want to authenticate.",
+                auth_policy,
+            )
+            credential_scopes = []
+        return credential_scopes
+
+    def get_token_credential(self, credential_scopes: List[str]) -> Dict[str, Any]:
+        return {
+            "type": OAUTH_TYPE,
+            "policy": {
+                "type": "ARMChallengeAuthenticationPolicy"
+                if self.options.get("azure-arm")
+                else "BearerTokenCredentialPolicy",
+                "credentialScopes": credential_scopes,
+            },
+        }
+
+    def update_credential_from_flags(self) -> Dict[str, Any]:
+        default_auth_policy = (
+            "ARMChallengeAuthenticationPolicy"
+            if self.options.get("azure-arm")
+            else "BearerTokenCredentialPolicy"
+        )
+        auth_policy = (
+            self.options.get("credential-default-policy-type") or default_auth_policy
+        )
+        credential_scopes = self.get_credential_scopes_from_flags(auth_policy)
+        key = self.options.get("credential-key-header-name")
+        if auth_policy.lower() in (
+            "armchallengeauthenticationpolicy",
+            "bearertokencredentialpolicy",
+        ):
+            if key:
+                raise ValueError(
+                    "You have passed in a credential key header name with default credential policy type "
+                    f"{auth_policy}. This is not allowed, since credential key header "
+                    "name is tied with AzureKeyCredentialPolicy. Instead, with this policy it is recommend you "
+                    "pass in --credential-scopes."
+                )
+            return self.get_token_credential(credential_scopes)
+        # Otherwise you have AzureKeyCredentialPolicy
+        if self.options.get("credential-scopes"):
+            raise ValueError(
+                "You have passed in credential scopes with default credential policy type "
+                "AzureKeyCredentialPolicy. This is not allowed, since credential scopes is tied with "
+                f"{default_auth_policy}. Instead, with this policy "
+                "you must pass in --credential-key-header-name."
+            )
+        if not key:
+            key = "api-key"
+            _LOGGER.info(
+                "Defaulting the AzureKeyCredentialPolicy header's name to 'api-key'"
+            )
+        return get_azure_key_credential(key)
+
+    def update_credential(self, yaml_data: Dict[str, Any]) -> None:
+        credential_type = self.update_credential_from_flags()
+        yaml_data["types"].append(credential_type)
+        credential = {
+            "type": credential_type,
+            "optional": False,
+            "description": "Credential needed for the client to connect to Azure.",
+            "clientName": "credential",
+            "location": "other",
+            "restApiName": "credential",
+            "implementation": "Client",
+            "skipUrlEncoding": True,
+            "inOverload": False,
+        }
+        yaml_data["client"]["parameters"].append(credential)
+
+
+if __name__ == "__main__":
+    # CADL pipeline will call this
+    args = parse_args()
+    CadlFlags(output_folder=args.output_folder, cadl_file=args.cadl_file).process()

--- a/packages/autorest.python/autorest/cadlflags/__init__.py
+++ b/packages/autorest.python/autorest/cadlflags/__init__.py
@@ -30,6 +30,8 @@ class CadlFlags(YamlUpdatePlugin):  # pylint: disable=abstract-method
             self.update_credential(yaml_data)
         if self.options.get("namespace"):
             yaml_data["client"]["namespace"] = self.options["namespace"]
+        if self.options.get("title"):
+            yaml_data["client"]["name"] = self.options["title"]
 
     def get_credential_scopes_from_flags(self, auth_policy: str) -> List[str]:
         if self.options.get("azure-arm"):

--- a/packages/autorest.python/run_cadl.py
+++ b/packages/autorest.python/run_cadl.py
@@ -22,5 +22,6 @@ if __name__ == "__main__":
     # run m2r
     python_run(venv_context, "autorest.m2r.__init__", command=sys.argv[1:])
     python_run(venv_context, "autorest.preprocess.__init__", command=sys.argv[1:])
+    python_run(venv_context, "autorest.cadlflags.__init__", command=sys.argv[1:])
     python_run(venv_context, "autorest.codegen.__init__", command=sys.argv[1:])
     python_run(venv_context, "autorest.black.__init__", command=sys.argv[1:])


### PR DESCRIPTION
Add temporary plugin `cadlflags`. Only cadl pipeline will call it, and it will apply some of the flags from `python.json` that we expect either the cadl file, or the sidecar story to handle in the future

Right now, we're only using it to see if we want credentials for the client, and whether we want to override the namespace