### PR TITLE
upgrade to tsp may release

### DIFF
--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -43,12 +43,12 @@
       "get-autorest-python-path.cjs"
     ],
     "peerDependencies": {
-      "@azure-tools/typespec-azure-core": ">=0.29.0 <1.0.0",
-      "@azure-tools/typespec-client-generator-core": ">=0.30.0-dev.13 <1.0.0",
-      "@typespec/compiler": ">=0.43.0 <1.0.0",
-      "@typespec/http": ">=0.43.1 <1.0.0",
-      "@typespec/rest": ">=0.43.0 <1.0.0",
-      "@typespec/versioning": ">=0.43.0 <1.0.0"
+      "@azure-tools/typespec-azure-core": ">=0.30.0 <1.0.0",
+      "@azure-tools/typespec-client-generator-core": ">=0.30.0 <1.0.0",
+      "@typespec/compiler": ">=0.44.0 <1.0.0",
+      "@typespec/http": ">=0.44.0 <1.0.0",
+      "@typespec/rest": ">=0.44.0 <1.0.0",
+      "@typespec/versioning": ">=0.44.0 <1.0.0"
     },
     "dependencies": {
       "@autorest/python": "workspace:^",
@@ -60,8 +60,8 @@
       "@types/js-yaml": "~4.0.5",
       "@types/mocha": "~10.0.1",
       "@types/node": "^18.16.3",
-      "@typespec/eslint-config-typespec": "~0.6.0",
-      "@typespec/openapi": ">=0.43.0 <1.0.0",
+      "@typespec/eslint-config-typespec": "~0.7.0",
+      "@typespec/openapi": ">=0.44.0 <1.0.0",
       "c8": "~7.13.0",
       "eslint": "^8.39.0",
       "eslint-plugin-deprecation": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,33 +45,33 @@ importers:
         specifier: workspace:^
         version: link:../autorest.python
       '@azure-tools/typespec-azure-core':
-        specifier: '>=0.29.0 <1.0.0'
-        version: 0.29.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)
+        specifier: '>=0.30.0 <1.0.0'
+        version: 0.30.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)
       '@azure-tools/typespec-client-generator-core':
-        specifier: '>=0.30.0-dev.13 <1.0.0'
-        version: 0.30.0-dev.13(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)
+        specifier: '>=0.30.0 <1.0.0'
+        version: 0.30.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)
       '@typespec/compiler':
-        specifier: '>=0.43.0 <1.0.0'
-        version: 0.43.0
+        specifier: '>=0.44.0 <1.0.0'
+        version: 0.44.0
       '@typespec/http':
-        specifier: '>=0.43.1 <1.0.0'
-        version: 0.43.1(@typespec/compiler@0.43.0)
+        specifier: '>=0.44.0 <1.0.0'
+        version: 0.44.0(@typespec/compiler@0.44.0)
       '@typespec/rest':
-        specifier: '>=0.43.0 <1.0.0'
-        version: 0.43.0(@typespec/compiler@0.43.0)
+        specifier: '>=0.44.0 <1.0.0'
+        version: 0.44.0(@typespec/compiler@0.44.0)
       '@typespec/versioning':
-        specifier: '>=0.43.0 <1.0.0'
-        version: 0.43.0
+        specifier: '>=0.44.0 <1.0.0'
+        version: 0.44.0(@typespec/compiler@0.44.0)
       js-yaml:
         specifier: ~4.1.0
         version: 4.1.0
     devDependencies:
       '@azure-tools/cadl-ranch-expect':
         specifier: ~0.3.0
-        version: 0.3.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.43.0)
+        version: 0.3.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)(@typespec/versioning@0.44.0)
       '@azure-tools/cadl-ranch-specs':
         specifier: ~0.14.10
-        version: 0.14.10(@azure-tools/cadl-ranch-expect@0.3.0)(@azure-tools/typespec-azure-core@0.29.0)(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.43.0)
+        version: 0.14.10(@azure-tools/cadl-ranch-expect@0.3.0)(@azure-tools/typespec-azure-core@0.30.0)(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)(@typespec/versioning@0.44.0)
       '@types/js-yaml':
         specifier: ~4.0.5
         version: 4.0.5
