### PR TITLE
do not do diff check when nightly build

### DIFF
--- a/eng/pipelines/ci-template.yml
+++ b/eng/pipelines/ci-template.yml
@@ -6,6 +6,7 @@ parameters:
     pythonCodeChecks: false
     pythonFolderName: ""
     regenerate: false
+    checkChange: true
     updateToLatestTypespec: false
 
 steps:
@@ -117,12 +118,12 @@ steps:
     - script: node ../../../eng/scripts/check-for-changed-files.js
       displayName: Fail on regeneration diff in Typespec
       workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/typespec-python/test
-      condition: and(succeeded(), ${{ parameters.regenerate }})
+      condition: and(succeeded(), ${{ parameters.regenerate }}), ${{ parameters.checkChange }})
 
     - script: node ../../../eng/scripts/check-for-changed-files.js
       displayName: Fail on regeneration diff in Autorest
       workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test
-      condition: and(succeeded(), ${{ parameters.regenerate }})
+      condition: and(succeeded(), ${{ parameters.regenerate }}), ${{ parameters.checkChange }})
 
     - task: UsePythonVersion@0
       displayName: "Use Python $(PythonVersion)"

--- a/eng/pipelines/nightly.yml
+++ b/eng/pipelines/nightly.yml
@@ -27,6 +27,7 @@ steps:
         folderName: "typespec-python"
         regenerate: true
         updateToLatestTypespec: true
+        checkChange: false
 
     - template: generated-code-checks-template.yml
       parameters:


### PR DESCRIPTION
Any tsp core lib change may cause minor code diff for emitter, but we do not care about that in nightly build, we just care about the compile and test pass. So, this PR introduce a new flag for `ci-template.yml` and diasble diff check for nightly build.