### PR TITLE
update mypy version to match next-mypy in azure-sdk-for-python

### DIFF
--- a/eng/requirements.txt
+++ b/eng/requirements.txt
@@ -2,4 +2,4 @@
 pyright==1.1.299
 pylint==2.17.5
 tox==4.11.3
-mypy==1.3.0
+mypy==1.4.1


### PR DESCRIPTION
Updating the pinned mypy version to target the version we're bumping up to in azure-sdk-for-python in October. CI seems to be passing so I think it's safe to merge?