### PR TITLE
compatible with automation config

### DIFF
--- a/packages/typespec-python/src/lib.ts
+++ b/packages/typespec-python/src/lib.ts
@@ -12,7 +12,7 @@ export interface PythonEmitterOptions {
 
 const EmitterOptionsSchema: JSONSchemaType<PythonEmitterOptions> = {
     type: "object",
-    additionalProperties: false,
+    additionalProperties: true,
     properties: {
         "basic-setup-py": { type: "boolean", nullable: true },
         "package-version": { type: "string", nullable: true },


### PR DESCRIPTION
["package-dir"](https://github.com/openapi-env-test/azure-rest-api-specs/pull/3657/files#diff-b7e75220b6f450282cba2075cfb681c5c83cbb0090b9e5d3784ba768c55a09b5) is used in automation of pipeline but cause compiler error in python emitter. So we update emitter config to avoid it.