@@ -82,11 +82,11 @@ importers:
         specifier: ^18.16.3
         version: 18.16.3
       '@typespec/eslint-config-typespec':
-        specifier: ~0.6.0
-        version: 0.6.0(prettier@2.8.8)
+        specifier: ~0.7.0
+        version: 0.7.0(prettier@2.8.8)
       '@typespec/openapi':
-        specifier: '>=0.43.0 <1.0.0'
-        version: 0.43.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)
+        specifier: '>=0.44.0 <1.0.0'
+        version: 0.44.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)
       c8:
         specifier: ~7.13.0
         version: 7.13.0
@@ -150,7 +150,7 @@ packages:
       - supports-color
     dev: true
 
-  /@azure-tools/cadl-ranch-expect@0.3.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.43.0):
+  /@azure-tools/cadl-ranch-expect@0.3.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.44.0):
     resolution: {integrity: sha512-+kqMvlAHChvz4+h9FYsZfPp5KigFYdwH+FzdUWlB5NN3WjK+X8A5CuXh2MLCVd53tiQr3qv2Ji5NlGMlhyH4Qw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -162,10 +162,25 @@ packages:
       '@typespec/compiler': 0.43.0
       '@typespec/http': 0.43.1(@typespec/compiler@0.43.0)
       '@typespec/rest': 0.43.0(@typespec/compiler@0.43.0)
-      '@typespec/versioning': 0.43.0
+      '@typespec/versioning': 0.44.0(@typespec/compiler@0.44.0)
     dev: true
 
-  /@azure-tools/cadl-ranch-specs@0.14.10(@azure-tools/cadl-ranch-expect@0.3.0)(@azure-tools/typespec-azure-core@0.29.0)(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.43.0):
+  /@azure-tools/cadl-ranch-expect@0.3.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)(@typespec/versioning@0.44.0):
+    resolution: {integrity: sha512-+kqMvlAHChvz4+h9FYsZfPp5KigFYdwH+FzdUWlB5NN3WjK+X8A5CuXh2MLCVd53tiQr3qv2Ji5NlGMlhyH4Qw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@typespec/compiler': ~0.43.0
+      '@typespec/http': ~0.43.1
+      '@typespec/rest': ~0.43.0
+      '@typespec/versioning': ~0.43.0
+    dependencies:
+      '@typespec/compiler': 0.44.0
+      '@typespec/http': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/rest': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/versioning': 0.44.0(@typespec/compiler@0.44.0)
+    dev: true
+
+  /@azure-tools/cadl-ranch-specs@0.14.10(@azure-tools/cadl-ranch-expect@0.3.0)(@azure-tools/typespec-azure-core@0.30.0)(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)(@typespec/versioning@0.44.0):
     resolution: {integrity: sha512-BkBRnh6pI/vWoycYPxOaKNlgob1pdZPZdv5LoUovsInShS4X6YHJ58GWYSxSaAGDWMwjd2YJ9EwBY9mc9cwzfQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -176,28 +191,28 @@ packages:
       '@typespec/rest': ~0.43.0
       '@typespec/versioning': ~0.43.0
     dependencies:
-      '@azure-tools/cadl-ranch': 0.4.13(@typespec/versioning@0.43.0)
+      '@azure-tools/cadl-ranch': 0.4.13(@typespec/versioning@0.44.0)
       '@azure-tools/cadl-ranch-api': 0.2.5
-      '@azure-tools/cadl-ranch-expect': 0.3.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.43.0)
-      '@azure-tools/typespec-azure-core': 0.29.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1(@typespec/compiler@0.43.0)
-      '@typespec/rest': 0.43.0(@typespec/compiler@0.43.0)
-      '@typespec/versioning': 0.43.0
+      '@azure-tools/cadl-ranch-expect': 0.3.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)(@typespec/versioning@0.44.0)
+      '@azure-tools/typespec-azure-core': 0.30.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0)
+      '@typespec/compiler': 0.44.0
+      '@typespec/http': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/rest': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/versioning': 0.44.0(@typespec/compiler@0.44.0)
     transitivePeerDependencies:
       - '@types/express'
       - encoding
       - supports-color
     dev: true
 
