### PR TITLE
[etag] skip quote for W/

### DIFF
--- a/packages/autorest.python/autorest/codegen/templates/vendor.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/vendor.py.jinja2
@@ -39,6 +39,8 @@ def raise_if_not_implemented(cls, abstract_methods):
 def quote_etag(etag: Optional[str]) -> Optional[str]:
     if not etag or etag == "*":
         return etag
+    if etag.startswith('W/'):
+        return  etag
     if etag.startswith('"') and etag.endswith('"'):
         return etag
     if etag.startswith("'") and etag.endswith("'"):


### PR DESCRIPTION
With https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#syntax, SDK shall not add quote for etag if it starts with `W/`