### PR TITLE
use shell=True to start cadl-ranch in windows 

### DIFF
--- a/packages/cadl-python/test/mock_api_tests/conftest.py
+++ b/packages/cadl-python/test/mock_api_tests/conftest.py
@@ -13,9 +13,9 @@ def start_server_process():
     path = Path(os.path.dirname(__file__)) / Path("../../node_modules/@azure-tools/cadl-ranch-specs")
     os.chdir(path.resolve())
     cmd = "cadl-ranch serve ./http"
-    if os.name == "nt":  # on windows, subprocess creation works without being in the shell
-        return subprocess.Popen(cmd)
-    return subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid) #On linux, have to set shell=True
+    if os.name == "nt":
+        return subprocess.Popen(cmd, shell=True)
+    return subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid)
 
 def terminate_server_process(process):
     if os.name == 'nt':


### PR DESCRIPTION
I found below issue in windows if there is no `shell=True`:
![image](https://user-images.githubusercontent.com/59815250/190983426-0b3f0f80-65e3-4376-8e5a-c4c5c1a67c89.png)
