### PR TITLE
fix logic for judging whether there is non-abstract operations

### DIFF
--- a/packages/autorest.python/autorest/codegen/models/client.py
+++ b/packages/autorest.python/autorest/codegen/models/client.py
@@ -304,6 +304,11 @@ class Client(_ClientConfigBase[ClientGlobalParameterList]):
         """Whether there is abstract operation in any operation group."""
         return any(og.has_abstract_operations for og in self.operation_groups)
 
+    @property
+    def has_non_abstract_operations(self) -> bool:
+        """Whether there is non-abstract operation in any operation group."""
+        return any(og.has_non_abstract_operations for og in self.operation_groups)
+
     def imports(self, async_mode: bool) -> FileImport:
         file_import = self._imports_shared(async_mode)
         if async_mode:

--- a/packages/autorest.python/autorest/codegen/models/code_model.py
+++ b/packages/autorest.python/autorest/codegen/models/code_model.py
@@ -104,7 +104,11 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
     @property
     def has_non_abstract_operations(self) -> bool:
         return any(c for c in self.clients if c.has_non_abstract_operations) or any(
-            c for c in cs if c.has_non_abstract_operations for cs in self.subnamespace_to_clients.values())
+            c
+            for cs in self.subnamespace_to_clients.values()
+            for c in cs
+            if c.has_non_abstract_operations
+        )
 
     def lookup_request_builder(
         self, request_builder_id: int
@@ -189,7 +193,7 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
                 t
                 for t in self.types_map.values()
                 if isinstance(t, ModelType)
-                   and not (self.options["models_mode"] == "dpg" and t.page_result_model)
+                and not (self.options["models_mode"] == "dpg" and t.page_result_model)
             ]
         return self._model_types
 

--- a/packages/autorest.python/autorest/codegen/models/code_model.py
+++ b/packages/autorest.python/autorest/codegen/models/code_model.py
@@ -103,18 +103,8 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
 
     @property
     def has_non_abstract_operations(self) -> bool:
-        for client in self.clients:
-            for operation_group in client.operation_groups:
-                for operation in operation_group.operations:
-                    if not operation.abstract:
-                        return True
-        for clients in self.subnamespace_to_clients.values():
-            for client in clients:
-                for operation_group in client.operation_groups:
-                    for operation in operation_group.operations:
-                        if not operation.abstract:
-                            return True
-        return False
+        return any(c for c in self.clients if c.has_non_abstract_operations) or any(
+            c for c in cs if c.has_non_abstract_operations for cs in self.subnamespace_to_clients.values())
 
     def lookup_request_builder(
         self, request_builder_id: int
@@ -199,7 +189,7 @@ class CodeModel:  # pylint: disable=too-many-public-methods, disable=too-many-in
                 t
                 for t in self.types_map.values()
                 if isinstance(t, ModelType)
-                and not (self.options["models_mode"] == "dpg" and t.page_result_model)
+                   and not (self.options["models_mode"] == "dpg" and t.page_result_model)
             ]
         return self._model_types
 

--- a/packages/autorest.python/autorest/codegen/models/operation_group.py
+++ b/packages/autorest.python/autorest/codegen/models/operation_group.py
@@ -48,7 +48,15 @@ class OperationGroup(BaseModel):
 
     @property
     def has_abstract_operations(self) -> bool:
-        return any(o for o in self.operations if o.abstract)
+        return any(o for o in self.operations if o.abstract) or any(
+            operation_group.has_abstract_operations for operation_group in self.operation_groups
+        )
+
+    @property
+    def has_non_abstract_operations(self) -> bool:
+        return any(o for o in self.operations if not o.abstract) or any(
+            operation_group.has_non_abstract_operations for operation_group in self.operation_groups
+        )
 
     @property
     def base_class(self) -> str:

--- a/packages/autorest.python/autorest/codegen/models/operation_group.py
+++ b/packages/autorest.python/autorest/codegen/models/operation_group.py
@@ -49,13 +49,15 @@ class OperationGroup(BaseModel):
     @property
     def has_abstract_operations(self) -> bool:
         return any(o for o in self.operations if o.abstract) or any(
-            operation_group.has_abstract_operations for operation_group in self.operation_groups
+            operation_group.has_abstract_operations
+            for operation_group in self.operation_groups
         )
 
     @property
     def has_non_abstract_operations(self) -> bool:
         return any(o for o in self.operations if not o.abstract) or any(
-            operation_group.has_non_abstract_operations for operation_group in self.operation_groups
+            operation_group.has_non_abstract_operations
+            for operation_group in self.operation_groups
         )
 
     @property

