### PR TITLE
separate lro initial operation from lro

### DIFF
--- a/packages/autorest.python/autorest/codegen/models/__init__.py
+++ b/packages/autorest.python/autorest/codegen/models/__init__.py
@@ -183,3 +183,4 @@ RequestBuilderType = Union[RequestBuilder, OverloadedRequestBuilder]
 ParameterType = Union[
     Parameter, RequestBuilderParameter, ClientParameter, ConfigParameter
 ]
+OperationType = Union[Operation, LROOperation, PagingOperation, LROPagingOperation]

--- a/packages/autorest.python/autorest/codegen/models/base_builder.py
+++ b/packages/autorest.python/autorest/codegen/models/base_builder.py
@@ -45,7 +45,6 @@ class BaseBuilder(
         parameters: ParameterListType,
         *,
         overloads=None,
-        want_tracing: bool = True,
     ) -> None:
         super().__init__(yaml_data=yaml_data, code_model=code_model)
         self.client = client
@@ -56,7 +55,7 @@ class BaseBuilder(
             overloads or []
         )
         self._summary: str = yaml_data.get("summary", "")
-        self.want_tracing = want_tracing
+        self.want_tracing: bool = yaml_data.get("wantTracing", True)
         self.group_name: str = yaml_data[
             "groupName"
         ]  # either operationGroup or client I am on

--- a/packages/autorest.python/autorest/codegen/models/client.py
+++ b/packages/autorest.python/autorest/codegen/models/client.py
@@ -72,7 +72,6 @@ class Client(_ClientConfigBase[ClientGlobalParameterList]):
                 OperationGroup.from_yaml(op_group, code_model, self)
                 for op_group in self.yaml_data.get("operationGroups", [])
             ]
-            self.format_lro_operations()
 
     def _build_request_builders(
         self,
@@ -221,19 +220,6 @@ class Client(_ClientConfigBase[ClientGlobalParameterList]):
             for operation_group in self.operation_groups
         )
 
-    def format_lro_operations(self) -> None:
-        """Adds operations and attributes needed for LROs.
-        If there are LRO functions in here, will add initial LRO function. Will also set the return
-        type of the LRO operation
-        """
-        for operation_group in self.operation_groups:
-            i = 0
-            while i < len(operation_group.operations):
-                operation = operation_group.operations[i]
-                if operation.operation_type in ("lro", "lropaging"):
-                    operation_group.operations.insert(i, operation.initial_operation)  # type: ignore
-                    i += 1
-                i += 1
 
     @property
     def need_request_converter(self) -> bool:

--- a/packages/autorest.python/autorest/codegen/models/client.py
+++ b/packages/autorest.python/autorest/codegen/models/client.py
@@ -83,7 +83,7 @@ class Client(_ClientConfigBase[ClientGlobalParameterList]):
         request_builders: List[Union[RequestBuilder, OverloadedRequestBuilder]] = []
         for og_group in self.yaml_data["operationGroups"]:
             for operation_yaml in og_group["operations"]:
