### PR TITLE
fix msrest deserialization key for private model

### DIFF
--- a/packages/autorest.python/autorest/codegen/models/base.py
+++ b/packages/autorest.python/autorest/codegen/models/base.py
@@ -102,7 +102,7 @@ class BaseType(BaseModel, ABC):
         raise NotImplementedError()
 
     @property
-    def msrest_serialization_type(self) -> str:
+    def msrest_deserialization_type(self) -> str:
         return self.serialization_type
 
     @property

--- a/packages/autorest.python/autorest/codegen/models/base.py
+++ b/packages/autorest.python/autorest/codegen/models/base.py
@@ -87,7 +87,6 @@ class BaseType(BaseModel, ABC):
         return ", ".join(attrs_list)
 
     @property
-    @abstractmethod
     def serialization_type(self) -> str:
         """The tag recognized by 'msrest' as a serialization/deserialization.
 
@@ -100,6 +99,11 @@ class BaseType(BaseModel, ABC):
         If dict: '{str}'
         """
         ...
+        raise NotImplementedError()
+
+    @property
+    def msrest_serialization_type(self) -> str:
+        return self.serialization_type
 
     @property
     def client_default_value(self) -> Any:

--- a/packages/autorest.python/autorest/codegen/models/base.py
+++ b/packages/autorest.python/autorest/codegen/models/base.py
@@ -102,7 +102,7 @@ class BaseType(BaseModel, ABC):
         raise NotImplementedError()
 
     @property
-    def msrest_deserialization_type(self) -> str:
+    def msrest_deserialization_key(self) -> str:
         return self.serialization_type
 
     @property

--- a/packages/autorest.python/autorest/codegen/models/model_type.py
+++ b/packages/autorest.python/autorest/codegen/models/model_type.py
@@ -75,7 +75,6 @@ class ModelType(
     @property
     def serialization_type(self) -> str:
         if self.code_model.options["models_mode"] == "msrest":
-            return self.name
             private_model_path = f"_models.{self.code_model.models_filename}."
             return f"{'' if self.is_public else private_model_path}{self.name}"
         if self.code_model.options["models_mode"] == "dpg":
@@ -83,7 +82,7 @@ class ModelType(
         return "object"
 
     @property
-    def msrest_serialization_type(self) -> str:
+    def msrest_deserialization_type(self) -> str:
         if self.code_model.options["models_mode"] == "msrest":
             return self.name
         return self.serialization_type

--- a/packages/autorest.python/autorest/codegen/models/model_type.py
+++ b/packages/autorest.python/autorest/codegen/models/model_type.py
@@ -82,10 +82,8 @@ class ModelType(
         return "object"
 
     @property
-    def msrest_deserialization_type(self) -> str:
-        if self.code_model.options["models_mode"] == "msrest":
-            return self.name
-        return self.serialization_type
+    def msrest_deserialization_key(self) -> str:
+        return self.name
 
     @property
     def is_polymorphic(self) -> bool:

--- a/packages/autorest.python/autorest/codegen/models/model_type.py
+++ b/packages/autorest.python/autorest/codegen/models/model_type.py
@@ -75,11 +75,18 @@ class ModelType(
     @property
     def serialization_type(self) -> str:
         if self.code_model.options["models_mode"] == "msrest":
+            return self.name
             private_model_path = f"_models.{self.code_model.models_filename}."
             return f"{'' if self.is_public else private_model_path}{self.name}"
         if self.code_model.options["models_mode"] == "dpg":
             return f"{'' if self.is_public else '_models.'}_models.{self.name}"
         return "object"
+
+    @property
+    def msrest_serialization_type(self) -> str:
+        if self.code_model.options["models_mode"] == "msrest":
+            return self.name
+        return self.serialization_type
 
     @property
     def is_polymorphic(self) -> bool:

--- a/packages/autorest.python/autorest/codegen/models/property.py
+++ b/packages/autorest.python/autorest/codegen/models/property.py
@@ -83,6 +83,10 @@ class Property(BaseModel):  # pylint: disable=too-many-instance-attributes
     def serialization_type(self) -> str:
         return self.type.serialization_type
 
+    @property
+    def msrest_deserialization_type(self) -> str:
+        return self.type.msrest_deserialization_type
+
     def type_annotation(self, *, is_operation_file: bool = False) -> str:
         if self.optional and self.client_default_value is None:
             return f"Optional[{self.type.type_annotation(is_operation_file=is_operation_file)}]"

--- a/packages/autorest.python/autorest/codegen/models/property.py
+++ b/packages/autorest.python/autorest/codegen/models/property.py
@@ -84,8 +84,8 @@ class Property(BaseModel):  # pylint: disable=too-many-instance-attributes
         return self.type.serialization_type
 
     @property
-    def msrest_deserialization_type(self) -> str:
-        return self.type.msrest_deserialization_type
+    def msrest_deserialization_key(self) -> str:
+        return self.type.msrest_deserialization_key
 
     def type_annotation(self, *, is_operation_file: bool = False) -> str:
         if self.optional and self.client_default_value is None:

--- a/packages/autorest.python/autorest/codegen/serializers/model_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/model_serializer.py
@@ -195,7 +195,10 @@ class MsrestModelSerializer(_ModelSerializer):
             xml_metadata = f", 'xml': {{{prop.type.xml_serialization_ctxt}}}"
         else:
             xml_metadata = ""
-        return f'"{prop.client_name}": {{"key": "{attribute_key}", "type": "{prop.serialization_type}"{xml_metadata}}},'
+        return (
+            f'"{prop.client_name}": {{"key": "{attribute_key}",'
+            f' "type": "{prop.msrest_deserialization_type}"{xml_metadata}}},'
+        )
 
 
 class DpgModelSerializer(_ModelSerializer):

--- a/packages/autorest.python/autorest/codegen/serializers/model_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/model_serializer.py
@@ -197,7 +197,7 @@ class MsrestModelSerializer(_ModelSerializer):
             xml_metadata = ""
         return (
             f'"{prop.client_name}": {{"key": "{attribute_key}",'
-            f' "type": "{prop.msrest_deserialization_type}"{xml_metadata}}},'
+            f' "type": "{prop.msrest_deserialization_key}"{xml_metadata}}},'
         )
 
 


### PR DESCRIPTION
In _serialization.py, the msrest deserialization just use class name directly without any namespaces.
So this PR changed generated models like below:
![image](https://user-images.githubusercontent.com/59815250/199918855-818db369-3cac-4003-bdd6-8f675a98a48e.png)
