### PR TITLE
add record unknown test

### DIFF
--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/_client.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/_client.py
@@ -29,6 +29,7 @@ from .operations import (
     IntOperations,
     ModelOperations,
     NeverOperations,
+    RecordUnknownOperations,
     StringOperations,
 )
 
@@ -67,6 +68,8 @@ class ValueTypesClient:  # pylint: disable=client-accepts-api-version-keyword,to
     :vartype dictionary_string: typetest.property.valuetypes.operations.DictionaryStringOperations
     :ivar never: NeverOperations operations
     :vartype never: typetest.property.valuetypes.operations.NeverOperations
+    :ivar record_unknown: RecordUnknownOperations operations
+    :vartype record_unknown: typetest.property.valuetypes.operations.RecordUnknownOperations
     """
 
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=missing-client-constructor-parameter-credential
@@ -98,6 +101,7 @@ class ValueTypesClient:  # pylint: disable=client-accepts-api-version-keyword,to
             self._client, self._config, self._serialize, self._deserialize
         )
         self.never = NeverOperations(self._client, self._config, self._serialize, self._deserialize)
+        self.record_unknown = RecordUnknownOperations(self._client, self._config, self._serialize, self._deserialize)
 
     def send_request(self, request: HttpRequest, **kwargs: Any) -> HttpResponse:
         """Runs the network request through the client's chained policies.

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/_client.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/_client.py
@@ -29,6 +29,7 @@ from .operations import (
     IntOperations,
     ModelOperations,
     NeverOperations,
+    RecordUnknownOperations,
     StringOperations,
 )
 
@@ -69,6 +70,8 @@ class ValueTypesClient:  # pylint: disable=client-accepts-api-version-keyword,to
      typetest.property.valuetypes.aio.operations.DictionaryStringOperations
     :ivar never: NeverOperations operations
     :vartype never: typetest.property.valuetypes.aio.operations.NeverOperations
+    :ivar record_unknown: RecordUnknownOperations operations
+    :vartype record_unknown: typetest.property.valuetypes.aio.operations.RecordUnknownOperations
     """
 
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=missing-client-constructor-parameter-credential
@@ -100,6 +103,7 @@ class ValueTypesClient:  # pylint: disable=client-accepts-api-version-keyword,to
             self._client, self._config, self._serialize, self._deserialize
         )
         self.never = NeverOperations(self._client, self._config, self._serialize, self._deserialize)
+        self.record_unknown = RecordUnknownOperations(self._client, self._config, self._serialize, self._deserialize)
 
     def send_request(self, request: HttpRequest, **kwargs: Any) -> Awaitable[AsyncHttpResponse]:
         """Runs the network request through the client's chained policies.

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/__init__.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/__init__.py
@@ -21,6 +21,7 @@ from ._operations import CollectionsIntOperations
 from ._operations import CollectionsModelOperations
 from ._operations import DictionaryStringOperations
 from ._operations import NeverOperations
+from ._operations import RecordUnknownOperations
 
 from ._patch import __all__ as _patch_all
 from ._patch import *  # pylint: disable=unused-wildcard-import
@@ -42,6 +43,7 @@ __all__ = [
     "CollectionsModelOperations",
     "DictionaryStringOperations",
     "NeverOperations",
+    "RecordUnknownOperations",
 ]
 __all__.extend([p for p in _patch_all if p not in __all__])
 _patch_sdk()

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/_operations.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/_operations.py
@@ -56,6 +56,8 @@ from ...operations._operations import (
     build_model_put_request,
     build_never_get_request,
     build_never_put_request,
+    build_record_unknown_get_request,
+    build_record_unknown_put_request,
     build_string_get_request,
     build_string_put_request,
 )