--- a/packages/typespec-python/test/azure/generated/authentication-api-key/README.md
+++ b/packages/typespec-python/test/azure/generated/authentication-api-key/README.md
@@ -13,7 +13,7 @@ python -m pip install authentication-apikey
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Authentication Apikey instance.
 

--- a/packages/typespec-python/test/azure/generated/authentication-http-custom/README.md
+++ b/packages/typespec-python/test/azure/generated/authentication-http-custom/README.md
@@ -13,7 +13,7 @@ python -m pip install authentication-http-custom
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Authentication Http Custom instance.
 

--- a/packages/typespec-python/test/azure/generated/authentication-oauth2/README.md
+++ b/packages/typespec-python/test/azure/generated/authentication-oauth2/README.md
@@ -13,7 +13,7 @@ python -m pip install authentication-oauth2
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Authentication Oauth2 instance.
 #### Create with an Azure Active Directory Credential

--- a/packages/typespec-python/test/azure/generated/authentication-union/README.md
+++ b/packages/typespec-python/test/azure/generated/authentication-union/README.md
@@ -13,7 +13,7 @@ python -m pip install authentication-union
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Authentication Union instance.
 

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/README.md
@@ -13,7 +13,7 @@ python -m pip install specs-azure-clientgenerator-core-access
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specs Azure Clientgenerator Core Access instance.
 

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/README.md
@@ -13,7 +13,7 @@ python -m pip install specs-azure-clientgenerator-core-usage
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specs Azure Clientgenerator Core Usage instance.
 

--- a/packages/typespec-python/test/azure/generated/azure-core-basic/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-core-basic/README.md
@@ -13,7 +13,7 @@ python -m pip install specs-azure-core-basic
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specs Azure Core Basic instance.
 

--- a/packages/typespec-python/test/azure/generated/azure-core-lro-standard/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-core-lro-standard/README.md
@@ -13,7 +13,7 @@ python -m pip install specs-azure-core-lro-standard
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specs Azure Core Lro Standard instance.
 

--- a/packages/typespec-python/test/azure/generated/azure-core-traits/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-core-traits/README.md
@@ -13,7 +13,7 @@ python -m pip install specs-azure-core-traits
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specs Azure Core Traits instance.
 

--- a/packages/typespec-python/test/azure/generated/azure-mgmt-spheredpg/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-mgmt-spheredpg/README.md
@@ -13,7 +13,7 @@ python -m pip install azure-mgmt-spheredpg
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Azure Mgmt Spheredpg instance.
 #### Create with an Azure Active Directory Credential

--- a/packages/typespec-python/test/azure/generated/azure-mgmt-spheremsrest/README.md
+++ b/packages/typespec-python/test/azure/generated/azure-mgmt-spheremsrest/README.md
@@ -13,7 +13,7 @@ python -m pip install azure-mgmt-spheremsrest
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Azure Mgmt Spheremsrest instance.
 #### Create with an Azure Active Directory Credential

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/README.md
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/README.md
@@ -13,7 +13,7 @@ python -m pip install azurecore-lro-rpc
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Azurecore Lro Rpc instance.
 

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpclegacy/README.md
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpclegacy/README.md
@@ -13,7 +13,7 @@ python -m pip install azurecore-lro-rpclegacy
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Azurecore Lro Rpclegacy instance.
 

--- a/packages/typespec-python/test/azure/generated/client-structure-default/README.md
+++ b/packages/typespec-python/test/azure/generated/client-structure-default/README.md
@@ -13,7 +13,7 @@ python -m pip install client-structure-service
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Client Structure Service instance.
 

--- a/packages/typespec-python/test/azure/generated/client-structure-multiclient/README.md
+++ b/packages/typespec-python/test/azure/generated/client-structure-multiclient/README.md
@@ -13,7 +13,7 @@ python -m pip install client-structure-multiclient
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Client Structure Multiclient instance.
 

--- a/packages/typespec-python/test/azure/generated/client-structure-renamedoperation/README.md
+++ b/packages/typespec-python/test/azure/generated/client-structure-renamedoperation/README.md
@@ -13,7 +13,7 @@ python -m pip install client-structure-renamedoperation
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Client Structure Renamedoperation instance.
 

--- a/packages/typespec-python/test/azure/generated/client-structure-twooperationgroup/README.md
+++ b/packages/typespec-python/test/azure/generated/client-structure-twooperationgroup/README.md
@@ -13,7 +13,7 @@ python -m pip install client-structure-twooperationgroup
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Client Structure Twooperationgroup instance.
 

--- a/packages/typespec-python/test/azure/generated/encode-bytes/README.md
+++ b/packages/typespec-python/test/azure/generated/encode-bytes/README.md
@@ -13,7 +13,7 @@ python -m pip install encode-bytes
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Encode Bytes instance.
 

