### PR TITLE
Use default coverage report name

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -175,5 +175,5 @@ jobs:
         workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/cadl-python/node_modules/@azure-tools/cadl-ranch-specs
         continueOnError: true
 
-      - publish: $(Build.SourcesDirectory)/autorest.python/packages/cadl-python/node_modules/@azure-tools/cadl-ranch-specs/cadl-ranch-coverage-python.json
+      - publish: $(Build.SourcesDirectory)/autorest.python/packages/cadl-python/node_modules/@azure-tools/cadl-ranch-specs/cadl-ranch-coverage.json
         artifact: CoverageReport

--- a/eng/pipelines/internal-ci.yml
+++ b/eng/pipelines/internal-ci.yml
@@ -31,5 +31,5 @@ steps:
         azureSubscription: "Azure SDK Playground"
         scriptType: "bash"
         scriptLocation: "inlineScript"
-        inlineScript: cadl-ranch upload-coverage --coverageFile ./cadl-ranch-coverage-python.json --generatorName python --storageAccountName cadlranchcoverage --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/autorest.python/packages/cadl-python/package.json').version")
+        inlineScript: cadl-ranch upload-coverage --generatorName python --storageAccountName cadlranchcoverage --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/autorest.python/packages/cadl-python/package.json').version")
         workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/cadl-python/node_modules/@azure-tools/cadl-ranch-specs

--- a/packages/cadl-python/test/mock_api_tests/conftest.py
+++ b/packages/cadl-python/test/mock_api_tests/conftest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 def start_server_process():
     path = Path(os.path.dirname(__file__)) / Path("../../node_modules/@azure-tools/cadl-ranch-specs")
     os.chdir(path.resolve())
-    cmd = "cadl-ranch serve ./http --coverageFile ./cadl-ranch-coverage-python.json"
+    cmd = "cadl-ranch serve ./http
     if os.name == "nt":
         return subprocess.Popen(cmd, shell=True)
     return subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid)

--- a/packages/cadl-python/test/mock_api_tests/conftest.py
+++ b/packages/cadl-python/test/mock_api_tests/conftest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 def start_server_process():
     path = Path(os.path.dirname(__file__)) / Path("../../node_modules/@azure-tools/cadl-ranch-specs")
     os.chdir(path.resolve())
-    cmd = "cadl-ranch serve ./http
+    cmd = "cadl-ranch serve ./http"
     if os.name == "nt":
         return subprocess.Popen(cmd, shell=True)
     return subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid)


### PR DESCRIPTION
Right now it's broken, because we are not explicit everywhere, so the coverage step in CI is all red