@@ -2780,6 +2782,188 @@ class NeverOperations:
             _content = json.dumps(body, cls=AzureJSONEncoder)  # type: ignore
 
         request = build_never_put_request(
+            content_type=content_type,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        request.url = self._client.format_url(request.url)
+
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # pylint: disable=protected-access
+            request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [204]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response)
+
+        if cls:
+            return cls(pipeline_response, None, {})
+
+
+class RecordUnknownOperations:
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~typetest.property.valuetypes.aio.ValueTypesClient`'s
+        :attr:`record_unknown` attribute.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        input_args = list(args)
+        self._client = input_args.pop(0) if input_args else kwargs.pop("client")
+        self._config = input_args.pop(0) if input_args else kwargs.pop("config")
+        self._serialize = input_args.pop(0) if input_args else kwargs.pop("serializer")
+        self._deserialize = input_args.pop(0) if input_args else kwargs.pop("deserializer")
+
+    @distributed_trace_async
+    async def get(self, **kwargs: Any) -> _models.RecordUnknownProperty:
+        """Get call.
+
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: RecordUnknownProperty. The RecordUnknownProperty is compatible with MutableMapping
+        :rtype: ~typetest.property.valuetypes.models.RecordUnknownProperty
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.RecordUnknownProperty] = kwargs.pop("cls", None)
+
+        request = build_record_unknown_get_request(
+            headers=_headers,
+            params=_params,
+        )
+        request.url = self._client.format_url(request.url)
+
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = await self._client._pipeline.run(  # pylint: disable=protected-access
+            request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response)
+
+        if _stream:
+            deserialized = response.iter_bytes()
+        else:
+            deserialized = _deserialize(_models.RecordUnknownProperty, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    async def put(  # pylint: disable=inconsistent-return-statements
+        self, body: _models.RecordUnknownProperty, *, content_type: str = "application/json", **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Required.
+        :type body: ~typetest.property.valuetypes.models.RecordUnknownProperty
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def put(  # pylint: disable=inconsistent-return-statements
+        self, body: JSON, *, content_type: str = "application/json", **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Required.
+        :type body: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    async def put(  # pylint: disable=inconsistent-return-statements
+        self, body: IO, *, content_type: str = "application/json", **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Required.
+        :type body: IO
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace_async
+    async def put(  # pylint: disable=inconsistent-return-statements
+        self, body: Union[_models.RecordUnknownProperty, JSON, IO], **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Is one of the following types: RecordUnknownProperty, JSON, IO Required.
+        :type body: ~typetest.property.valuetypes.models.RecordUnknownProperty or JSON or IO
+        :keyword content_type: Body parameter Content-Type. Known values are: application/json. Default
+         value is None.
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[None] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(body, (IOBase, bytes)):
+            _content = body
+        else:
+            _content = json.dumps(body, cls=AzureJSONEncoder)  # type: ignore
+
+        request = build_record_unknown_put_request(
             content_type=content_type,
             content=_content,
             headers=_headers,

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/models/__init__.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/models/__init__.py
@@ -21,6 +21,7 @@ from ._models import InnerModel
 from ._models import IntProperty
 from ._models import ModelProperty
 from ._models import NeverProperty
+from ._models import RecordUnknownProperty
 from ._models import StringProperty
 
 from ._enums import FixedInnerEnum
@@ -45,6 +46,7 @@ __all__ = [
     "IntProperty",
     "ModelProperty",
     "NeverProperty",
+    "RecordUnknownProperty",
     "StringProperty",
     "FixedInnerEnum",
     "InnerEnum",

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/models/_models.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/models/_models.py
@@ -456,6 +456,37 @@ class NeverProperty(_model_base.Model):
     """Model with a property never. (This property should not be included)."""
 
 
+class RecordUnknownProperty(_model_base.Model):
+    """Model with Record:code:`<unknown>` property, and the data is a json object.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar property: Property. Required.
+    :vartype property: any
+    """
+
+    property: Any = rest_field()
+    """Property. Required."""
+
+    @overload
+    def __init__(
+        self,
+        *,
+        property: Any,  # pylint: disable=redefined-builtin
+    ):
+        ...
+
+    @overload
+    def __init__(self, mapping: Mapping[str, Any]):
+        """
+        :param mapping: raw JSON to initialize the model.
+        :type mapping: Mapping[str, Any]
+        """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pylint: disable=useless-super-delegation
+        super().__init__(*args, **kwargs)
+
+
 class StringProperty(_model_base.Model):
     """Model with a string property.
 

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/models/_models.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/models/_models.py
@@ -462,17 +462,17 @@ class RecordUnknownProperty(_model_base.Model):
     All required parameters must be populated in order to send to Azure.
 
     :ivar property: Property. Required.
-    :vartype property: any
+    :vartype property: dict[str, any]
     """
 
-    property: Any = rest_field()
+    property: Dict[str, Any] = rest_field()
     """Property. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        property: Any,  # pylint: disable=redefined-builtin
+        property: Dict[str, Any],  # pylint: disable=redefined-builtin
     ):
         ...
 

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/__init__.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/__init__.py
@@ -21,6 +21,7 @@ from ._operations import CollectionsIntOperations
 from ._operations import CollectionsModelOperations
 from ._operations import DictionaryStringOperations
 from ._operations import NeverOperations
+from ._operations import RecordUnknownOperations
 
 from ._patch import __all__ as _patch_all
 from ._patch import *  # pylint: disable=unused-wildcard-import
@@ -42,6 +43,7 @@ __all__ = [
     "CollectionsModelOperations",
     "DictionaryStringOperations",
     "NeverOperations",
+    "RecordUnknownOperations",
 ]
 __all__.extend([p for p in _patch_all if p not in __all__])
 _patch_sdk()

--- a/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/_operations.py
+++ b/packages/typespec-python/test/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/_operations.py
@@ -461,6 +461,34 @@ def build_never_put_request(**kwargs: Any) -> HttpRequest:
     return HttpRequest(method="PUT", url=_url, headers=_headers, **kwargs)
 
 
+def build_record_unknown_get_request(**kwargs: Any) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/type/property/value-types/record/unknown"
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, headers=_headers, **kwargs)
+
+
+def build_record_unknown_put_request(**kwargs: Any) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    # Construct URL
+    _url = "/type/property/value-types/record/unknown"
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+
+    return HttpRequest(method="PUT", url=_url, headers=_headers, **kwargs)
+
+
 class BooleanOperations:
     """
     .. warning::
@@ -3172,6 +3200,188 @@ class NeverOperations:
             _content = json.dumps(body, cls=AzureJSONEncoder)  # type: ignore
 
         request = build_never_put_request(
+            content_type=content_type,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        request.url = self._client.format_url(request.url)
+
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [204]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response)
+
+        if cls:
+            return cls(pipeline_response, None, {})
+
+
+class RecordUnknownOperations:
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~typetest.property.valuetypes.ValueTypesClient`'s
+        :attr:`record_unknown` attribute.
+    """
+
+    def __init__(self, *args, **kwargs):
+        input_args = list(args)
+        self._client = input_args.pop(0) if input_args else kwargs.pop("client")
+        self._config = input_args.pop(0) if input_args else kwargs.pop("config")
+        self._serialize = input_args.pop(0) if input_args else kwargs.pop("serializer")
+        self._deserialize = input_args.pop(0) if input_args else kwargs.pop("deserializer")
+
+    @distributed_trace
+    def get(self, **kwargs: Any) -> _models.RecordUnknownProperty:
+        """Get call.
+
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: RecordUnknownProperty. The RecordUnknownProperty is compatible with MutableMapping
+        :rtype: ~typetest.property.valuetypes.models.RecordUnknownProperty
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[_models.RecordUnknownProperty] = kwargs.pop("cls", None)
+
+        request = build_record_unknown_get_request(
+            headers=_headers,
+            params=_params,
+        )
+        request.url = self._client.format_url(request.url)
+
+        _stream = kwargs.pop("stream", False)
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response)
+
+        if _stream:
+            deserialized = response.iter_bytes()
+        else:
+            deserialized = _deserialize(_models.RecordUnknownProperty, response.json())
+
+        if cls:
+            return cls(pipeline_response, deserialized, {})  # type: ignore
+
+        return deserialized  # type: ignore
+
+    @overload
+    def put(  # pylint: disable=inconsistent-return-statements
+        self, body: _models.RecordUnknownProperty, *, content_type: str = "application/json", **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Required.
+        :type body: ~typetest.property.valuetypes.models.RecordUnknownProperty
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def put(  # pylint: disable=inconsistent-return-statements
+        self, body: JSON, *, content_type: str = "application/json", **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Required.
+        :type body: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @overload
+    def put(  # pylint: disable=inconsistent-return-statements
+        self, body: IO, *, content_type: str = "application/json", **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Required.
+        :type body: IO
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    def put(  # pylint: disable=inconsistent-return-statements
+        self, body: Union[_models.RecordUnknownProperty, JSON, IO], **kwargs: Any
+    ) -> None:
+        """Put operation.
+
+        :param body: body. Is one of the following types: RecordUnknownProperty, JSON, IO Required.
+        :type body: ~typetest.property.valuetypes.models.RecordUnknownProperty or JSON or IO
+        :keyword content_type: Body parameter Content-Type. Known values are: application/json. Default
+         value is None.
+        :paramtype content_type: str
+        :keyword bool stream: Whether to stream the response of this operation. Defaults to False. You
+         will have to context manage the returned stream.
+        :return: None
+        :rtype: None
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        error_map = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[None] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _content = None
+        if isinstance(body, (IOBase, bytes)):
+            _content = body
+        else:
+            _content = json.dumps(body, cls=AzureJSONEncoder)  # type: ignore
+
+        request = build_record_unknown_put_request(
             content_type=content_type,
             content=_content,
             headers=_headers,

--- a/packages/typespec-python/test/mock_api_tests/asynctests/test_typetest_property_valuetypes_async.py
+++ b/packages/typespec-python/test/mock_api_tests/asynctests/test_typetest_property_valuetypes_async.py
@@ -17,7 +17,8 @@ async def client():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "og_name,val", [
+    "og_name,val",
+    [
         ("boolean", True),
         ("string", "hello"),
         ("bytes", "aGVsbG8sIHdvcmxkIQ=="),
@@ -27,12 +28,23 @@ async def client():
         ("duration", "P123DT22H14M12.011S"),
         ("enum", "ValueOne"),
         ("extensible_enum", "UnknownValue"),
-        ("model", {'property': 'hello'}),
-        ("collections_string", ['hello', 'world']),
+        ("model", {"property": "hello"}),
+        ("collections_string", ["hello", "world"]),
         ("collections_int", [1, 2]),
-        ("collections_model", [{'property': 'hello'}, {'property': 'world'}]),
-        ("dictionary_string", {'k1': 'hello', 'k2': 'world'}),
-    ]
+        ("collections_model", [{"property": "hello"}, {"property": "world"}]),
+        ("dictionary_string", {"k1": "hello", "k2": "world"}),
+        (
+            "record_unknown",
+            {
+                "k1": "hello",
+                "k2": 42,
+                "k3": {"k3k1": 1, "k3k2": "test"},
+                "k4": [1, 2, 3],
+                "k5": True,
+                "k6": 3.1415,
+            },
+        ),
+    ],
 )
 async def test(client, og_name, val):
     body = {"property": val}
@@ -42,23 +54,41 @@ async def test(client, og_name, val):
 
 
 @pytest.mark.parametrize(
-    "og_name,model,val", [
+    "og_name,model,val",
+    [
         ("boolean", models.BooleanProperty, True),
         ("string", models.StringProperty, "hello"),
-        ("bytes", models.BytesProperty, b'hello, world!'),
+        ("bytes", models.BytesProperty, b"hello, world!"),
         ("int", models.IntProperty, 42),
         ("float", models.FloatProperty, 42.42),
         ("enum", models.EnumProperty, models.InnerEnum.VALUE_ONE),
         ("extensible_enum", models.ExtensibleEnumProperty, "UnknownValue"),
         ("model", models.ModelProperty, models.InnerModel(property="hello")),
-        ("collections_string",
-         models.CollectionsStringProperty, ['hello', 'world']),
+        ("collections_string", models.CollectionsStringProperty, ["hello", "world"]),
         ("collections_int", models.CollectionsIntProperty, [1, 2]),
-        ("collections_model", models.CollectionsModelProperty,
-         [{'property': 'hello'}, {'property': 'world'}]),
-        ("dictionary_string", models.DictionaryStringProperty,
-         {'k1': 'hello', 'k2': 'world'}),
-    ]
+        (
+            "collections_model",
+            models.CollectionsModelProperty,
+            [{"property": "hello"}, {"property": "world"}],
+        ),
+        (
+            "dictionary_string",
+            models.DictionaryStringProperty,
+            {"k1": "hello", "k2": "world"},
+        ),
+        (
+            "record_unknown",
+            models.RecordUnknownProperty,
+            {
+                "k1": "hello",
+                "k2": 42,
+                "k3": {"k3k1": 1, "k3k2": "test"},
+                "k4": [1, 2, 3],
+                "k5": True,
+                "k6": 3.1415,
+            },
+        ),
+    ],
 )
 @pytest.mark.asyncio
 async def test_model(client, og_name, model, val):
@@ -72,19 +102,24 @@ async def test_model(client, og_name, model, val):
 @pytest.mark.asyncio
 async def test_datetime_model(client):
     received_body = await client.datetime.get()
-    assert received_body == {"property": '2022-08-26T18:38:00Z'}
+    assert received_body == {"property": "2022-08-26T18:38:00Z"}
     assert received_body.property.year == 2022
     assert received_body.property.month == 8
     assert received_body.property.day == 26
     assert received_body.property.hour == 18
     assert received_body.property.minute == 38
-    await client.datetime.put(models.DatetimeProperty(property=datetime.datetime(2022, 8, 26, hour=18, minute=38)))
+    await client.datetime.put(
+        models.DatetimeProperty(
+            property=datetime.datetime(2022, 8, 26, hour=18, minute=38)
+        )
+    )
 
 
 @pytest.mark.asyncio
 async def test_never_model(client: ValueTypesClient):
     assert await client.never.get() == models.NeverProperty()
     await client.never.put(models.NeverProperty())
+
 
 @pytest.mark.asyncio
 async def test_model_deserialization(client: ValueTypesClient):
@@ -93,7 +128,9 @@ async def test_model_deserialization(client: ValueTypesClient):
     resp = await client.model.get()
     assert resp.property.property == resp["property"]["property"]
 
-    body = models.CollectionsModelProperty(property=[{'property': 'hello'}, {'property': 'world'}])
+    body = models.CollectionsModelProperty(
+        property=[{"property": "hello"}, {"property": "world"}]
+    )
     assert body.property[0].property == body["property"][0]["property"]
     resp = await client.collections_model.get()
     assert resp.property[1].property == resp["property"][1]["property"]

--- a/packages/typespec-python/test/mock_api_tests/test_typetest_property_valuetypes.py
+++ b/packages/typespec-python/test/mock_api_tests/test_typetest_property_valuetypes.py
@@ -15,22 +15,34 @@ def client():
 
 
 @pytest.mark.parametrize(
-    "og_name,val", [
+    "og_name,val",
+    [
         ("boolean", True),
         ("string", "hello"),
         ("bytes", "aGVsbG8sIHdvcmxkIQ=="),
         ("int", 42),
         ("float", 42.42),
-        ("datetime", '2022-08-26T18:38:00Z'),
+        ("datetime", "2022-08-26T18:38:00Z"),
         ("duration", "P123DT22H14M12.011S"),
         ("enum", "ValueOne"),
         ("extensible_enum", "UnknownValue"),
-        ("model", {'property': 'hello'}),
-        ("collections_string", ['hello', 'world']),
+        ("model", {"property": "hello"}),
+        ("collections_string", ["hello", "world"]),
         ("collections_int", [1, 2]),
-        ("collections_model", [{'property': 'hello'}, {'property': 'world'}]),
-        ("dictionary_string", {'k1': 'hello', 'k2': 'world'}),
-    ]
+        ("collections_model", [{"property": "hello"}, {"property": "world"}]),
+        ("dictionary_string", {"k1": "hello", "k2": "world"}),
+        (
+            "record_unknown",
+            {
+                "k1": "hello",
+                "k2": 42,
+                "k3": {"k3k1": 1, "k3k2": "test"},
+                "k4": [1, 2, 3],
+                "k5": True,
+                "k6": 3.1415,
+            },
+        ),
+    ],
 )
 def test_json(client, og_name, val):
     body = {"property": val}
@@ -40,23 +52,41 @@ def test_json(client, og_name, val):
 
 
 @pytest.mark.parametrize(
-    "og_name,model,val", [
+    "og_name,model,val",
+    [
         ("boolean", models.BooleanProperty, True),
         ("string", models.StringProperty, "hello"),
-        ("bytes", models.BytesProperty, b'hello, world!'),
+        ("bytes", models.BytesProperty, b"hello, world!"),
         ("int", models.IntProperty, 42),
         ("float", models.FloatProperty, 42.42),
         ("enum", models.EnumProperty, models.InnerEnum.VALUE_ONE),
         ("extensible_enum", models.ExtensibleEnumProperty, "UnknownValue"),
         ("model", models.ModelProperty, models.InnerModel(property="hello")),
-        ("collections_string",
-         models.CollectionsStringProperty, ['hello', 'world']),
+        ("collections_string", models.CollectionsStringProperty, ["hello", "world"]),
         ("collections_int", models.CollectionsIntProperty, [1, 2]),
-        ("collections_model", models.CollectionsModelProperty,
-         [{'property': 'hello'}, {'property': 'world'}]),
-        ("dictionary_string", models.DictionaryStringProperty,
-         {'k1': 'hello', 'k2': 'world'}),
-    ]
+        (
+            "collections_model",
+            models.CollectionsModelProperty,
+            [{"property": "hello"}, {"property": "world"}],
+        ),
+        (
+            "dictionary_string",
+            models.DictionaryStringProperty,
+            {"k1": "hello", "k2": "world"},
+        ),
+        (
+            "record_unknown",
+            models.RecordUnknownProperty,
+            {
+                "k1": "hello",
+                "k2": 42,
+                "k3": {"k3k1": 1, "k3k2": "test"},
+                "k4": [1, 2, 3],
+                "k5": True,
+                "k6": 3.1415,
+            },
+        ),
+    ],
 )
 def test_model(client, og_name, model, val):
     body = model(property=val)
@@ -68,14 +98,17 @@ def test_model(client, og_name, model, val):
 
 def test_datetime_model(client):
     received_body = client.datetime.get()
-    assert received_body == {"property": '2022-08-26T18:38:00Z'}
+    assert received_body == {"property": "2022-08-26T18:38:00Z"}
     assert received_body.property.year == 2022
     assert received_body.property.month == 8
     assert received_body.property.day == 26
     assert received_body.property.hour == 18
     assert received_body.property.minute == 38
-    client.datetime.put(models.DatetimeProperty(
-        property=datetime.datetime(2022, 8, 26, hour=18, minute=38)))
+    client.datetime.put(
+        models.DatetimeProperty(
+            property=datetime.datetime(2022, 8, 26, hour=18, minute=38)
+        )
+    )
 
 
 def test_never_model(client: ValueTypesClient):
@@ -89,7 +122,9 @@ def test_model_deserialization(client: ValueTypesClient):
     resp = client.model.get()
     assert resp.property.property == resp["property"]["property"]
 
-    body = models.CollectionsModelProperty(property=[{'property': 'hello'}, {'property': 'world'}])
+    body = models.CollectionsModelProperty(
+        property=[{"property": "hello"}, {"property": "world"}]
+    )
     assert body.property[0].property == body["property"][0]["property"]
     resp = client.collections_model.get()
     assert resp.property[1].property == resp["property"][1]["property"]


### PR DESCRIPTION
resolve: https://github.com/Azure/autorest.python/issues/1828

Currently, `unknown`, `object`, `Record<unknown>`, `{}` will all generated with `any` in Python.

Depends on https://github.com/Azure/cadl-ranch/pull/297