### PR TITLE
allow users to pass flags through cadl-project

### DIFF
--- a/packages/autorest.python/autorest/_utils.py
+++ b/packages/autorest.python/autorest/_utils.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 import re
 import argparse
 
@@ -37,7 +37,9 @@ def to_snake_case(name: str) -> str:
     return re.sub("[A-Z]+", replace_upper_characters, name)
 
 
-def parse_args(need_cadl_file: bool = True):
+def parse_args(
+    need_cadl_file: bool = True,
+) -> Tuple[argparse.Namespace, Dict[str, Any]]:
     parser = argparse.ArgumentParser(
         description="Run mypy against target folder. Add a local custom plugin to the path prior to execution. "
     )
@@ -60,7 +62,24 @@ def parse_args(need_cadl_file: bool = True):
         required=False,
         action="store_true",
     )
-    return parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
+
+    def _get_value(value: Any) -> Any:
+        if value == "true":
+            return True
+        if value == "false":
+            return False
+        try:
+            return int(value)
+        except ValueError:
+            pass
+        return value
+
+    unknown_args_ret = {
+        ua.strip("--").split("=")[0]: _get_value(ua.strip("--").split("=")[1])
+        for ua in unknown_args
+    }
+    return args, unknown_args_ret
 
 
 def get_body_type_for_description(body_parameter: Dict[str, Any]) -> str:

--- a/packages/autorest.python/autorest/black/__init__.py
+++ b/packages/autorest.python/autorest/black/__init__.py
@@ -54,5 +54,5 @@ class BlackScriptPluginAutorest(BlackScriptPlugin, PluginAutorest):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args, options = parse_args(need_cadl_file=False)
-    BlackScriptPlugin(output_folder=args.output_folder, **options).process()
+    args, unknown_args = parse_args(need_cadl_file=False)
+    BlackScriptPlugin(output_folder=args.output_folder, **unknown_args).process()

--- a/packages/autorest.python/autorest/black/__init__.py
+++ b/packages/autorest.python/autorest/black/__init__.py
@@ -54,5 +54,5 @@ class BlackScriptPluginAutorest(BlackScriptPlugin, PluginAutorest):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args = parse_args(need_cadl_file=False)
-    BlackScriptPlugin(output_folder=args.output_folder).process()
+    args, options = parse_args(need_cadl_file=False)
+    BlackScriptPlugin(output_folder=args.output_folder, **options).process()

--- a/packages/autorest.python/autorest/cadlflags/__init__.py
+++ b/packages/autorest.python/autorest/cadlflags/__init__.py
@@ -124,7 +124,7 @@ class CadlFlags(YamlUpdatePlugin):  # pylint: disable=abstract-method
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args, options = parse_args()
+    args, unknown_args = parse_args()
     CadlFlags(
-        output_folder=args.output_folder, cadl_file=args.cadl_file, **options
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **unknown_args
     ).process()

--- a/packages/autorest.python/autorest/cadlflags/__init__.py
+++ b/packages/autorest.python/autorest/cadlflags/__init__.py
@@ -124,5 +124,7 @@ class CadlFlags(YamlUpdatePlugin):  # pylint: disable=abstract-method
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args = parse_args()
-    CadlFlags(output_folder=args.output_folder, cadl_file=args.cadl_file).process()
+    args, options = parse_args()
+    CadlFlags(
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **options
+    ).process()

--- a/packages/autorest.python/autorest/codegen/__init__.py
+++ b/packages/autorest.python/autorest/codegen/__init__.py
@@ -361,5 +361,7 @@ class CodeGeneratorAutorest(CodeGenerator, PluginAutorest):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args = parse_args()
-    CodeGenerator(output_folder=args.output_folder, cadl_file=args.cadl_file).process()
+    args, options = parse_args()
+    CodeGenerator(
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **options
+    ).process()

--- a/packages/autorest.python/autorest/codegen/__init__.py
+++ b/packages/autorest.python/autorest/codegen/__init__.py
@@ -361,7 +361,7 @@ class CodeGeneratorAutorest(CodeGenerator, PluginAutorest):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args, options = parse_args()
+    args, unknown_args = parse_args()
     CodeGenerator(
-        output_folder=args.output_folder, cadl_file=args.cadl_file, **options
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **unknown_args
     ).process()

