### PR TITLE
re-enable pylint in CI pipeline

### DIFF
--- a/eng/pipelines/generated-code-checks-template.yml
+++ b/eng/pipelines/generated-code-checks-template.yml
@@ -10,7 +10,7 @@ steps:
     - script: tox run -e lint
       displayName: Lint ${{ parameters.folderName }} - Python $(PythonVersion)
       workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/${{parameters.package}}/test/${{ parameters.folderName }}
-      condition: and(eq(variables['PythonVersion'], '3.8'), or(contains( '${{ parameters.folderName }}', 'version-tolerant'), eq('${{parameters.package}}', 'typespec-python')))
+      condition: and(eq(variables['PythonVersion'], '3.10'), or(contains( '${{ parameters.folderName }}', 'version-tolerant'), eq('${{parameters.package}}', 'typespec-python')))
 
     - script: tox run -e mypy
       displayName: Mypy ${{ parameters.folderName }} - Python $(PythonVersion)

--- a/packages/autorest.python/autorest/codegen/templates/model_base.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/model_base.py.jinja2
@@ -625,7 +625,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/autorest.python/pylintrc
+++ b/packages/autorest.python/pylintrc
@@ -12,7 +12,7 @@ ignore=_generated,samples,examples,test,tests,doc,.tox,generated_samples
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
 # Let's black deal with bad-continuation
-disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name
+disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name
 
 [FORMAT]
 max-line-length=120

--- a/packages/autorest.python/pylintrc
+++ b/packages/autorest.python/pylintrc
@@ -12,7 +12,7 @@ ignore=_generated,samples,examples,test,tests,doc,.tox,generated_samples
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
 # Let's black deal with bad-continuation
-disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name
+disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name
 
 [FORMAT]
 max-line-length=120

--- a/packages/typespec-python/test/azure/generated/authentication-api-key/authentication/apikey/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/authentication-api-key/authentication/apikey/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/authentication-http-custom/authentication/http/custom/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/authentication-http-custom/authentication/http/custom/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/authentication-oauth2/authentication/oauth2/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/authentication-oauth2/authentication/oauth2/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/authentication-union/authentication/union/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/authentication-union/authentication/union/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azure-mgmt-spheredpg/azure/mgmt/spheredpg/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azure-mgmt-spheredpg/azure/mgmt/spheredpg/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpclegacy/azurecore/lro/rpclegacy/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpclegacy/azurecore/lro/rpclegacy/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/client-structure-default/client/structure/service/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-default/client/structure/service/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/client-structure-multiclient/client/structure/multiclient/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-multiclient/client/structure/multiclient/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/client-structure-renamedoperation/client/structure/renamedoperation/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-renamedoperation/client/structure/renamedoperation/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/parameters-collection-format/parameters/collectionformat/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/parameters-collection-format/parameters/collectionformat/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/payload-media-type/payload/mediatype/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/payload-media-type/payload/mediatype/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/projection-projected-name/projection/projectedname/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/projection-projected-name/projection/projectedname/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/resiliency-srv-driven1/resiliency/srv/driven1/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/resiliency-srv-driven1/resiliency/srv/driven1/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/resiliency-srv-driven2/resiliency/srv/driven2/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/resiliency-srv-driven2/resiliency/srv/driven2/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/server-path-multiple/server/path/multiple/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/server-path-multiple/server/path/multiple/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/server-path-single/server/path/single/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/server-path-single/server/path/single/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/server-versions-not-versioned/server/versions/notversioned/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/server-versions-not-versioned/server/versions/notversioned/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/server-versions-versioned/server/versions/versioned/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/server-versions-versioned/server/versions/versioned/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/special-headers-client-request-id/specialheaders/clientrequestid/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/special-headers-client-request-id/specialheaders/clientrequestid/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/special-headers-repeatability/specialheaders/repeatability/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/special-headers-repeatability/specialheaders/repeatability/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/special-words/specialwords/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/special-words/specialwords/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-enum-extensible/typetest/enum/extensible/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-enum-extensible/typetest/enum/extensible/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-enum-fixed/typetest/enum/fixed/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-enum-fixed/typetest/enum/fixed/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/_model_base.py
+++ b/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/authentication-api-key/authentication/apikey/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-api-key/authentication/apikey/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/authentication-http-custom/authentication/http/custom/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-http-custom/authentication/http/custom/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/authentication-oauth2/authentication/oauth2/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-oauth2/authentication/oauth2/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/authentication-union/authentication/union/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-union/authentication/union/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/client-structure-default/client/structure/service/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-default/client/structure/service/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/client-structure-multiclient/client/structure/multiclient/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-multiclient/client/structure/multiclient/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/client-structure-renamedoperation/client/structure/renamedoperation/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-renamedoperation/client/structure/renamedoperation/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/parameters-collection-format/parameters/collectionformat/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-collection-format/parameters/collectionformat/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/payload-media-type/payload/mediatype/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-media-type/payload/mediatype/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/projection-projected-name/projection/projectedname/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/projection-projected-name/projection/projectedname/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven1/resiliency/srv/driven1/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven1/resiliency/srv/driven1/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven2/resiliency/srv/driven2/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven2/resiliency/srv/driven2/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/server-path-multiple/server/path/multiple/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/server-path-multiple/server/path/multiple/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/server-path-single/server/path/single/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/server-path-single/server/path/single/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/server-versions-not-versioned/server/versions/notversioned/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/server-versions-not-versioned/server/versions/notversioned/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/server-versions-versioned/server/versions/versioned/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/server-versions-versioned/server/versions/versioned/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/special-headers-repeatability/specialheaders/repeatability/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/special-headers-repeatability/specialheaders/repeatability/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/special-words/specialwords/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/special-words/specialwords/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-enum-extensible/typetest/enum/extensible/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-enum-extensible/typetest/enum/extensible/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-enum-fixed/typetest/enum/fixed/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-enum-fixed/typetest/enum/fixed/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass

--- a/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/_model_base.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/_model_base.py
@@ -611,7 +611,7 @@ def _get_deserialize_callable_from_annotation(  # pylint: disable=R0911, R0915, 
 
     # is it a literal?
     try:
-        if annotation.__origin__ == typing.Literal:
+        if annotation.__origin__ is typing.Literal:
             return None
     except AttributeError:
         pass


### PR DESCRIPTION
It looks like that when we dropped 3.7, we stopped running pylint in the CI pipelines. Updating this to the next minimum version of Python we run and fixing a linting error that came up.