--- a/packages/typespec-python/test/azure/generated/encode-datetime/README.md
+++ b/packages/typespec-python/test/azure/generated/encode-datetime/README.md
@@ -13,7 +13,7 @@ python -m pip install encode-datetime
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Encode Datetime instance.
 

--- a/packages/typespec-python/test/azure/generated/encode-duration/README.md
+++ b/packages/typespec-python/test/azure/generated/encode-duration/README.md
@@ -13,7 +13,7 @@ python -m pip install encode-duration
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Encode Duration instance.
 

--- a/packages/typespec-python/test/azure/generated/headasbooleanfalse/README.md
+++ b/packages/typespec-python/test/azure/generated/headasbooleanfalse/README.md
@@ -13,7 +13,7 @@ python -m pip install headasbooleanfalse
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Headasbooleanfalse instance.
 

--- a/packages/typespec-python/test/azure/generated/headasbooleantrue/README.md
+++ b/packages/typespec-python/test/azure/generated/headasbooleantrue/README.md
@@ -13,7 +13,7 @@ python -m pip install headasbooleantrue
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Headasbooleantrue instance.
 

--- a/packages/typespec-python/test/azure/generated/parameters-body-optionality/README.md
+++ b/packages/typespec-python/test/azure/generated/parameters-body-optionality/README.md
@@ -13,7 +13,7 @@ python -m pip install parameters-bodyoptionality
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Parameters Bodyoptionality instance.
 

--- a/packages/typespec-python/test/azure/generated/parameters-collection-format/README.md
+++ b/packages/typespec-python/test/azure/generated/parameters-collection-format/README.md
@@ -13,7 +13,7 @@ python -m pip install parameters-collectionformat
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Parameters Collectionformat instance.
 

--- a/packages/typespec-python/test/azure/generated/parameters-spread/README.md
+++ b/packages/typespec-python/test/azure/generated/parameters-spread/README.md
@@ -13,7 +13,7 @@ python -m pip install parameters-spread
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Parameters Spread instance.
 

--- a/packages/typespec-python/test/azure/generated/payload-content-negotiation/README.md
+++ b/packages/typespec-python/test/azure/generated/payload-content-negotiation/README.md
@@ -13,7 +13,7 @@ python -m pip install payload-contentnegotiation
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Payload Contentnegotiation instance.
 

--- a/packages/typespec-python/test/azure/generated/payload-media-type/README.md
+++ b/packages/typespec-python/test/azure/generated/payload-media-type/README.md
@@ -13,7 +13,7 @@ python -m pip install payload-mediatype
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Payload Mediatype instance.
 

--- a/packages/typespec-python/test/azure/generated/payload-multipart/README.md
+++ b/packages/typespec-python/test/azure/generated/payload-multipart/README.md
@@ -13,7 +13,7 @@ python -m pip install payload-multipart
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Payload Multipart instance.
 

--- a/packages/typespec-python/test/azure/generated/payload-pageable/README.md
+++ b/packages/typespec-python/test/azure/generated/payload-pageable/README.md
@@ -13,7 +13,7 @@ python -m pip install payload-pageable
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Payload Pageable instance.
 

--- a/packages/typespec-python/test/azure/generated/projection-projected-name/README.md
+++ b/packages/typespec-python/test/azure/generated/projection-projected-name/README.md
@@ -13,7 +13,7 @@ python -m pip install projection-projectedname
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Projection Projectedname instance.
 

--- a/packages/typespec-python/test/azure/generated/resiliency-srv-driven1/README.md
+++ b/packages/typespec-python/test/azure/generated/resiliency-srv-driven1/README.md
@@ -13,7 +13,7 @@ python -m pip install resiliency-srv-driven1
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing ResiliencySrvDriven1 instance.
 

--- a/packages/typespec-python/test/azure/generated/resiliency-srv-driven2/README.md
+++ b/packages/typespec-python/test/azure/generated/resiliency-srv-driven2/README.md
@@ -13,7 +13,7 @@ python -m pip install resiliency-srv-driven2
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing ResiliencySrvDriven2 instance.
 

--- a/packages/typespec-python/test/azure/generated/server-path-multiple/README.md
+++ b/packages/typespec-python/test/azure/generated/server-path-multiple/README.md
@@ -13,7 +13,7 @@ python -m pip install server-path-multiple
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Server Path Multiple instance.
 

--- a/packages/typespec-python/test/azure/generated/server-path-single/README.md
+++ b/packages/typespec-python/test/azure/generated/server-path-single/README.md
@@ -13,7 +13,7 @@ python -m pip install server-path-single
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Server Path Single instance.
 

