### PR TITLE
Unproper model name when using template of `@azure-tools/cadl-azure-core`

### DIFF
--- a/packages/cadl-python/src/emitter.ts
+++ b/packages/cadl-python/src/emitter.ts
@@ -187,11 +187,9 @@ function getEffectiveSchemaType(program: Program, type: Model): Model {
         return !(headerInfo || queryInfo || pathInfo || statusCodeinfo);
     }
 
-    if (type.kind === "Model" && !type.name) {
-        const effective = getEffectiveModelType(program, type, isSchemaProperty);
-        if (effective.name) {
-            return effective;
-        }
+    const effective = getEffectiveModelType(program, type, isSchemaProperty);
+    if (effective.name) {
+        return effective;
     }
     return type;
 }


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.python/issues/1473