-  /@azure-tools/cadl-ranch@0.4.13(@typespec/versioning@0.43.0):
+  /@azure-tools/cadl-ranch@0.4.13(@typespec/versioning@0.44.0):
     resolution: {integrity: sha512-3YAUs0ErlcGLna9RO71S8rZ1lRAJ4yYWhEhpGhOXsNfz43qrn7pa/ur/u9qJxRz8kOMCXC6aAUR8C49SylOyeg==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
       '@azure-tools/cadl-ranch-api': 0.2.5
       '@azure-tools/cadl-ranch-coverage-sdk': 0.2.3
-      '@azure-tools/cadl-ranch-expect': 0.3.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.43.0)
+      '@azure-tools/cadl-ranch-expect': 0.3.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0)(@typespec/versioning@0.44.0)
       '@azure/identity': 3.1.4
       '@types/js-yaml': 4.0.5
       '@typespec/compiler': 0.43.0
@@ -226,31 +241,31 @@ packages:
       - supports-color
     dev: true
 
-  /@azure-tools/typespec-azure-core@0.29.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0):
-    resolution: {integrity: sha512-JJ8o/aCDdt1clrPeKwQloXqPPMO146ifdhQd69GAenR/OfmzUnuc23ubkzYcgs5fmH+5i37fKsxGhFGFDJiL1g==}
+  /@azure-tools/typespec-azure-core@0.30.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0):
+    resolution: {integrity: sha512-OsLI/opkv3JO+tkdHa04/fL84qSNvRLHDsRQ+Q3VK8rLul9WXHa74yAqn5r3D8WuK+h2KG2dDNtJhhew5ehlgg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.43.0
-      '@typespec/http': ~0.43.0
-      '@typespec/rest': ~0.43.0
+      '@typespec/compiler': ~0.44.0
+      '@typespec/http': ~0.44.0
+      '@typespec/rest': ~0.44.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1(@typespec/compiler@0.43.0)
-      '@typespec/lint': 0.43.0(@typespec/compiler@0.43.0)
-      '@typespec/rest': 0.43.0(@typespec/compiler@0.43.0)
+      '@typespec/compiler': 0.44.0
+      '@typespec/http': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/lint': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/rest': 0.44.0(@typespec/compiler@0.44.0)
 
-  /@azure-tools/typespec-client-generator-core@0.30.0-dev.13(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0):
-    resolution: {integrity: sha512-qDn2nYt4JnmSBzCeeYuQ7F4UIN6RYRWNMn4cX3lAvBJRSOIFveO69xtIZrzLs7v1WtMD4AnYppLwPDWNPeFadg==}
+  /@azure-tools/typespec-client-generator-core@0.30.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0):
+    resolution: {integrity: sha512-2CyCrIPXL/k6vXGWixWCYlA8gENErIUncdN9IFUBlqyqWlgb8GBpjl2RhIqbQCo2PGS6U3s1NEdZffzD0tNSdw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': '>=0.43.0'
-      '@typespec/http': '>=0.43.1'
-      '@typespec/rest': '>=0.43.0'
+      '@typespec/compiler': ~0.44.0
+      '@typespec/http': ~0.44.0
+      '@typespec/rest': ~0.44.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1(@typespec/compiler@0.43.0)
-      '@typespec/lint': 0.43.0(@typespec/compiler@0.43.0)
-      '@typespec/rest': 0.43.0(@typespec/compiler@0.43.0)
+      '@typespec/compiler': 0.44.0
+      '@typespec/http': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/lint': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/rest': 0.44.0(@typespec/compiler@0.44.0)
     dev: false
 
   /@azure/abort-controller@1.1.0:
@@ -477,13 +492,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
+    dev: true
 
   /@babel/code-frame@7.21.4:
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
-    dev: true
 
   /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
@@ -707,7 +722,7 @@ packages:
       '@types/node': 18.16.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.34.0(@typescript-eslint/parser@5.34.0)(eslint@8.39.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.34.0(@typescript-eslint/parser@5.34.0)(eslint@8.39.0)(typescript@5.0.4):
     resolution: {integrity: sha512-eRfPPcasO39iwjlUAMtjeueRGuIrW3TQ9WseIDl7i5UWuFbf83yYaU7YPs4j8+4CxUMIsj1k+4kV+E+G+6ypDQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -720,16 +735,16 @@ packages:
     dependencies:
       '@typescript-eslint/parser': 5.34.0(eslint@8.39.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.34.0
-      '@typescript-eslint/type-utils': 5.34.0(eslint@8.39.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.34.0(eslint@8.39.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.34.0(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.34.0(eslint@8.39.0)(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.39.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -770,7 +785,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.2
     dev: true
 
-  /@typescript-eslint/type-utils@5.34.0(eslint@8.39.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.34.0(eslint@8.39.0)(typescript@5.0.4):
     resolution: {integrity: sha512-Pxlno9bjsQ7hs1pdWRUv9aJijGYPYsHpwMeCQ/Inavhym3/XaKt1ZKAA8FIw4odTBfowBdZJDMxf2aavyMDkLg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -780,11 +795,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.34.0(eslint@8.39.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.34.0(eslint@8.39.0)(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.39.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -797,27 +812,6 @@ packages:
   /@typescript-eslint/types@5.59.2:
     resolution: {integrity: sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.34.0(typescript@4.9.5):
-    resolution: {integrity: sha512-mXHAqapJJDVzxauEkfJI96j3D10sd567LlqroyCeJaHnu42sDbjxotGb3XFtGPYKPD9IyLjhsoULML1oI3M86A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.34.0
-      '@typescript-eslint/visitor-keys': 5.34.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@5.34.0(typescript@5.0.4):
@@ -862,7 +856,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.34.0(eslint@8.39.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.34.0(eslint@8.39.0)(typescript@5.0.4):
     resolution: {integrity: sha512-kWRYybU4Rn++7lm9yu8pbuydRyQsHRoBDIo11k7eqBWTldN4xUdVUMCsHBiE7aoEkFzrUEaZy3iH477vr4xHAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -871,7 +865,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.34.0
       '@typescript-eslint/types': 5.34.0
-      '@typescript-eslint/typescript-estree': 5.34.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.34.0(typescript@5.0.4)
       eslint: 8.39.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.39.0)
@@ -936,19 +930,42 @@ packages:
       vscode-languageserver: 8.0.2
       vscode-languageserver-textdocument: 1.0.5
       yargs: 17.6.2
+    dev: true
 
-  /@typespec/eslint-config-typespec@0.6.0(prettier@2.8.8):
-    resolution: {integrity: sha512-ZjANoGn+kLr8lDlP5RijeTqKLvVMjq7Vr98dQT8jrz41i+Oal6eCLwHc7JdmssFF9d/czsVaWlBcLH//r3KMLg==}
+  /@typespec/compiler@0.44.0:
+    resolution: {integrity: sha512-NESRujXwHHhJZsHn+Bf4zOlJ2eTJB/oYRIFMqV7lAOut3OILngQfmO3iVLpTVrHjwgrUdetU1GXt1Ref3rmATA==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      ajv: 8.12.0
+      change-case: 4.1.2
+      globby: 13.1.2
+      js-yaml: 4.1.0
+      mkdirp: 2.1.6
+      mustache: 4.2.0
+      node-fetch: 3.2.8
+      node-watch: 0.7.3
+      picocolors: 1.0.0
+      prettier: 2.8.8
+      prompts: 2.4.2
+      vscode-languageserver: 8.1.0
+      vscode-languageserver-textdocument: 1.0.5
+      yargs: 17.7.2
+
+  /@typespec/eslint-config-typespec@0.7.0(prettier@2.8.8):
+    resolution: {integrity: sha512-FkBHQFA6RfpSKkkHV4N8rT0SH9fXQPuGwzjSQkbrDV5QoWtbMU7JBbdbIotXnaXCsf/VEMPPXQKrZvjwgPhd+Q==}
     dependencies:
       '@rushstack/eslint-patch': 1.1.0
-      '@typescript-eslint/eslint-plugin': 5.34.0(@typescript-eslint/parser@5.34.0)(eslint@8.39.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.34.0(@typescript-eslint/parser@5.34.0)(eslint@8.39.0)(typescript@5.0.4)
       '@typescript-eslint/parser': 5.34.0(eslint@8.39.0)(typescript@5.0.4)
       eslint: 8.39.0
       eslint-config-prettier: 8.5.0(eslint@8.39.0)
+      eslint-plugin-deprecation: 1.4.1(eslint@8.39.0)(typescript@5.0.4)
       eslint-plugin-mocha: 10.1.0(eslint@8.39.0)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.5.0)(eslint@8.39.0)(prettier@2.8.8)
       eslint-plugin-unicorn: 42.0.0(eslint@8.39.0)
-      typescript: 4.9.5
+      typescript: 5.0.4
     transitivePeerDependencies:
       - prettier
       - supports-color
@@ -961,26 +978,35 @@ packages:
       '@typespec/compiler': ~0.43.0
     dependencies:
       '@typespec/compiler': 0.43.0
+    dev: true
 
-  /@typespec/lint@0.43.0(@typespec/compiler@0.43.0):
-    resolution: {integrity: sha512-Hs4zEws8+ZOu3wuN32dmAKOkvlmQzdpkd96Wyx8tT4j3aovf1APqlGjozgp9DZcKxpT+jAxpS+GLpjBTZEeUnQ==}
+  /@typespec/http@0.44.0(@typespec/compiler@0.44.0):
+    resolution: {integrity: sha512-isIcg0/fidnbUeSp9qX1ir5XXThrKrdhwXle1Y4f+sR0DcTf4gJSEesjiZkV+Ea7u5nHjJ3/f+/Stp6XyuwOZw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.43.0
+      '@typespec/compiler': ~0.44.0
     dependencies:
-      '@typespec/compiler': 0.43.0
+      '@typespec/compiler': 0.44.0
 
-  /@typespec/openapi@0.43.0(@typespec/compiler@0.43.0)(@typespec/http@0.43.1)(@typespec/rest@0.43.0):
-    resolution: {integrity: sha512-WDQopOJBGsUoztpNUtoYJ5gEJac0W5g8JGKqMaAmAjJ47Cq/BJh2NCrxJKZeFEhKI98zz13IQmRbcf1zmSLPJw==}
+  /@typespec/lint@0.44.0(@typespec/compiler@0.44.0):
+    resolution: {integrity: sha512-IEmaP7+PLDQOeZPqwH0XZe+Llt1P/SUzIj4zLEARBaAbBSGmekwUrXRlwrrDyZEPmmsnuIRuZNuXolG+REUh5g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.43.0
-      '@typespec/http': ~0.43.0
-      '@typespec/rest': ~0.43.0
+      '@typespec/compiler': ~0.44.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1(@typespec/compiler@0.43.0)
-      '@typespec/rest': 0.43.0(@typespec/compiler@0.43.0)
+      '@typespec/compiler': 0.44.0
+
+  /@typespec/openapi@0.44.0(@typespec/compiler@0.44.0)(@typespec/http@0.44.0)(@typespec/rest@0.44.0):
+    resolution: {integrity: sha512-uZ8rZ4cIWDsBKGbmUODu5HjAimnePmajQ5xO5QJGji9E/nK8LuEsJEnQA/qXaahEbiZTwZCH5J+ooPFLbEzXEA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@typespec/compiler': ~0.44.0
+      '@typespec/http': ~0.44.0
+      '@typespec/rest': ~0.44.0
+    dependencies:
+      '@typespec/compiler': 0.44.0
+      '@typespec/http': 0.44.0(@typespec/compiler@0.44.0)
+      '@typespec/rest': 0.44.0(@typespec/compiler@0.44.0)
     dev: true
 
   /@typespec/prettier-plugin-typespec@0.43.0:
@@ -996,12 +1022,23 @@ packages:
       '@typespec/compiler': ~0.43.0
     dependencies:
       '@typespec/compiler': 0.43.0
+    dev: true
 
-  /@typespec/versioning@0.43.0:
-    resolution: {integrity: sha512-YxU9QPH05wF/8k0BjyR1pFTxA5qWxjeq8RyQtwFf+smz1pFbFLf7RmqEUZgXChC4H+7cwsIC8eLefx4ukObF9Q==}
+  /@typespec/rest@0.44.0(@typespec/compiler@0.44.0):
+    resolution: {integrity: sha512-frHx0cKyvrtB3CST4x/38QevoSWj+anSmCDW2mvdUwV7PEkTzC5b3d0O3LDbCECT/WHp09PCkKqMEODe03xBlQ==}
     engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@typespec/compiler': ~0.44.0
     dependencies:
-      '@typespec/compiler': 0.43.0
+      '@typespec/compiler': 0.44.0
+
+  /@typespec/versioning@0.44.0(@typespec/compiler@0.44.0):
+    resolution: {integrity: sha512-7Z+1wV3XM4W+QbkWFVyOsoQXtS9y4aUcpq5rbLtUCUTvI26IcTOv94b2+HbPJl2x7j3o+KYfvVLVj8fiCqxXJg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@typespec/compiler': ~0.44.0
+    dependencies:
+      '@typespec/compiler': 0.44.0
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1050,6 +1087,7 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+    dev: true
 
   /ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
@@ -1058,7 +1096,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    dev: true
 
   /ansi-colors@4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
@@ -3369,6 +3406,12 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+    dev: true
+
+  /mkdirp@2.1.6:
+    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   /mocha@10.2.0:
     resolution: {integrity: sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==}
@@ -4414,16 +4457,6 @@ packages:
   /tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tsutils@3.21.0(typescript@4.9.5):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.9.5
-    dev: true
-
   /tsutils@3.21.0(typescript@5.0.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -4485,12 +4518,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-    dev: true
-
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /typescript@5.0.4:
@@ -4602,24 +4629,47 @@ packages:
   /vscode-jsonrpc@8.0.2:
     resolution: {integrity: sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==}
     engines: {node: '>=14.0.0'}
+    dev: true
+
+  /vscode-jsonrpc@8.1.0:
+    resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
+    engines: {node: '>=14.0.0'}
 
   /vscode-languageserver-protocol@3.17.2:
     resolution: {integrity: sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==}
     dependencies:
       vscode-jsonrpc: 8.0.2
       vscode-languageserver-types: 3.17.2
+    dev: true
+
+  /vscode-languageserver-protocol@3.17.3:
+    resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
+    dependencies:
+      vscode-jsonrpc: 8.1.0
+      vscode-languageserver-types: 3.17.3
 
   /vscode-languageserver-textdocument@1.0.5:
     resolution: {integrity: sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==}
 
   /vscode-languageserver-types@3.17.2:
     resolution: {integrity: sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==}
+    dev: true
+
+  /vscode-languageserver-types@3.17.3:
+    resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
 
   /vscode-languageserver@8.0.2:
     resolution: {integrity: sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==}
     hasBin: true
     dependencies:
       vscode-languageserver-protocol: 3.17.2
+    dev: true
+
+  /vscode-languageserver@8.1.0:
+    resolution: {integrity: sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==}
+    hasBin: true
+    dependencies:
+      vscode-languageserver-protocol: 3.17.3
 
   /web-streams-polyfill@3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
@@ -4798,6 +4848,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -4810,7 +4861,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}


### PR DESCRIPTION
cadl-ranch has not released yet, but shall not affect python emitter.