--- a/packages/autorest.python/autorest/m2r/__init__.py
+++ b/packages/autorest.python/autorest/m2r/__init__.py
@@ -68,5 +68,5 @@ class M2RAutorest(YamlUpdatePluginAutorest, M2R):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args = parse_args()
-    M2R(output_folder=args.output_folder, cadl_file=args.cadl_file).process()
+    args, options = parse_args()
+    M2R(output_folder=args.output_folder, cadl_file=args.cadl_file, **options).process()

--- a/packages/autorest.python/autorest/m2r/__init__.py
+++ b/packages/autorest.python/autorest/m2r/__init__.py
@@ -68,5 +68,7 @@ class M2RAutorest(YamlUpdatePluginAutorest, M2R):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args, options = parse_args()
-    M2R(output_folder=args.output_folder, cadl_file=args.cadl_file, **options).process()
+    args, unknown_args = parse_args()
+    M2R(
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **unknown_args
+    ).process()

--- a/packages/autorest.python/autorest/preprocess/__init__.py
+++ b/packages/autorest.python/autorest/preprocess/__init__.py
@@ -363,7 +363,7 @@ class PreProcessPluginAutorest(YamlUpdatePluginAutorest, PreProcessPlugin):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args = parse_args()
+    args, options = parse_args()
     PreProcessPlugin(
-        output_folder=args.output_folder, cadl_file=args.cadl_file
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **options
     ).process()

--- a/packages/autorest.python/autorest/preprocess/__init__.py
+++ b/packages/autorest.python/autorest/preprocess/__init__.py
@@ -363,7 +363,7 @@ class PreProcessPluginAutorest(YamlUpdatePluginAutorest, PreProcessPlugin):
 
 if __name__ == "__main__":
     # CADL pipeline will call this
-    args, options = parse_args()
+    args, unknown_args = parse_args()
     PreProcessPlugin(
-        output_folder=args.output_folder, cadl_file=args.cadl_file, **options
+        output_folder=args.output_folder, cadl_file=args.cadl_file, **unknown_args
     ).process()

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "prepare": "node run-python3.js prepare.py",

--- a/packages/cadl-python/package.json
+++ b/packages/cadl-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-python",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Microsoft Corporation",
   "description": "Cadl emitter for Python SDKs",
   "homepage": "https://github.com/Azure/autorest.python",

--- a/packages/cadl-python/src/emitter.ts
+++ b/packages/cadl-python/src/emitter.ts
@@ -66,6 +66,7 @@ export interface EmitterOptions {
     "basic-setup-py": boolean;
     "package-version": string;
     "package-name": string;
+    "output-path": string;
 }
 
 const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
@@ -75,6 +76,7 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
         "basic-setup-py": { type: "boolean", nullable: true },
         "package-version": { type: "string", nullable: true },
         "package-name": { type: "string", nullable: true },
+        "output-path": { type: "string", nullable: true },
     },
     required: [],
 };
@@ -92,10 +94,11 @@ export async function $onEmit(program: Program, options: EmitterOptions) {
     const yamlPath = resolvePath(program.compilerOptions.outputPath!, "output.yaml");
     await program.host.writeFile(yamlPath, dump(yamlMap));
     const root = process.cwd();
+    const outputFolder = options["output-path"] ?? program.compilerOptions.outputPath!;
     const commandArgs = [
         `${root}/node_modules/@autorest/python/run-python3.js`,
         `${root}/node_modules/@autorest/python/run_cadl.py`,
-        `--output-folder=${program.compilerOptions.outputPath!}`,
+        `--output-folder=${outputFolder}`,
         `--cadl-file=${yamlPath}`,
     ];
     for (const [key, value] of Object.entries(options)) {


### PR DESCRIPTION
Example cadl-project.yaml

```yaml
emitters:
  "@azure-tools/cadl-python":
    "basic-setup-py": true
    "package-version": "1.0.0b1"
```

SHould generate a basic setup.py with package version 1.0.0b1