### PR TITLE
recover test case for "encode/bytes"

### DIFF
--- a/packages/typespec-python/test/generic_mock_api_tests/test_encode_bytes.py
+++ b/packages/typespec-python/test/generic_mock_api_tests/test_encode_bytes.py
@@ -103,9 +103,8 @@ def png_data() -> bytes:
 
 def test_request_body(client: BytesClient, png_data: bytes):
     client.request_body.default(value=bytes("test", "utf-8"), )
-    # cadl-ranch has some problems for these two test cases
-    # client.request_body.octet_stream(value=png_data, )
-    # client.request_body.custom_content_type(value=png_data, )
+    client.request_body.octet_stream(value=png_data)
+    client.request_body.custom_content_type(value=png_data)
     client.request_body.base64(value=bytes("test", "utf-8"), )
     client.request_body.base64url(value=bytes("test", "utf-8"), )
 


### PR DESCRIPTION
pending on cadl-ranch fix PR https://github.com/Azure/cadl-ranch/pull/455