### PR TITLE
switch logging level for failsafe deserialize

### DIFF
--- a/packages/autorest.python/ChangeLog.md
+++ b/packages/autorest.python/ChangeLog.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 2022-08-XX - 6.1.4
+### 2022-08-31 - 6.1.4
 
 | Library                                                                 | Min Version |
 | ----------------------------------------------------------------------- | ----------- |
@@ -15,6 +15,7 @@
 
 - Fix generation failure for `format: password`  #1404
 - Fix `content_type` error when paging with body  #1407
+- Fix excessive warning level logging in vendored `failsafe_deserialize`  #1419
 
 **Other Changes**
 

--- a/packages/autorest.python/autorest/codegen/templates/serialization.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/serialization.py.jinja2
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "prepare": "node run-python3.js prepare.py",

--- a/packages/autorest.python/samples/specification/azure_key_credential/generated/azure/key/credential/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/azure_key_credential/generated/azure/key/credential/sample/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/samples/specification/basic/generated/azure/basic/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/basic/generated/azure/basic/sample/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/samples/specification/directives/generated/azure/directives/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/directives/generated/azure/directives/sample/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/samples/specification/management/generated/azure/mgmt/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/management/generated/azure/mgmt/sample/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureReport/azurereport/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureReport/azurereport/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Head/head/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Head/head/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadExceptions/headexceptions/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadExceptions/headexceptions/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadWithAzureKeyCredentialPolicy/headwithazurekeycredentialpolicy/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadWithAzureKeyCredentialPolicy/headwithazurekeycredentialpolicy/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/head/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/head/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/paging/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/paging/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeCustomize/azure/packagemode/customize/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeCustomize/azure/packagemode/customize/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeDataPlane/azure/packagemode/dataplane/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeDataPlane/azure/packagemode/dataplane/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeMgmtPlane/azure/package/mode/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeMgmtPlane/azure/package/mode/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureBodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureBodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureParameterGroupingVersionTolerant/azureparametergroupingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureParameterGroupingVersionTolerant/azureparametergroupingversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureReportVersionTolerant/azurereportversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureReportVersionTolerant/azurereportversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureSpecialsVersionTolerant/azurespecialpropertiesversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureSpecialsVersionTolerant/azurespecialpropertiesversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomUrlPagingVersionTolerant/custombaseurlpagingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomUrlPagingVersionTolerant/custombaseurlpagingversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadExceptionsVersionTolerant/headexceptionsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadExceptionsVersionTolerant/headexceptionsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadVersionTolerant/headversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadVersionTolerant/headversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/SubscriptionIdApiVersionVersionTolerant/subscriptionidapiversionversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/SubscriptionIdApiVersionVersionTolerant/subscriptionidapiversionversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenInitialVersionTolerant/dpgservicedriveninitialversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenInitialVersionTolerant/dpgservicedriveninitialversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_serialization.py
@@ -1524,7 +1524,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization",
 				exc_info=True
             )

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Anything/anything/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Anything/anything/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArray/bodyarray/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArray/bodyarray/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBinary/bodybinary/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBinary/bodybinary/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBoolean/bodyboolean/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBoolean/bodyboolean/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByte/bodybyte/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByte/bodybyte/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDate/bodydate/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDate/bodydate/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTime/bodydatetime/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTime/bodydatetime/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDictionary/bodydictionary/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDictionary/bodydictionary/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDuration/bodyduration/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDuration/bodyduration/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFile/bodyfile/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFile/bodyfile/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormData/bodyformdata/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormData/bodyformdata/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormUrlEncodedData/bodyformurlencodeddata/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormUrlEncodedData/bodyformurlencodeddata/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyInteger/bodyinteger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyInteger/bodyinteger/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyNumber/bodynumber/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyNumber/bodynumber/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyString/bodystring/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyString/bodystring/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyTime/bodytime/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyTime/bodytime/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Constants/constants/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Constants/constants/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ErrorWithSecrets/errorwithsecrets/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ErrorWithSecrets/errorwithsecrets/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Header/header/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Header/header/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Http/httpinfrastructure/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Http/httpinfrastructure/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/IncorrectErrorResponse/incorrecterrorresponse/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/IncorrectErrorResponse/incorrecterrorresponse/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MergePatchJson/mergepatchjson/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MergePatchJson/mergepatchjson/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ModelFlattening/modelflattening/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ModelFlattening/modelflattening/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NoOperations/nooperations/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NoOperations/nooperations/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NonStringEnums/nonstringenums/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NonStringEnums/nonstringenums/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ObjectType/objecttype/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ObjectType/objecttype/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/PackageModeDataPlane/packagemode/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/PackageModeDataPlane/packagemode/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterizedEndpoint/parameterizedendpoint/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterizedEndpoint/parameterizedendpoint/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Report/report/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Report/report/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ReservedWords/reservedwords/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ReservedWords/reservedwords/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwaggerCredentialFlag/securityaadswaggercredentialflag/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwaggerCredentialFlag/securityaadswaggercredentialflag/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwaggerCredentialFlag/securitykeyswaggercredentialflag/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwaggerCredentialFlag/securitykeyswaggercredentialflag/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Xml/xmlservice/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Xml/xmlservice/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AdditionalPropertiesVersionTolerant/additionalpropertiesversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AdditionalPropertiesVersionTolerant/additionalpropertiesversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AnythingVersionTolerant/anythingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AnythingVersionTolerant/anythingversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyArrayVersionTolerant/bodyarrayversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyArrayVersionTolerant/bodyarrayversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBinaryVersionTolerant/bodybinaryversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBinaryVersionTolerant/bodybinaryversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBooleanVersionTolerant/bodybooleanversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBooleanVersionTolerant/bodybooleanversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyByteVersionTolerant/bodybyteversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyByteVersionTolerant/bodybyteversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeRfc1123VersionTolerant/bodydatetimerfc1123versiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeRfc1123VersionTolerant/bodydatetimerfc1123versiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeVersionTolerant/bodydatetimeversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeVersionTolerant/bodydatetimeversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateVersionTolerant/bodydateversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateVersionTolerant/bodydateversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDictionaryVersionTolerant/bodydictionaryversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDictionaryVersionTolerant/bodydictionaryversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFileVersionTolerant/bodyfileversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFileVersionTolerant/bodyfileversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormDataVersionTolerant/bodyformdataversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormDataVersionTolerant/bodyformdataversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormUrlEncodedDataVersionTolerant/bodyformurlencodeddataversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormUrlEncodedDataVersionTolerant/bodyformurlencodeddataversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyIntegerVersionTolerant/bodyintegerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyIntegerVersionTolerant/bodyintegerversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyNumberVersionTolerant/bodynumberversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyNumberVersionTolerant/bodynumberversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyStringVersionTolerant/bodystringversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyStringVersionTolerant/bodystringversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyTimeVersionTolerant/bodytimeversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyTimeVersionTolerant/bodytimeversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ConstantsVersionTolerant/constantsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ConstantsVersionTolerant/constantsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriMoreOptionsVersionTolerant/custombaseurlmoreoptionsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriMoreOptionsVersionTolerant/custombaseurlmoreoptionsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ErrorWithSecretsVersionTolerant/errorwithsecretsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ErrorWithSecretsVersionTolerant/errorwithsecretsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ExtensibleEnumsVersionTolerant/extensibleenumsswaggerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ExtensibleEnumsVersionTolerant/extensibleenumsswaggerversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HeaderVersionTolerant/headerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HeaderVersionTolerant/headerversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HttpVersionTolerant/httpinfrastructureversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HttpVersionTolerant/httpinfrastructureversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/IncorrectErrorResponseVersionTolerant/incorrecterrorresponseversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/IncorrectErrorResponseVersionTolerant/incorrecterrorresponseversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MergePatchJsonVersionTolerant/mergepatchjsonversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MergePatchJsonVersionTolerant/mergepatchjsonversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ModelFlatteningVersionTolerant/modelflatteningversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ModelFlatteningVersionTolerant/modelflatteningversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MultipleInheritanceVersionTolerant/multipleinheritanceversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MultipleInheritanceVersionTolerant/multipleinheritanceversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoNamespaceFlagVersionTolerant/anything_client/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoNamespaceFlagVersionTolerant/anything_client/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoOperationsVersionTolerant/nooperationsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoOperationsVersionTolerant/nooperationsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NonStringEnumsVersionTolerant/nonstringenumsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NonStringEnumsVersionTolerant/nonstringenumsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ObjectTypeVersionTolerant/objecttypeversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ObjectTypeVersionTolerant/objecttypeversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterFlatteningVersionTolerant/parameterflatteningversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterFlatteningVersionTolerant/parameterflatteningversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterizedEndpointVersionTolerant/parameterizedendpointversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterizedEndpointVersionTolerant/parameterizedendpointversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReportVersionTolerant/reportversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReportVersionTolerant/reportversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/RequiredOptionalVersionTolerant/requiredoptionalversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/RequiredOptionalVersionTolerant/requiredoptionalversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReservedWordsVersionTolerant/reservedwordsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReservedWordsVersionTolerant/reservedwordsversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityAadSwaggerVersionTolerant/securityaadswaggerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityAadSwaggerVersionTolerant/securityaadswaggerversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityKeySwaggerVersionTolerant/securitykeyswaggerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityKeySwaggerVersionTolerant/securitykeyswaggerversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlMultiCollectionFormatVersionTolerant/urlmulticollectionformatversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlMultiCollectionFormatVersionTolerant/urlmulticollectionformatversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlVersionTolerant/urlversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlVersionTolerant/urlversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ValidationVersionTolerant/validationversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ValidationVersionTolerant/validationversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmlVersionTolerant/xmlserviceversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmlVersionTolerant/xmlserviceversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmsErrorResponseVersionTolerant/xmserrorresponseversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmsErrorResponseVersionTolerant/xmserrorresponseversiontolerant/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/dev-driven/resiliency/devdriven/_serialization.py
+++ b/packages/cadl-python/test/generated/dev-driven/resiliency/devdriven/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/extensible-enums/extensibleenums/_serialization.py
+++ b/packages/cadl-python/test/generated/extensible-enums/extensibleenums/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/hello/hello/_serialization.py
+++ b/packages/cadl-python/test/generated/hello/hello/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/inheritance/basicpolymorphicmodels/_serialization.py
+++ b/packages/cadl-python/test/generated/inheritance/basicpolymorphicmodels/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/input-basic/inputbasic/_serialization.py
+++ b/packages/cadl-python/test/generated/input-basic/inputbasic/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/interfaces/multiinterfaceclient/_serialization.py
+++ b/packages/cadl-python/test/generated/interfaces/multiinterfaceclient/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/nested-models/nestedmodelsbasic/_serialization.py
+++ b/packages/cadl-python/test/generated/nested-models/nestedmodelsbasic/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/optional-properties/optionalproperties/_serialization.py
+++ b/packages/cadl-python/test/generated/optional-properties/optionalproperties/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/output-basic/outputbasic/_serialization.py
+++ b/packages/cadl-python/test/generated/output-basic/outputbasic/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/property-types/models/property/types/_serialization.py
+++ b/packages/cadl-python/test/generated/property-types/models/property/types/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/readonly-properties/readonlyproperties/_serialization.py
+++ b/packages/cadl-python/test/generated/readonly-properties/readonlyproperties/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/roundtrip-basic/roundtripbasic/_serialization.py
+++ b/packages/cadl-python/test/generated/roundtrip-basic/roundtripbasic/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/srv-driven-1/resiliency/servicedriven1/_serialization.py
+++ b/packages/cadl-python/test/generated/srv-driven-1/resiliency/servicedriven1/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None

--- a/packages/cadl-python/test/generated/srv-driven-2/resiliency/servicedriven2/_serialization.py
+++ b/packages/cadl-python/test/generated/srv-driven-2/resiliency/servicedriven2/_serialization.py
@@ -1505,7 +1505,7 @@ class Deserializer(object):
         try:
             return self(target_obj, data, content_type=content_type)
         except:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Ran into a deserialization error. Ignoring since this is failsafe deserialization", exc_info=True
             )
             return None


### PR DESCRIPTION
We don't want to expose this as a warning to end users, so switching to debug level

See related issue here https://github.com/Azure/azure-sdk-for-python/issues/25954