### PR TITLE
[Mgmt][Multiapi] fix typing_definitions for `JSON`

### DIFF
--- a/packages/autorest.python/autorest/codegen/serializers/import_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/import_serializer.py
@@ -108,8 +108,8 @@ class FileImportSerializer:
                 "typing", "TYPE_CHECKING", ImportType.STDLIB
             )
 
-    def _get_typing_definitions(self) -> str:
-        def declare_defintion(
+    def get_typing_definitions(self) -> str:
+        def declare_definition(
             type_name: str, type_definition: TypeDefinition
         ) -> List[str]:
             ret: List[str] = []
@@ -125,7 +125,7 @@ class FileImportSerializer:
             return ""
         declarations: List[str] = [""]
         for type_name, value in self.file_import.type_definitions.items():
-            declarations.extend(declare_defintion(type_name, value))
+            declarations.extend(declare_definition(type_name, value))
         return "\n".join(declarations)
 
     def __str__(self) -> str:
@@ -151,4 +151,4 @@ class FileImportSerializer:
             typing_imports += "\n\n    ".join(
                 _get_import_clauses(typing_imports_list, "\n    ")
             )
-        return regular_imports + typing_imports + self._get_typing_definitions()
+        return regular_imports + typing_imports + self.get_typing_definitions()

--- a/packages/autorest.python/autorest/codegen/templates/metadata.json.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/metadata.json.jinja2
@@ -115,6 +115,8 @@
     "operation_mixins": {
         "sync_imports": {{ str(sync_mixin_imports) | tojson }},
         "async_imports": {{ str(async_mixin_imports) | tojson }},
+        "sync_mixin_typing_definitions": {{ str(sync_mixin_typing_definitions) | tojson }},
+        "async_mixin_typing_definitions": {{ str(async_mixin_typing_definitions) | tojson }},
         "operations": {
             {% for operation in mixin_operations %}
             {{ operation.name | tojson }} : {

--- a/packages/autorest.python/autorest/multiapi/models/operation_mixin_group.py
+++ b/packages/autorest.python/autorest/multiapi/models/operation_mixin_group.py
@@ -31,6 +31,20 @@ class OperationMixinGroup:
                 imports.merge(current_version_imports)
         return imports
 
+    def typing_definitions(self, async_mode: bool) -> str:
+        key = (
+            "sync_mixin_typing_definitions"
+            if async_mode
+            else "async_mixin_typing_definitions"
+        )
+        origin = "".join(
+            [
+                metadata_json.get("operation_mixins", {}).get(key, "")
+                for metadata_json in self.version_path_to_metadata.values()
+            ]
+        )
+        return "\n".join(set(origin.split("\n")))
+
     def _use_metadata_of_default_api_version(
         self, mixin_operations: List[MixinOperation]
     ) -> List[MixinOperation]:

--- a/packages/autorest.python/autorest/multiapi/serializers/__init__.py
+++ b/packages/autorest.python/autorest/multiapi/serializers/__init__.py
@@ -101,7 +101,8 @@ class MultiAPISerializer(ReaderAndWriter):  # pylint: disable=abstract-method
         # serialize mixins
         if code_model.operation_mixin_group.mixin_operations:
             imports = FileImportSerializer(
-                code_model.operation_mixin_group.imports(async_mode)
+                code_model.operation_mixin_group.imports(async_mode),
+                code_model.operation_mixin_group.typing_definitions(async_mode),
             )
             self.write_file(
                 _get_file_path("_operations_mixin", async_mode),

--- a/packages/autorest.python/autorest/multiapi/serializers/import_serializer.py
+++ b/packages/autorest.python/autorest/multiapi/serializers/import_serializer.py
@@ -135,8 +135,9 @@ def _get_import_clauses(
 
 
 class FileImportSerializer:
-    def __init__(self, file_import: FileImport) -> None:
+    def __init__(self, file_import: FileImport, typing_definitions: str = "") -> None:
         self._file_import = file_import
+        self._typing_definitions = typing_definitions
 
     def _switch_typing_section_key(self, new_key: TypingSection):
         switched_dictionary = {}
@@ -193,4 +194,4 @@ class FileImportSerializer:
                 _get_import_clauses(typing_imports_dict, "\n    ")
             )
 
-        return regular_imports + typing_imports
+        return regular_imports + typing_imports + self._typing_definitions

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v1/_metadata.json
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/_metadata.json
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/_metadata.json
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.paging\": [\"ItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.async_paging\": [\"AsyncItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_paging" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v2/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/v3/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.paging\": [\"ItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.async_paging\": [\"AsyncItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_paging" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v2/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/v3/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.paging\": [\"ItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.async_paging\": [\"AsyncItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_paging" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v1/_metadata.json
@@ -95,6 +95,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/v2/_metadata.json
@@ -95,6 +95,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v2/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/v3/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.paging\": [\"ItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.async_paging\": [\"AsyncItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_paging" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiKeywordOnly/multiapikeywordonly/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiKeywordOnly/multiapikeywordonly/v1/_metadata.json
@@ -95,6 +95,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiKeywordOnly/multiapikeywordonly/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiKeywordOnly/multiapikeywordonly/v2/_metadata.json
@@ -95,6 +95,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v2/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/v3/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.paging\": [\"ItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.async_paging\": [\"AsyncItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_paging" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v1/_metadata.json
@@ -97,6 +97,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"LROPoller\"], \"azure.core.paging\": [\"ItemPaged\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"IO\", \"Optional\", \"Union\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.polling\": [\"AsyncLROPoller\"], \"azure.core.async_paging\": [\"AsyncItemPaged\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v2/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\".\": [[\"models\", \"_models\"]]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\"]}}, \"regular\": {\"stdlib\": {\"typing\": [\"Optional\"]}, \"local\": {\"..\": [[\"models\", \"_models\"]]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_one" : {
                 "sync": {

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/_metadata.json
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/v3/_metadata.json
@@ -98,6 +98,8 @@
     "operation_mixins": {
         "sync_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"Iterable\"]}}, \"regular\": {\"local\": {\".\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.paging\": [\"ItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
         "async_imports": "{\"conditional\": {\"stdlib\": {\"typing\": [\"Any\", \"AsyncIterable\"]}}, \"regular\": {\"local\": {\"..\": [[\"models\", \"_models\"]]}, \"azurecore\": {\"azure.core.async_paging\": [\"AsyncItemPaged\"]}, \"stdlib\": {\"typing\": [\"Optional\"]}}}",
+        "sync_mixin_typing_definitions": "",
+        "async_mixin_typing_definitions": "",
         "operations": {
             "test_paging" : {
                 "sync": {


### PR DESCRIPTION
supplement for https://github.com/Azure/autorest.python/pull/1774.
Test scenario: https://github.com/Azure/azure-rest-api-specs/tree/web-repro-error
`autorest D:\dev2\azure-rest-api-specs\specification\storage\resource-manager\readme.md --python --python-sdks-folder=D:\dev2\azure-sdk-for-python\sdk --version-tolerant=false  --use=@autorest\python@6.4.2 --use=@autorest\modelerfour@4.24.3 --version=3.9.2 --include-x-ms-examples-original-file --generate-sample `