### PR TITLE
set array format in cadl-python

### DIFF
--- a/packages/cadl-python/src/emitter.ts
+++ b/packages/cadl-python/src/emitter.ts
@@ -406,6 +406,13 @@ function emitParameter(
         implementation: implementation,
         skipUrlEncoding: parameter.type === "endpointPath",
     };
+    if (type.type == "list" && (parameter.type == "query" || parameter.type == "header")) {
+        if (parameter.format == "csv") {
+            paramMap["delimiter"] = "comma";
+        } else {
+            paramMap["explode"] = true;
+        }
+    }
 
     if (paramMap.type.type === "constant") {
         clientDefaultValue = paramMap.type.value;


### PR DESCRIPTION
`format: "multi"` are now generated as below:
``` python
    _params["colors"] = [_SERIALIZER.query("colors", q, "str") if q is not None else "" for q in colors]
```

`format: "csv"` as below:
``` python
    _params["colors"] = _SERIALIZER.query("colors", colors, "[str]", div=",")
```