### PR TITLE
use getAddedOnVersions

### DIFF
--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release
 
+## 2023-03-23 - 0.7.2
+
+**Other Changes**
+
+- Switch from `@typespec/versioning`'s `getAddedOnVersion` to `getAddedOnVersions` because it's getting deprecated #1808
+
 ## 2023-03-23 - 0.7.1
 
 **Bug Fixes**

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-python",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "Microsoft Corporation",
   "description": "Cadl emitter for Python SDKs",
   "homepage": "https://github.com/Azure/autorest.python",

--- a/packages/typespec-python/src/emitter.ts
+++ b/packages/typespec-python/src/emitter.ts
@@ -53,7 +53,7 @@ import {
     HttpOperation,
     isHeader,
 } from "@typespec/http";
-import { getAddedOn } from "@typespec/versioning";
+import { getAddedOnVersions } from "@typespec/versioning";
 import {
     Client,
     listClients,
@@ -268,7 +268,11 @@ function getType(context: DpgContext, type: EmitterType): any {
 
 // To pass the yaml dump
 function getAddedOnVersion(context: DpgContext, t: Type): string | undefined {
-    return getAddedOn(context.program as any, t as any)?.value;
+    const versions = getAddedOnVersions(context.program as any, t as any);
+    if (versions !== undefined && versions.length > 0) {
+        return versions[0].value;
+    }
+    return undefined;
 }
 
 type ParamBase = {


### PR DESCRIPTION
getAddedOnVersion from the versioning library is getting deprecated, so switching to `getAddedOnVersions` to avoid all of the warnings