--- a/packages/typespec-python/test/azure/generated/server-versions-not-versioned/README.md
+++ b/packages/typespec-python/test/azure/generated/server-versions-not-versioned/README.md
@@ -13,7 +13,7 @@ python -m pip install server-versions-notversioned
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Server Versions Notversioned instance.
 

--- a/packages/typespec-python/test/azure/generated/server-versions-versioned/README.md
+++ b/packages/typespec-python/test/azure/generated/server-versions-versioned/README.md
@@ -13,7 +13,7 @@ python -m pip install server-versions-versioned
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Server Versions Versioned instance.
 

--- a/packages/typespec-python/test/azure/generated/special-headers-client-request-id/README.md
+++ b/packages/typespec-python/test/azure/generated/special-headers-client-request-id/README.md
@@ -13,7 +13,7 @@ python -m pip install specialheaders-clientrequestid
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specialheaders Clientrequestid instance.
 

--- a/packages/typespec-python/test/azure/generated/special-headers-conditional-request/README.md
+++ b/packages/typespec-python/test/azure/generated/special-headers-conditional-request/README.md
@@ -13,7 +13,7 @@ python -m pip install specialheaders-conditionalrequest
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specialheaders Conditionalrequest instance.
 

--- a/packages/typespec-python/test/azure/generated/special-headers-repeatability/README.md
+++ b/packages/typespec-python/test/azure/generated/special-headers-repeatability/README.md
@@ -13,7 +13,7 @@ python -m pip install specialheaders-repeatability
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specialheaders Repeatability instance.
 

--- a/packages/typespec-python/test/azure/generated/special-words/README.md
+++ b/packages/typespec-python/test/azure/generated/special-words/README.md
@@ -13,7 +13,7 @@ python -m pip install specialwords
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Specialwords instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-array/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-array/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-array
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Array instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-dictionary/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-dictionary/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-dictionary
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Dictionary instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-enum-extensible/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-enum-extensible/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-enum-extensible
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Enum Extensible instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-enum-fixed/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-enum-fixed/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-enum-fixed
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Enum Fixed instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-empty/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-empty/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-empty
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Empty instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-enumdiscriminator
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Enumdiscriminator instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-nesteddiscriminator
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Nesteddiscriminator instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-notdiscriminated
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Notdiscriminated instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-recursive/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-recursive/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-recursive
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Recursive instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-singlediscriminator
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Singlediscriminator instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-usage/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-usage/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-usage
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Usage instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-visibility/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-model-visibility/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-model-visibility
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Model Visibility instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-property-additionalproperties
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Property Additionalproperties instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-property-nullable/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-property-nullable/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-property-nullable
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Property Nullable instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-property-optional/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-property-optional/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-property-optional
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Property Optional instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-property-valuetypes
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Property Valuetypes instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-scalar/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-scalar/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-scalar
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Scalar instance.
 

--- a/packages/typespec-python/test/azure/generated/typetest-union/README.md
+++ b/packages/typespec-python/test/azure/generated/typetest-union/README.md
@@ -13,7 +13,7 @@ python -m pip install typetest-union
 
 #### Prequisites
 
-- Python 3.7 or later is required to use this package.
+- Python 3.8 or later is required to use this package.
 - You need an [Azure subscription][azure_sub] to use this package.
 - An existing Typetest Union instance.
 


### PR DESCRIPTION
fixes #2336

issue found in face.


請教一個 python code gen 的問題
從 TypeSpec gen 出來的 SDK 直接執行會出現 error
E NameError: name '_SERIALIZER' is not defined
azure\ai\face\operations\_operations.py:52: NameError
參考其他 sdk 在 _operations.py top level 補上以下兩行就能正常執行了
_SERIALIZER = Serializer()
_SERIALIZER.client_side_validation = False
請問這部分是 autorest 那邊的問題，還是我們的 TypeSpec 需要修正?
TypeSpec: [TypeSpec for Face API session operations by Han-msft · Pull Request #15710 · Azure/azure-rest-api-specs-pr (github.com)](https://github.com/Azure/azure-rest-api-specs-pr/pull/15710/files#diff-0bf7af519c60fe479f86ccbdeb3c6781ba4a4013aa317d733fe2d7e0a2301033)
Python sdk code: [azure-sdk-for-python-pr/sdk/face/azure-ai-face/azure/ai/face/operations/_operations.py at sdkAuto/15710/azure-ai-face · azure-sdk/azure-sdk-for-python-pr (github.com)](https://github.com/azure-sdk/azure-sdk-for-python-pr/blob/sdkAuto/15710/azure-ai-face/sdk/face/azure-ai-face/azure/ai/face/operations/_operations.py)