### PR TITLE
make operations abstract if multiple content types

### DIFF
--- a/packages/typespec-python/src/emitter.ts
+++ b/packages/typespec-python/src/emitter.ts
@@ -349,9 +349,6 @@ function emitBodyParameter(context: DpgContext, httpOperation: HttpOperation): B
     if (contentTypes.length === 0) {
         contentTypes = ["application/json"];
     }
-    if (contentTypes.length !== 1) {
-        throw Error("Currently only one kind of content-type!");
-    }
     const type = getType(context, getBodyType(context, httpOperation));
 
     if (type.type === "model" && type.name === "") {
@@ -646,6 +643,11 @@ function emitPagingOperation(
     return retval;
 }
 
+function isAbstract(operation: HttpOperation): boolean {
+    const body = operation.parameters.body;
+    return body !== undefined && body.contentTypes.length > 1;
+}
+
 function emitBasicOperation(
     context: DpgContext,
     operation: Operation,
@@ -731,6 +733,7 @@ function emitBasicOperation(
             apiVersions: [getAddedOnVersion(context, operation)],
             wantTracing: true,
             exposeStreamKeyword: true,
+            abstract: isAbstract(httpOperation),
         },
     ];
 }


### PR DESCRIPTION
Right now we raise from the emitter if we see multiple content types. Instead we want to generate abstract operations and have sdk authors handauthor them for now

cc @mpodwysocki 