### PR TITLE
filter header in model

### DIFF
--- a/packages/cadl-python/src/emitter.ts
+++ b/packages/cadl-python/src/emitter.ts
@@ -53,6 +53,7 @@ import {
     HttpServer,
     isStatusCode,
     HttpOperation,
+    isHeader,
 } from "@cadl-lang/rest/http";
 import { getAddedOn } from "@cadl-lang/versioning";
 import {
@@ -256,7 +257,7 @@ function getType(program: Program, type: EmitterType): any {
         if (type.kind === "Model") {
             // need to do properties after insertion to avoid infinite recursion
             for (const property of type.properties.values()) {
-                if (isStatusCode(program, property) || isNeverType(property.type)) {
+                if (isStatusCode(program, property) || isNeverType(property.type) || isHeader(program, property)) {
                     continue;
                 }
                 newValue.properties.push(emitProperty(program, property));


### PR DESCRIPTION
fix https://github.com/Azure/autorest.python/issues/1654
no header in model anymore:
https://github.com/Azure/autorest.python/blob/1fd644f44c5cbb0541ee3577f8713fa18494b762/packages/cadl-python/inference/generated_code/azure/openai/python/models/_models.py#L75-L96