-                if operation_yaml["discriminator"] == "lro":
+                if operation_yaml["discriminator"] in ("lro", "lropaging"):
                     continue
                 request_builder = get_request_builder(
                     operation_yaml,
@@ -93,9 +93,7 @@ class Client(_ClientConfigBase[ClientGlobalParameterList]):
                 if operation_yaml.get("isLroInitialOperation"):
                     # we want to change the name
                     request_builder.name = request_builder.get_name(
-                        request_builder.yaml_data["name"]
-                        .rstrip("_initial")
-                        .lstrip("_"),
+                        request_builder.yaml_data["name"][1 : -len("_initial")],
                         request_builder.yaml_data,
                         request_builder.code_model,
                         request_builder.client,

--- a/packages/autorest.python/autorest/codegen/models/lro_operation.py
+++ b/packages/autorest.python/autorest/codegen/models/lro_operation.py
@@ -34,7 +34,6 @@ class LROOperationBase(OperationBase[LROResponseType]):
         *,
         overloads: Optional[List[Operation]] = None,
         public: bool = True,
-        want_tracing: bool = True,
     ) -> None:
         super().__init__(
             code_model=code_model,
@@ -47,7 +46,6 @@ class LROOperationBase(OperationBase[LROResponseType]):
             exceptions=exceptions,
             overloads=overloads,
             public=public,
-            want_tracing=want_tracing,
         )
         self.name = "begin_" + self.name
         self.lro_options: Dict[str, Any] = self.yaml_data.get("lroOptions", {})
@@ -92,26 +90,6 @@ class LROOperationBase(OperationBase[LROResponseType]):
     def cls_type_annotation(self, *, async_mode: bool) -> str:
         """We don't want the poller to show up in ClsType, so we call super() on resposne type annotation"""
         return f"ClsType[{Response.type_annotation(self.responses[0], async_mode=async_mode)}]"
-
-    @property
-    def initial_operation(self) -> Operation:
-        """Initial operation that creates the first call for LRO polling"""
-        return Operation(
-            yaml_data=self.yaml_data,
-            code_model=self.code_model,
-            client=self.client,
-            request_builder=self.client.lookup_request_builder(id(self.yaml_data)),
-            name=self.name[5:] + "_initial",
-            overloads=self.overloads,
-            parameters=self.parameters,
-            responses=[
-                Response(r.yaml_data, self.code_model, headers=r.headers, type=r.type)
-                for r in self.responses
-            ],
-            exceptions=self.exceptions,
-            public=False,
-            want_tracing=False,
-        )
 
     def get_poller(self, async_mode: bool) -> str:
         return self.responses[0].get_poller(async_mode)

--- a/packages/autorest.python/autorest/codegen/models/lro_operation.py
+++ b/packages/autorest.python/autorest/codegen/models/lro_operation.py
@@ -134,8 +134,10 @@ class LROOperationBase(OperationBase[LROResponseType]):
         file_import.add_submodule_import("typing", "cast", ImportType.STDLIB)
         return file_import
 
-
-class LROOperation(LROOperationBase[LROResponse]):
     @classmethod
     def get_request_builder(cls, yaml_data: Dict[str, Any], client: "Client"):
         return client.lookup_request_builder(id(yaml_data["initialOperation"]))
+
+
+class LROOperation(LROOperationBase[LROResponse]):
+    ...

--- a/packages/autorest.python/autorest/codegen/models/operation.py
+++ b/packages/autorest.python/autorest/codegen/models/operation.py
@@ -64,7 +64,6 @@ class OperationBase(  # pylint: disable=too-many-public-methods
         *,
         overloads: Optional[List["Operation"]] = None,
         public: bool = True,
-        want_tracing: bool = True,
     ) -> None:
         super().__init__(
             code_model=code_model,
@@ -73,7 +72,6 @@ class OperationBase(  # pylint: disable=too-many-public-methods
             name=name,
             parameters=parameters,
             overloads=overloads,
-            want_tracing=want_tracing,
         )
         self.overloads: List["Operation"] = overloads or []
         self.responses = responses
@@ -470,7 +468,6 @@ class OperationBase(  # pylint: disable=too-many-public-methods
             overloads=overloads,
             responses=responses,
             exceptions=exceptions,
-            want_tracing=not yaml_data["isOverload"],
         )
 
 

--- a/packages/autorest.python/autorest/codegen/models/operation_group.py
+++ b/packages/autorest.python/autorest/codegen/models/operation_group.py
@@ -8,13 +8,14 @@ from typing import Dict, List, Any, TYPE_CHECKING
 from autorest.codegen.models.utils import OrderedSet
 
 from .base import BaseModel
-from .operation import OperationBase, get_operation
+from .operation import get_operation
 from .imports import FileImport, ImportType, TypingSection
 from .utils import add_to_pylint_disable
 
 if TYPE_CHECKING:
     from .code_model import CodeModel
     from .client import Client
+    from . import OperationType
 
 
 class OperationGroup(BaseModel):
@@ -25,7 +26,7 @@ class OperationGroup(BaseModel):
         yaml_data: Dict[str, Any],
         code_model: "CodeModel",
         client: "Client",
-        operations: List[OperationBase],
+        operations: List["OperationType"],
         api_versions: List[str],
     ) -> None:
         super().__init__(yaml_data, code_model)

--- a/packages/autorest.python/autorest/codegen/models/paging_operation.py
+++ b/packages/autorest.python/autorest/codegen/models/paging_operation.py
@@ -38,7 +38,6 @@ class PagingOperationBase(OperationBase[PagingResponseType]):
         exceptions: List[Response],
         *,
         overloads: Optional[List[Operation]] = None,
-        public: bool = True,
         override_success_response_to_200: bool = False,
     ) -> None:
         super().__init__(
@@ -51,7 +50,6 @@ class PagingOperationBase(OperationBase[PagingResponseType]):
             responses=responses,
             exceptions=exceptions,
             overloads=overloads,
-            public=public,
         )
         self.next_request_builder: Optional[
             Union[RequestBuilder, OverloadedRequestBuilder]

--- a/packages/autorest.python/autorest/codegen/models/paging_operation.py
+++ b/packages/autorest.python/autorest/codegen/models/paging_operation.py
@@ -39,7 +39,6 @@ class PagingOperationBase(OperationBase[PagingResponseType]):
         *,
         overloads: Optional[List[Operation]] = None,
         public: bool = True,
-        want_tracing: bool = True,
         override_success_response_to_200: bool = False,
     ) -> None:
         super().__init__(
@@ -53,7 +52,6 @@ class PagingOperationBase(OperationBase[PagingResponseType]):
             exceptions=exceptions,
             overloads=overloads,
             public=public,
-            want_tracing=want_tracing,
         )
         self.next_request_builder: Optional[
             Union[RequestBuilder, OverloadedRequestBuilder]

--- a/packages/autorest.python/autorest/codegen/models/request_builder.py
+++ b/packages/autorest.python/autorest/codegen/models/request_builder.py
@@ -127,14 +127,13 @@ class RequestBuilderBase(BaseBuilder[ParameterListType]):
         ...
 
     @classmethod
-    def from_yaml(
+    def get_name(
         cls,
+        name: str,
         yaml_data: Dict[str, Any],
         code_model: "CodeModel",
         client: "Client",
-    ):
-        # when combine embedded builders into one operation file, we need to avoid duplicated build function name.
-        # So add operation group name is effective method
+    ) -> str:
         additional_mark = ""
         if (
             code_model.options["combine_operation_files"]
@@ -146,10 +145,21 @@ class RequestBuilderBase(BaseBuilder[ParameterListType]):
         names = [
             "build",
             additional_mark,
-            yaml_data["name"],
+            name,
             "request",
         ]
-        name = "_".join([n for n in names if n])
+        return "_".join([n for n in names if n])
+
+    @classmethod
+    def from_yaml(
+        cls,
+        yaml_data: Dict[str, Any],
+        code_model: "CodeModel",
+        client: "Client",
+    ):
+        # when combine embedded builders into one operation file, we need to avoid duplicated build function name.
+        # So add operation group name is effective method
+
         overloads = [
             RequestBuilder.from_yaml(rb_yaml_data, code_model, client)
             for rb_yaml_data in yaml_data.get("overloads", [])
@@ -160,7 +170,7 @@ class RequestBuilderBase(BaseBuilder[ParameterListType]):
             yaml_data=yaml_data,
             code_model=code_model,
             client=client,
-            name=name,
+            name=cls.get_name(yaml_data["name"], yaml_data, code_model, client),
             parameters=parameter_list,
             overloads=overloads,
         )

--- a/packages/autorest.python/autorest/codegen/models/request_builder.py
+++ b/packages/autorest.python/autorest/codegen/models/request_builder.py
@@ -50,11 +50,11 @@ class RequestBuilderBase(BaseBuilder[ParameterListType]):
             name=name,
             parameters=parameters,
             overloads=overloads,
-            want_tracing=False,
         )
         self.overloads: List["RequestBuilder"] = overloads or []
         self.url: str = yaml_data["url"]
         self.method: str = yaml_data["method"]
+        self.want_tracing = False
 
     def response_type_annotation(self, **kwargs) -> str:
         return "HttpRequest"

--- a/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
@@ -1477,7 +1477,7 @@ class _LROOperationSerializer(_OperationSerializer[LROOperationType]):
         )
         retval.append("if cont_token is None:")
         retval.append(
-            f"    raw_result = {self._call_method}self.{builder.name}("
+            f"    raw_result = {self._call_method}self.{builder.initial_operation.name}("
             f"{''  if builder.lro_response and builder.lro_response.type else '  # type: ignore'}"
         )
         retval.extend(

--- a/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
@@ -1477,7 +1477,7 @@ class _LROOperationSerializer(_OperationSerializer[LROOperationType]):
         )
         retval.append("if cont_token is None:")
         retval.append(
-            f"    raw_result = {self._call_method}self.{builder.initial_operation.name}("
+            f"    raw_result = {self._call_method}self.{builder.name}("
             f"{''  if builder.lro_response and builder.lro_response.type else '  # type: ignore'}"
         )
         retval.extend(

--- a/packages/autorest.python/autorest/codegen/templates/lro_operation.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/lro_operation.py.jinja2
@@ -1,6 +1,6 @@
 {% import 'operation_tools.jinja2' as op_tools with context %}
 {# actual template starts here #}
-{% if operation.overloads and operation.public %}
+{% if operation.overloads and operation.include_documentation %}
 {{ op_tools.generate_overloads(operation_serializer, operation) }}
 {% endif %}
 {{ operation_serializer.method_signature_and_response_type_annotation(operation) }}

--- a/packages/autorest.python/autorest/codegen/templates/lro_paging_operation.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/lro_paging_operation.py.jinja2
@@ -1,7 +1,7 @@
 {% import 'operation_tools.jinja2' as op_tools with context %}
 {% import 'keywords.jinja2' as keywords with context %}
 {# actual template starts here #}
-{% if operation.overloads and operation.public %}
+{% if operation.overloads and operation.include_documentation %}
 {{ op_tools.generate_overloads(operation_serializer, operation) }}
 {% endif %}
 {{ operation_serializer.method_signature_and_response_type_annotation(operation) }}

--- a/packages/autorest.python/autorest/codegen/templates/operation.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/operation.py.jinja2
@@ -1,11 +1,11 @@
 {% import 'keywords.jinja2' as keywords with context %}
 {% import 'operation_tools.jinja2' as op_tools %}
 {# actual template starts here #}
-{% if operation.overloads and operation.public %}
+{% if operation.overloads and operation.include_documentation %}
 {{ op_tools.generate_overloads(operation_serializer, operation) }}
 {% endif %}
 {{ operation_serializer.method_signature_and_response_type_annotation(operation) }}
-{% if operation.public %}
+{% if operation.include_documentation %}
     {{ op_tools.description(operation, operation_serializer) | indent }}{% endif %}
     {% if not operation.abstract %}
         {% if operation.deprecated %}

--- a/packages/autorest.python/autorest/codegen/templates/paging_operation.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/paging_operation.py.jinja2
@@ -1,10 +1,10 @@
 {% import 'operation_tools.jinja2' as op_tools with context %}
 {# actual template starts here #}
-{% if operation.overloads and operation.public %}
+{% if operation.overloads and operation.include_documentation %}
 {{ op_tools.generate_overloads(operation_serializer, operation) }}
 {% endif %}
 {{ operation_serializer.method_signature_and_response_type_annotation(operation) }}
-{% if operation.public %}
+{% if operation.include_documentation %}
     {{ op_tools.description(operation, operation_serializer) | indent }}{% endif %}
     {% if not operation.abstract %}
         {% if operation.deprecated %}

--- a/packages/autorest.python/autorest/preprocess/__init__.py
+++ b/packages/autorest.python/autorest/preprocess/__init__.py
@@ -68,6 +68,8 @@ def add_overload(
     overload["bodyParameter"]["type"] = body_type
     overload["bodyParameter"]["defaultToUnsetSentinel"] = False
     overload["overloads"] = []
+    if yaml_data.get("initialOperation"):
+        overload["initialOperation"] = yaml_data["initialOperation"]
 
     if for_flatten_params:
         overload["bodyParameter"]["flattened"] = True
@@ -320,9 +322,15 @@ class PreProcessPlugin(YamlUpdatePlugin):  # pylint: disable=abstract-method
         is_overload: bool = False,
     ) -> None:
         self.update_operation(code_model, yaml_data, is_overload=is_overload)
+        self.update_operation(
+            code_model, yaml_data["initialOperation"], is_overload=is_overload
+        )
         self._update_lro_operation_helper(yaml_data)
         for overload in yaml_data.get("overloads", []):
             self._update_lro_operation_helper(overload)
+            self.update_operation(
+                code_model, overload["initialOperation"], is_overload=True
+            )
 
     def update_paging_operation(
         self,

--- a/packages/cadl-python/src/emitter.ts
+++ b/packages/cadl-python/src/emitter.ts
@@ -623,6 +623,9 @@ function emitLroOperation(
 ): Record<string, any>[] {
     const retval = [];
     for (const emittedOperation of emitBasicOperation(context, operation, operationGroupName)) {
+        const initialOperation = JSON.parse(JSON.stringify(emittedOperation));
+        initialOperation["wantTracing"] = false;
+        initialOperation["name"] += "_initial"
         addLroInformation(emittedOperation);
         retval.push(emittedOperation);
     }
@@ -725,6 +728,7 @@ function emitBasicOperation(
             isOverload: false,
             overloads: [],
             apiVersions: [getAddedOnVersion(context, operation)],
+            wantTracing: true,
         },
     ];
 }

--- a/packages/cadl-python/src/emitter.ts
+++ b/packages/cadl-python/src/emitter.ts
@@ -574,7 +574,7 @@ function emitResponse(
     };
 }
 
-function emitOperation(context: DpgContext, operation: Operation, operationGroupName: string): Record<string, any> {
+function emitOperation(context: DpgContext, operation: Operation, operationGroupName: string): Record<string, any>[] {
     const lro = isLro(operation);
     const paging = getPagedResult(context.program, operation);
     if (lro && paging) {
@@ -605,35 +605,48 @@ function emitLroPagingOperation(
     context: DpgContext,
     operation: Operation,
     operationGroupName: string,
-): Record<string, any> {
-    const emittedOperation = emitBasicOperation(context, operation, operationGroupName);
-    addLroInformation(emittedOperation);
-    addPagingInformation(context, operation, emittedOperation);
-    emittedOperation["discriminator"] = "lropaging";
-    return emittedOperation;
+): Record<string, any>[] {
+    const retval: Record<string, any>[] = [];
+    for (const emittedOperation of emitBasicOperation(context, operation, operationGroupName)) {
+        addLroInformation(emittedOperation);
+        addPagingInformation(context, operation, emittedOperation);
+        emittedOperation["discriminator"] = "lropaging";
+        retval.push(emittedOperation);
+    }
+    return retval;
 }
 
-function emitLroOperation(context: DpgContext, operation: Operation, operationGroupName: string): Record<string, any> {
-    const emittedOperation = emitBasicOperation(context, operation, operationGroupName);
-    addLroInformation(emittedOperation);
-    return emittedOperation;
+function emitLroOperation(
+    context: DpgContext,
+    operation: Operation,
+    operationGroupName: string,
+): Record<string, any>[] {
+    const retval = [];
+    for (const emittedOperation of emitBasicOperation(context, operation, operationGroupName)) {
+        addLroInformation(emittedOperation);
+        retval.push(emittedOperation);
+    }
+    return retval;
 }
 
 function emitPagingOperation(
     context: DpgContext,
     operation: Operation,
     operationGroupName: string,
-): Record<string, any> {
-    const emittedOperation = emitBasicOperation(context, operation, operationGroupName);
-    addPagingInformation(context, operation, emittedOperation);
-    return emittedOperation;
+): Record<string, any>[] {
+    const retval = [];
+    for (const emittedOperation of emitBasicOperation(context, operation, operationGroupName)) {
+        addPagingInformation(context, operation, emittedOperation);
+        retval.push(emittedOperation);
+    }
+    return retval;
 }
 
 function emitBasicOperation(
     context: DpgContext,
     operation: Operation,
     operationGroupName: string,
-): Record<string, any> {
+): Record<string, any>[] {
     // Set up parameters for operation
     const parameters: Record<string, any>[] = [];
     if (endpointPathParameters) {
@@ -695,23 +708,25 @@ function emitBasicOperation(
         }
     }
     const name = camelToSnakeCase(getLibraryName(context, operation));
-    return {
-        name: name,
-        description: getDocStr(context, operation),
-        summary: getSummary(context.program, operation),
-        url: httpOperation.path,
-        method: httpOperation.verb.toUpperCase(),
-        parameters: parameters,
-        bodyParameter: bodyParameter,
-        responses: responses,
-        exceptions: exceptions,
-        groupName: operationGroupName,
-        addedOn: getAddedOnVersion(context, operation),
-        discriminator: "basic",
-        isOverload: false,
-        overloads: [],
-        apiVersions: [getAddedOnVersion(context, operation)],
-    };
+    return [
+        {
+            name: name,
+            description: getDocStr(context, operation),
+            summary: getSummary(context.program, operation),
+            url: httpOperation.path,
+            method: httpOperation.verb.toUpperCase(),
+            parameters: parameters,
+            bodyParameter: bodyParameter,
+            responses: responses,
+            exceptions: exceptions,
+            groupName: operationGroupName,
+            addedOn: getAddedOnVersion(context, operation),
+            discriminator: "basic",
+            isOverload: false,
+            overloads: [],
+            apiVersions: [getAddedOnVersion(context, operation)],
+        },
+    ];
 }
 
 function isReadOnly(context: DpgContext, type: ModelProperty): boolean {
@@ -1103,10 +1118,10 @@ function emitType(context: DpgContext, type: EmitterType): Record<string, any> {
 function emitOperationGroups(context: DpgContext, client: Client): Record<string, any>[] {
     const operationGroups: Record<string, any>[] = [];
     for (const operationGroup of listOperationGroups(context, client)) {
-        const operations: Record<string, any>[] = [];
+        let operations: Record<string, any>[] = [];
         const name = operationGroup.type.name;
         for (const operation of listOperationsInOperationGroup(context, operationGroup)) {
-            operations.push(emitOperation(context, operation, name));
+            operations = operations.concat(emitOperation(context, operation, name));
         }
         operationGroups.push({
             className: name,
@@ -1114,9 +1129,9 @@ function emitOperationGroups(context: DpgContext, client: Client): Record<string
             operations: operations,
         });
     }
-    const clientOperations: Record<string, any>[] = [];
+    let clientOperations: Record<string, any>[] = [];
     for (const operation of listOperationsInOperationGroup(context, client)) {
-        clientOperations.push(emitOperation(context, operation, ""));
+        clientOperations = clientOperations.concat(emitOperation(context, operation, ""));
     }
     if (clientOperations.length > 0) {
         operationGroups.push({


### PR DESCRIPTION
Currently we create the initial operation from a defined LRO operation. This means that the initial operation is closely tied to the initial LRO operation, and we don't really have the flexibility to have, say, a different return type. In this PR, I'm creating an initial operation during serialization, and with Mark's new LRO ability, we can assign different parameters / return types to these two different operations in CADL