### PR TITLE
fix breaking for `only-path-and-body-params-positional`

### DIFF
--- a/packages/autorest.python/ChangeLog.md
+++ b/packages/autorest.python/ChangeLog.md
@@ -15,6 +15,8 @@
 **Bug Fixes**
 
 - Switch typing for `api-version` parameters from a literal to a string #1796
+- Avoid `--only-path-and-body-params-positional` to influence order of client parameters for Mgmt SDK #1804
+- Fix generation failure for scenario where lropaging and overload exist together #1804
 
 ### 2023-03-14 - 6.4.5
 

--- a/packages/autorest.python/autorest/m4reformatter/__init__.py
+++ b/packages/autorest.python/autorest/m4reformatter/__init__.py
@@ -430,8 +430,13 @@ class M4Reformatter(
 
     @property
     def only_path_and_body_parameters_positional(self) -> bool:
-        return self.version_tolerant or bool(
-            self._autorestapi.get_boolean_value("only-path-and-body-params-positional")
+        return self.version_tolerant or (
+            bool(
+                self._autorestapi.get_boolean_value(
+                    "only-path-and-body-params-positional"
+                )
+            )
+            and not bool(self._autorestapi.get_boolean_value("azure-arm"))
         )
 
     @property

--- a/packages/autorest.python/autorest/preprocess/__init__.py
+++ b/packages/autorest.python/autorest/preprocess/__init__.py
@@ -80,6 +80,8 @@ def add_overload(
     # for yaml sync, we need to make sure all of the responses, parameters, and exceptions' types have the same yaml id
     for overload_p, original_p in zip(overload["parameters"], yaml_data["parameters"]):
         overload_p["type"] = original_p["type"]
+    if yaml_data.get("itemType"):
+        overload["itemType"] = yaml_data["itemType"]
     update_overload_section(overload, yaml_data, "responses")
     update_overload_section(overload, yaml_data, "exceptions")
 


### PR DESCRIPTION
https://github.com/Azure/sdk-release-request/issues/3959
The PR is to fix 2 problems:
(1) `only-path-and-body-params-positional` will influence client parameter order for mgmt SDK: https://github.com/Azure/azure-sdk-for-python/pull/29514/files#diff-9c08a8e3ef392d15c9aed079c9baa28d2193fb41648989f9c10575980a11b8ab
(2) lropaging with overload will fail which is related with https://github.com/Azure/autorest.python/pull/1786/files#diff-de6a2b913d2b78fb77637efb9be766dd8b5225c717842d62d2198ba1e6b91e7b. Here is the simple scenario to reproduce: 
https://github.com/Azure/azure-rest-api-specs/pull/23252