### PR TITLE
Bump cadl ranch 0.28.7

### DIFF
--- a/eng/pipelines/internal-ci.yml
+++ b/eng/pipelines/internal-ci.yml
@@ -27,16 +27,25 @@ steps:
       displayName: Mock Api Tests for Unbranded
       workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/typespec-python/test/unbranded
 
+    - task: AzureCLI@2
+      displayName: Upload scenario manifest for unbranded
+      inputs:
+        azureSubscription: "Cadl Ranch Storage"
+        scriptType: "bash"
+        scriptLocation: "inlineScript"
+        inlineScript: cadl-ranch upload-coverage --generatorName python --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/autorest.python/packages/typespec-python/package.json').version") --generatorMode standard
+        workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/typespec-python/node_modules/@azure-tools/cadl-ranch-specs
+
     - script: |
             tox run -e ci
       displayName: Mock Api Tests for Azure
       workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/typespec-python/test/azure
 
     - task: AzureCLI@2
-      displayName: Upload scenario manifest
+      displayName: Upload scenario manifest for azure
       inputs:
         azureSubscription: "Cadl Ranch Storage"
         scriptType: "bash"
         scriptLocation: "inlineScript"
-        inlineScript: cadl-ranch upload-coverage --generatorName python --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/autorest.python/packages/typespec-python/package.json').version")
+        inlineScript: cadl-ranch upload-coverage --generatorName python --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/autorest.python/packages/typespec-python/package.json').version") --generatorMode azure
         workingDirectory: $(Build.SourcesDirectory)/autorest.python/packages/typespec-python/node_modules/@azure-tools/cadl-ranch-specs

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/Azure/autorest.python#readme",
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "~0.51.0",
-    "@azure-tools/cadl-ranch": "~0.11.0",
+    "@azure-tools/cadl-ranch": "~0.11.2",
     "autorest": "3.6.3",
     "eslint": "^8.44.0",
     "eslint-plugin-import": "^2.27.5",

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -61,8 +61,8 @@
     "devDependencies": {
         "@azure-tools/typespec-azure-resource-manager": ">=0.37.0 <1.0.0",
         "@azure-tools/typespec-autorest": ">=0.37.0 <1.0.0",
-        "@azure-tools/cadl-ranch-expect": "~0.10.0",
-        "@azure-tools/cadl-ranch-specs": "~0.28.5",
+        "@azure-tools/cadl-ranch-expect": "~0.11.0",
+        "@azure-tools/cadl-ranch-specs": "~0.28.7",
         "@types/js-yaml": "~4.0.5",
         "@types/mocha": "~10.0.1",
         "@types/node": "^18.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
     devDependencies:
       '@azure-tools/cadl-ranch':
-        specifier: ~0.11.0
-        version: 0.11.0(@typespec/versioning@0.51.0)
+        specifier: ~0.11.2
+        version: 0.11.2(@typespec/versioning@0.51.0)
       '@typespec/prettier-plugin-typespec':
         specifier: ~0.51.0
         version: 0.51.0
@@ -55,11 +59,11 @@ importers:
         version: 4.1.0
     devDependencies:
       '@azure-tools/cadl-ranch-expect':
-        specifier: ~0.10.0
-        version: 0.10.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
+        specifier: ~0.11.0
+        version: 0.11.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
       '@azure-tools/cadl-ranch-specs':
-        specifier: ~0.28.5
-        version: 0.28.5(@azure-tools/cadl-ranch-expect@0.10.0)(@azure-tools/typespec-azure-core@0.37.0)(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
+        specifier: ~0.28.7
+        version: 0.28.7(@azure-tools/cadl-ranch-expect@0.11.0)(@azure-tools/typespec-azure-core@0.37.0)(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
       '@azure-tools/typespec-autorest':
         specifier: '>=0.37.0 <1.0.0'
         version: 0.37.0(@azure-tools/typespec-azure-core@0.37.0)(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/openapi@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
@@ -153,8 +157,8 @@ packages:
       - supports-color
     dev: true
 
-  /@azure-tools/cadl-ranch-coverage-sdk@0.6.0:
-    resolution: {integrity: sha512-Bn4Wnai4gFYer4V74miOokrPvfdaNq8WayQ0BpfgJW9bvQu9AHniDZno5dl4TIJp4FUSezluKe5YoBED/nkxFw==}
+  /@azure-tools/cadl-ranch-coverage-sdk@0.6.1:
+    resolution: {integrity: sha512-eQuzWblWdNLXZOVO+QMwFt3n+Y/DCekfmYK6XxNcASbh5KlL4hFkwg1Jjtm7bt/Eb+0uqmwAFnPDx7C+rCRCFQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@azure/identity': 3.3.0
@@ -165,8 +169,8 @@ packages:
       - supports-color
     dev: true
 
-  /@azure-tools/cadl-ranch-expect@0.10.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0):
-    resolution: {integrity: sha512-7PAM++YlTBY83kWgI/2UKEQv9iZDktSWiWHiiklXY5Zkd6Hqsg3vjWrLBO/gVXTWOe11LU8g9M177GSLh8bPGA==}
+  /@azure-tools/cadl-ranch-expect@0.11.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0):
+    resolution: {integrity: sha512-0iTdWr8X+Su+3HIfg1glIzlMzXdsIHKIAAZ8ks480wCVwkcCJQtFn4AtSYXLY2FWf0b6jzb+51BvDpAi0SSwqQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@typespec/compiler': ~0.51.0
@@ -180,20 +184,20 @@ packages:
       '@typespec/versioning': 0.51.0(@typespec/compiler@0.51.0)
     dev: true
 
-  /@azure-tools/cadl-ranch-specs@0.28.5(@azure-tools/cadl-ranch-expect@0.10.0)(@azure-tools/typespec-azure-core@0.37.0)(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0):
-    resolution: {integrity: sha512-BTHVDYY5JLG5Zf4WuV5hHvd8xLafIWgXuesuRUzDwT7gzfvBv7L1vLBXcgixh/7cXqforO7O+lozi0pPbgSydg==}
+  /@azure-tools/cadl-ranch-specs@0.28.7(@azure-tools/cadl-ranch-expect@0.11.0)(@azure-tools/typespec-azure-core@0.37.0)(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0):
+    resolution: {integrity: sha512-UDYR64oL0QZQ4FxKI7SEKPoLhewlYZRUrOD0fTnfUCTPuaQ/P5h+F5NZfEBHer+2WRhuvY5Xc7Glba33NPyTWg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@azure-tools/cadl-ranch-expect': ~0.10.0
+      '@azure-tools/cadl-ranch-expect': ~0.11.0
       '@azure-tools/typespec-azure-core': ~0.37.0
       '@typespec/compiler': ~0.51.0
       '@typespec/http': ~0.51.0
       '@typespec/rest': ~0.51.0
       '@typespec/versioning': ~0.51.0
     dependencies:
-      '@azure-tools/cadl-ranch': 0.11.0(@typespec/versioning@0.51.0)
+      '@azure-tools/cadl-ranch': 0.11.2(@typespec/versioning@0.51.0)
       '@azure-tools/cadl-ranch-api': 0.4.3
-      '@azure-tools/cadl-ranch-expect': 0.10.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
+      '@azure-tools/cadl-ranch-expect': 0.11.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
       '@azure-tools/typespec-azure-core': 0.37.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)
       '@typespec/compiler': 0.51.0
       '@typespec/http': 0.51.0(@typespec/compiler@0.51.0)
@@ -205,14 +209,14 @@ packages:
       - supports-color
     dev: true
 
-  /@azure-tools/cadl-ranch@0.11.0(@typespec/versioning@0.51.0):
-    resolution: {integrity: sha512-LfOt9HLn5F3vGOsWmqTjIgbOeV9sEb3KSYHmRCp6SDf2Rxc0fVLZL7ngXTvzQF+/Vid0xFkaW4Ze0jjXv6hyoQ==}
+  /@azure-tools/cadl-ranch@0.11.2(@typespec/versioning@0.51.0):
+    resolution: {integrity: sha512-7y8k2fvlo3+UolO93u7itmfkRzLW4ToknJaNA3nK2X7Nvkm80efFvdchgfl/wAdr+rt7Ms5o5DvDzlKj2vOu8g==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
       '@azure-tools/cadl-ranch-api': 0.4.3
-      '@azure-tools/cadl-ranch-coverage-sdk': 0.6.0
-      '@azure-tools/cadl-ranch-expect': 0.10.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
+      '@azure-tools/cadl-ranch-coverage-sdk': 0.6.1
+      '@azure-tools/cadl-ranch-expect': 0.11.0(@typespec/compiler@0.51.0)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)
       '@azure/identity': 3.3.0
       '@types/js-yaml': 4.0.5
       '@typespec/compiler': 0.51.0
@@ -5176,7 +5180,3 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
- bump cadl-ranch
- update ci to upload coverage report for unbranded/azure with reference of https://github.com/Azure/autorest.csharp/pull/4144