### PR TITLE
Fix generation error when `next_link` in undefined

### DIFF
--- a/packages/autorest.python/autorest/codegen/models/paging_operation.py
+++ b/packages/autorest.python/autorest/codegen/models/paging_operation.py
@@ -80,7 +80,7 @@ class PagingOperationBase(OperationBase[PagingResponseType]):
 
     @property
     def continuation_token_name(self) -> Optional[str]:
-        wire_name = self.yaml_data["continuationTokenName"]
+        wire_name = self.yaml_data.get("continuationTokenName")
         if not wire_name:
             # That's an ok scenario, it just means no next page possible
             return None

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -19,6 +19,7 @@
 **Bug Fixes**
 
 - Fix `_vendor.py` when only `etag` exists  #2056
+- Fix generation error when `next_link` in undefined  #2055
 
 ## 2023-08-09 - 0.13.1
 


### PR DESCRIPTION
https://github.com/Azure/autorest.python/issues/2055