### PR TITLE
fix parse error for `package-pprint-name` in `tspconfig.yaml`

### DIFF
--- a/packages/typespec-python/src/emitter.ts
+++ b/packages/typespec-python/src/emitter.ts
@@ -128,6 +128,12 @@ export async function $onEmit(context: EmitContext<PythonEmitterOptions>) {
         commandArgs.push(`--packaging-files-config='${keyValuePairs.join("|")}'`);
         resolvedOptions["packaging-files-config"] = undefined;
     }
+    if (
+        resolvedOptions["package-pprint-name"] !== undefined &&
+        !resolvedOptions["package-pprint-name"].startsWith('"')
+    ) {
+        resolvedOptions["package-pprint-name"] = `"${resolvedOptions["package-pprint-name"]}"`;
+    }
 
     for (const [key, value] of Object.entries(resolvedOptions)) {
         if (value !== undefined) {


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.python/issues/2345