### PR TITLE
serialize azure.core.serialization.NULL for DPG model

### DIFF
--- a/packages/autorest.python/ChangeLog.md
+++ b/packages/autorest.python/ChangeLog.md
@@ -1,5 +1,21 @@
 # Release History
 
+### 2023-01-XX - 6.xx.xx
+
+| Library                                                                 | Min Version |
+| ----------------------------------------------------------------------- | ----------- |
+| `@autorest/core`                                                        | `3.9.2`     |
+| `@autorest/modelerfour`                                                 | `4.24.3`    |
+| `azure-core` dep of generated code                                      | `1.24.0`    |
+| `isodate` dep of generated code                                         | `0.6.1`     |
+| `msrest` dep of generated code (If generating legacy code)              | `0.7.1`     |
+| `azure-mgmt-core` dep of generated code (If generating mgmt plane code) | `1.3.2`     |
+| `typing-extensions` dep of generated code (If generating with constants)| `4.0.1`     |
+
+**New Features**
+
+- Support `azure.core.serialization.NULL` in dpg model serialization #1669
+
 ### 2023-01-069 - 6.2.15
 
 | Library                                                                 | Min Version |

--- a/packages/autorest.python/autorest/codegen/templates/model_base.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/model_base.py.jinja2
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,6 +158,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/api-key/authentication/apikey/_model_base.py
+++ b/packages/cadl-python/test/generated/api-key/authentication/apikey/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/dev-driven/resiliency/devdriven/_model_base.py
+++ b/packages/cadl-python/test/generated/dev-driven/resiliency/devdriven/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/dictionary/dictionary/_model_base.py
+++ b/packages/cadl-python/test/generated/dictionary/dictionary/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/extensible/enums/extensible/_model_base.py
+++ b/packages/cadl-python/test/generated/extensible/enums/extensible/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/fixed/enums/fixed/_model_base.py
+++ b/packages/cadl-python/test/generated/fixed/enums/fixed/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/hello/hello/_model_base.py
+++ b/packages/cadl-python/test/generated/hello/hello/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/inheritance/models/inheritance/_model_base.py
+++ b/packages/cadl-python/test/generated/inheritance/models/inheritance/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/item-types/arrays/itemtypes/_model_base.py
+++ b/packages/cadl-python/test/generated/item-types/arrays/itemtypes/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/lro-basic/azure/lro/_model_base.py
+++ b/packages/cadl-python/test/generated/lro-basic/azure/lro/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/oauth2/authentication/oauth2/_model_base.py
+++ b/packages/cadl-python/test/generated/oauth2/authentication/oauth2/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/property-optional/models/property/optional/_model_base.py
+++ b/packages/cadl-python/test/generated/property-optional/models/property/optional/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/property-types/models/property/types/_model_base.py
+++ b/packages/cadl-python/test/generated/property-types/models/property/types/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/special-words/specialwords/_model_base.py
+++ b/packages/cadl-python/test/generated/special-words/specialwords/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/srv-driven-1/resiliency/servicedriven1/_model_base.py
+++ b/packages/cadl-python/test/generated/srv-driven-1/resiliency/servicedriven1/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/srv-driven-2/resiliency/servicedriven2/_model_base.py
+++ b/packages/cadl-python/test/generated/srv-driven-2/resiliency/servicedriven2/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/union/authentication/union/_model_base.py
+++ b/packages/cadl-python/test/generated/union/authentication/union/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/usage/models/usage/_model_base.py
+++ b/packages/cadl-python/test/generated/usage/models/usage/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:

--- a/packages/cadl-python/test/generated/visibility/models/visibility/automatic/_model_base.py
+++ b/packages/cadl-python/test/generated/visibility/models/visibility/automatic/_model_base.py
@@ -21,6 +21,7 @@ import isodate
 from azure.core.exceptions import DeserializationError
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.pipeline import PipelineResponse
+from azure.core.serialization import NULL as AzureCoreNull
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,6 +162,8 @@ class AzureJSONEncoder(JSONEncoder):
             return {k: v for k, v in o.items() if k not in readonly_props}
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
+        if o is AzureCoreNull:
+            return None
         try:
             return super(AzureJSONEncoder, self).default(o)
         except TypeError:


### PR DESCRIPTION
Verified with below code:

``` python
class ByteWrapper(Model):
    field: Optional[bytes] = rest_field(default=None)

mod = ByteWrapper(field=None)
assert '{}' == json.dumps(mod, cls=AzureJSONEncoder)

mod.field = azure.core.serialization.NULL
assert '{"field": null}' == json.dumps(mod, cls=AzureJSONEncoder)
```