### PR TITLE
make pyright + next-pyright clean

### DIFF
--- a/eng/requirements.txt
+++ b/eng/requirements.txt
@@ -1,5 +1,5 @@
 # This is for CI requirements or dev only
-pyright==1.1.333
+pyright==1.1.350
 pylint==3.0.3
 tox==4.12.1
 mypy==1.8.0

--- a/eng/requirements.txt
+++ b/eng/requirements.txt
@@ -1,5 +1,5 @@
 # This is for CI requirements or dev only
-pyright==1.1.350
+pyright==1.1.333
 pylint==3.0.3
 tox==4.12.1
 mypy==1.8.0

--- a/packages/autorest.python/autorest/codegen/templates/serialization.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/serialization.py.jinja2
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/samples/specification/azure_key_credential/generated/azure/key/credential/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/azure_key_credential/generated/azure/key/credential/sample/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/samples/specification/basic/generated/azure/basic/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/basic/generated/azure/basic/sample/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/samples/specification/directives/generated/azure/directives/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/directives/generated/azure/directives/sample/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/samples/specification/management/generated/azure/mgmt/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/management/generated/azure/mgmt/sample/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/_serialization.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureBodyDuration/bodyduration/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureReport/azurereport/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/AzureReport/azurereport/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomPollerPager/custompollerpager/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/CustomUrlPaging/custombaseurlpaging/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Head/head/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Head/head/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadExceptions/headexceptions/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadExceptions/headexceptions/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadWithAzureKeyCredentialPolicy/headwithazurekeycredentialpolicy/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/HeadWithAzureKeyCredentialPolicy/headwithazurekeycredentialpolicy/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Lro/lro/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/LroWithParameterizedEndpoints/lrowithparameterizedendpoints/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/MixedApiVersion/mixedapiversion/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/MixedApiVersion/mixedapiversion/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/head/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/head/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/paging/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeBatch/azure/packagemode/batch/paging/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeCustomize/azure/packagemode/customize/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeCustomize/azure/packagemode/customize/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeDataPlane/azure/packagemode/dataplane/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeDataPlane/azure/packagemode/dataplane/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeMgmtPlane/azure/package/mode/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/PackageModeMgmtPlane/azure/package/mode/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/Paging/paging/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/StorageManagementClient/storage/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/_serialization.py
+++ b/packages/autorest.python/test/azure/legacy/Expected/AcceptanceTests/SubscriptionIdApiVersion/subscriptionidapiversion/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureBodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureBodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureParameterGroupingVersionTolerant/azureparametergroupingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureParameterGroupingVersionTolerant/azureparametergroupingversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureReportVersionTolerant/azurereportversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureReportVersionTolerant/azurereportversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureSpecialsVersionTolerant/azurespecialpropertiesversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/AzureSpecialsVersionTolerant/azurespecialpropertiesversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomPollerPagerVersionTolerant/custompollerpagerversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomUrlPagingVersionTolerant/custombaseurlpagingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/CustomUrlPagingVersionTolerant/custombaseurlpagingversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadExceptionsVersionTolerant/headexceptionsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadExceptionsVersionTolerant/headexceptionsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadVersionTolerant/headversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/HeadVersionTolerant/headversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroPagingVersionTolerant/lropagingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroPagingVersionTolerant/lropagingversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroVersionTolerant/lroversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/LroWithParameterizedEndpointsVersionTolerant/lrowithparameterizedendpointsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/PagingVersionTolerant/pagingversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/StorageManagementClientVersionTolerant/storageversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/SubscriptionIdApiVersionVersionTolerant/subscriptionidapiversionversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/azure/version-tolerant/Expected/AcceptanceTests/SubscriptionIdApiVersionVersionTolerant/subscriptionidapiversionversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationCustomizedVersionTolerant/dpgcustomizationcustomizedversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGCustomizationInitialVersionTolerant/dpgcustomizationinitialversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenInitialVersionTolerant/dpgservicedriveninitialversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenInitialVersionTolerant/dpgservicedriveninitialversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGServiceDrivenUpdateOneVersionTolerant/dpgservicedrivenupdateoneversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/dpg/version-tolerant/Expected/AcceptanceTests/DPGTestModelsVersionTolerant/dpgtestmodelsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/Multiapi/multiapi/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCredentialDefaultPolicy/multiapicredentialdefaultpolicy/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiCustomBaseUrl/multiapicustombaseurl/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiDataPlane/multiapidataplane/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiKeywordOnly/multiapikeywordonly/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiKeywordOnly/multiapikeywordonly/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiNoAsync/multiapinoasync/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiSecurity/multiapisecurity/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/MultiapiWithSubmodule/multiapiwithsubmodule/submodule/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/multiapicombiner/multiapicombiner/_serialization.py
+++ b/packages/autorest.python/test/multiapi/Expected/AcceptanceTests/multiapicombiner/multiapicombiner/_serialization.py
@@ -1520,7 +1520,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/unittests/storage_models/serialization.py
+++ b/packages/autorest.python/test/unittests/storage_models/serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/AdditionalProperties/additionalproperties/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Anything/anything/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Anything/anything/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArray/bodyarray/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArray/bodyarray/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyArrayWithNamespaceFolders/vanilla/body/array/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBinary/bodybinary/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBinary/bodybinary/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBoolean/bodyboolean/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyBoolean/bodyboolean/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByte/bodybyte/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByte/bodybyte/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyByteWithPackageName/bodybytewithpackagename/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDate/bodydate/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDate/bodydate/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTime/bodydatetime/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTime/bodydatetime/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDateTimeRfc1123/bodydatetimerfc1123/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDictionary/bodydictionary/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDictionary/bodydictionary/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDuration/bodyduration/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyDuration/bodyduration/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFile/bodyfile/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFile/bodyfile/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormData/bodyformdata/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormData/bodyformdata/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormUrlEncodedData/bodyformurlencodeddata/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyFormUrlEncodedData/bodyformurlencodeddata/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyInteger/bodyinteger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyInteger/bodyinteger/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyNumber/bodynumber/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyNumber/bodynumber/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyString/bodystring/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyString/bodystring/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyTime/bodytime/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/BodyTime/bodytime/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ClientEnum/clientenum/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ClientEnum/clientenum/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Constants/constants/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Constants/constants/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/CustomBaseUriMoreOptions/custombaseurlmoreoptions/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ErrorWithSecrets/errorwithsecrets/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ErrorWithSecrets/errorwithsecrets/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ExtensibleEnums/extensibleenumsswagger/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Header/header/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Header/header/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Http/httpinfrastructure/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Http/httpinfrastructure/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/IncorrectErrorResponse/incorrecterrorresponse/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/IncorrectErrorResponse/incorrecterrorresponse/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/InternalOperation/internaloperation/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/InternalOperation/internaloperation/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MediaTypes/mediatypes/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MergePatchJson/mergepatchjson/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MergePatchJson/mergepatchjson/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ModelFlattening/modelflattening/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ModelFlattening/modelflattening/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/MultipleInheritance/multipleinheritance/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NoOperations/nooperations/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NoOperations/nooperations/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NonStringEnums/nonstringenums/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/NonStringEnums/nonstringenums/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ObjectType/objecttype/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ObjectType/objecttype/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/PackageModeDataPlane/packagemode/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/PackageModeDataPlane/packagemode/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterFlattening/parameterflattening/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterizedEndpoint/parameterizedendpoint/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ParameterizedEndpoint/parameterizedendpoint/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Report/report/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Report/report/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ReservedWords/reservedwords/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/ReservedWords/reservedwords/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwagger/securityaadswagger/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwaggerCredentialFlag/securityaadswaggercredentialflag/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityAadSwaggerCredentialFlag/securityaadswaggercredentialflag/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwagger/securitykeyswagger/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwaggerCredentialFlag/securitykeyswaggercredentialflag/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/SecurityKeySwaggerCredentialFlag/securitykeyswaggercredentialflag/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/UrlMultiCollectionFormat/urlmulticollectionformat/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Xml/xmlservice/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/Xml/xmlservice/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/_serialization.py
+++ b/packages/autorest.python/test/vanilla/legacy/Expected/AcceptanceTests/XmsErrorResponse/xmserrorresponse/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AdditionalPropertiesVersionTolerant/additionalpropertiesversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AdditionalPropertiesVersionTolerant/additionalpropertiesversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AnythingVersionTolerant/anythingversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/AnythingVersionTolerant/anythingversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyArrayVersionTolerant/bodyarrayversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyArrayVersionTolerant/bodyarrayversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBinaryVersionTolerant/bodybinaryversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBinaryVersionTolerant/bodybinaryversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBooleanVersionTolerant/bodybooleanversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyBooleanVersionTolerant/bodybooleanversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyByteVersionTolerant/bodybyteversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyByteVersionTolerant/bodybyteversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeRfc1123VersionTolerant/bodydatetimerfc1123versiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeRfc1123VersionTolerant/bodydatetimerfc1123versiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeVersionTolerant/bodydatetimeversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateTimeVersionTolerant/bodydatetimeversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateVersionTolerant/bodydateversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDateVersionTolerant/bodydateversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDictionaryVersionTolerant/bodydictionaryversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDictionaryVersionTolerant/bodydictionaryversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyDurationVersionTolerant/bodydurationversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFileVersionTolerant/bodyfileversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFileVersionTolerant/bodyfileversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormDataVersionTolerant/bodyformdataversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormDataVersionTolerant/bodyformdataversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormUrlEncodedDataVersionTolerant/bodyformurlencodeddataversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyFormUrlEncodedDataVersionTolerant/bodyformurlencodeddataversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyIntegerVersionTolerant/bodyintegerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyIntegerVersionTolerant/bodyintegerversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyNumberVersionTolerant/bodynumberversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyNumberVersionTolerant/bodynumberversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyStringVersionTolerant/bodystringversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyStringVersionTolerant/bodystringversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyTimeVersionTolerant/bodytimeversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyTimeVersionTolerant/bodytimeversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ClientEnumVersionTolerant/clientenumversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ClientEnumVersionTolerant/clientenumversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ConstantsVersionTolerant/constantsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ConstantsVersionTolerant/constantsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriMoreOptionsVersionTolerant/custombaseurlmoreoptionsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriMoreOptionsVersionTolerant/custombaseurlmoreoptionsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/CustomBaseUriVersionTolerant/custombaseurlversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ErrorWithSecretsVersionTolerant/errorwithsecretsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ErrorWithSecretsVersionTolerant/errorwithsecretsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ExtensibleEnumsVersionTolerant/extensibleenumsswaggerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ExtensibleEnumsVersionTolerant/extensibleenumsswaggerversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HeaderVersionTolerant/headerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HeaderVersionTolerant/headerversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HttpVersionTolerant/httpinfrastructureversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/HttpVersionTolerant/httpinfrastructureversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/IncorrectErrorResponseVersionTolerant/incorrecterrorresponseversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/IncorrectErrorResponseVersionTolerant/incorrecterrorresponseversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MediaTypesVersionTolerant/mediatypesversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MergePatchJsonVersionTolerant/mergepatchjsonversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MergePatchJsonVersionTolerant/mergepatchjsonversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ModelFlatteningVersionTolerant/modelflatteningversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ModelFlatteningVersionTolerant/modelflatteningversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MultipleInheritanceVersionTolerant/multipleinheritanceversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/MultipleInheritanceVersionTolerant/multipleinheritanceversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoNamespaceFlagVersionTolerant/anything_client/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoNamespaceFlagVersionTolerant/anything_client/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoOperationsVersionTolerant/nooperationsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NoOperationsVersionTolerant/nooperationsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NonStringEnumsVersionTolerant/nonstringenumsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/NonStringEnumsVersionTolerant/nonstringenumsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ObjectTypeVersionTolerant/objecttypeversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ObjectTypeVersionTolerant/objecttypeversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterFlatteningVersionTolerant/parameterflatteningversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterFlatteningVersionTolerant/parameterflatteningversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterizedEndpointVersionTolerant/parameterizedendpointversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ParameterizedEndpointVersionTolerant/parameterizedendpointversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReportVersionTolerant/reportversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReportVersionTolerant/reportversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/RequiredOptionalVersionTolerant/requiredoptionalversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/RequiredOptionalVersionTolerant/requiredoptionalversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReservedWordsVersionTolerant/reservedwordsversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ReservedWordsVersionTolerant/reservedwordsversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityAadSwaggerVersionTolerant/securityaadswaggerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityAadSwaggerVersionTolerant/securityaadswaggerversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityKeySwaggerVersionTolerant/securitykeyswaggerversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/SecurityKeySwaggerVersionTolerant/securitykeyswaggerversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlMultiCollectionFormatVersionTolerant/urlmulticollectionformatversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlMultiCollectionFormatVersionTolerant/urlmulticollectionformatversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlVersionTolerant/urlversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/UrlVersionTolerant/urlversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ValidationVersionTolerant/validationversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/ValidationVersionTolerant/validationversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmlVersionTolerant/xmlserviceversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmlVersionTolerant/xmlserviceversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmsErrorResponseVersionTolerant/xmserrorresponseversiontolerant/_serialization.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/XmsErrorResponseVersionTolerant/xmserrorresponseversiontolerant/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/authentication-api-key/authentication/apikey/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/authentication-api-key/authentication/apikey/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/authentication-http-custom/authentication/http/custom/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/authentication-http-custom/authentication/http/custom/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/authentication-oauth2/authentication/oauth2/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/authentication-oauth2/authentication/oauth2/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/authentication-union/authentication/union/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/authentication-union/authentication/union/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-flatten/type/model/flatten/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-flatten/type/model/flatten/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-mgmt-spheredpg/azure/mgmt/spheredpg/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-mgmt-spheredpg/azure/mgmt/spheredpg/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azure-mgmt-spheremsrest/azure/mgmt/spheremsrest/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azure-mgmt-spheremsrest/azure/mgmt/spheremsrest/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpclegacy/azurecore/lro/rpclegacy/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpclegacy/azurecore/lro/rpclegacy/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/client-structure-default/client/structure/service/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-default/client/structure/service/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/client-structure-multiclient/client/structure/multiclient/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-multiclient/client/structure/multiclient/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/client-structure-renamedoperation/client/structure/renamedoperation/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-renamedoperation/client/structure/renamedoperation/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/parameters-collection-format/parameters/collectionformat/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/parameters-collection-format/parameters/collectionformat/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/payload-json-merge-patch/payload/jsonmergepatch/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/payload-json-merge-patch/payload/jsonmergepatch/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/payload-media-type/payload/mediatype/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/payload-media-type/payload/mediatype/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/projection-projected-name/projection/projectedname/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/projection-projected-name/projection/projectedname/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/resiliency-srv-driven1/resiliency/srv/driven1/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/resiliency-srv-driven1/resiliency/srv/driven1/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/resiliency-srv-driven2/resiliency/srv/driven2/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/resiliency-srv-driven2/resiliency/srv/driven2/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/server-path-multiple/server/path/multiple/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/server-path-multiple/server/path/multiple/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/server-path-single/server/path/single/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/server-path-single/server/path/single/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/server-versions-not-versioned/server/versions/notversioned/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/server-versions-not-versioned/server/versions/notversioned/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/server-versions-versioned/server/versions/versioned/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/server-versions-versioned/server/versions/versioned/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/special-headers-client-request-id/specialheaders/clientrequestid/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/special-headers-client-request-id/specialheaders/clientrequestid/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/special-headers-repeatability/specialheaders/repeatability/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/special-headers-repeatability/specialheaders/repeatability/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/special-words/specialwords/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/special-words/specialwords/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-enum-extensible/typetest/enum/extensible/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-enum-extensible/typetest/enum/extensible/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-enum-fixed/typetest/enum/fixed/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-enum-fixed/typetest/enum/fixed/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/_serialization.py
+++ b/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/authentication-api-key/authentication/apikey/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-api-key/authentication/apikey/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/authentication-http-custom/authentication/http/custom/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-http-custom/authentication/http/custom/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/authentication-oauth2/authentication/oauth2/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-oauth2/authentication/oauth2/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/authentication-union/authentication/union/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/authentication-union/authentication/union/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/client-structure-default/client/structure/service/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-default/client/structure/service/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/client-structure-multiclient/client/structure/multiclient/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-multiclient/client/structure/multiclient/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/client-structure-renamedoperation/client/structure/renamedoperation/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-renamedoperation/client/structure/renamedoperation/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/client-structure-twooperationgroup/client/structure/twooperationgroup/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/parameters-collection-format/parameters/collectionformat/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-collection-format/parameters/collectionformat/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/payload-json-merge-patch/payload/jsonmergepatch/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-json-merge-patch/payload/jsonmergepatch/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/payload-media-type/payload/mediatype/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-media-type/payload/mediatype/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/projection-projected-name/projection/projectedname/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/projection-projected-name/projection/projectedname/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven1/resiliency/srv/driven1/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven1/resiliency/srv/driven1/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven2/resiliency/srv/driven2/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/resiliency-srv-driven2/resiliency/srv/driven2/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/server-path-multiple/server/path/multiple/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/server-path-multiple/server/path/multiple/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/server-path-single/server/path/single/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/server-path-single/server/path/single/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/server-versions-not-versioned/server/versions/notversioned/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/server-versions-not-versioned/server/versions/notversioned/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/server-versions-versioned/server/versions/versioned/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/server-versions-versioned/server/versions/versioned/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/special-headers-conditional-request/specialheaders/conditionalrequest/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/special-headers-repeatability/specialheaders/repeatability/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/special-headers-repeatability/specialheaders/repeatability/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/special-words/specialwords/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/special-words/specialwords/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-enum-extensible/typetest/enum/extensible/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-enum-extensible/typetest/enum/extensible/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-enum-fixed/typetest/enum/fixed/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-enum-fixed/typetest/enum/fixed/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore

--- a/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/_serialization.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/_serialization.py
@@ -1514,7 +1514,7 @@ class Deserializer(object):
                 return target, target
 
         try:
-            target = target._classify(data, self.dependencies)
+            target = target._classify(data, self.dependencies)  # type: ignore
         except AttributeError:
             pass  # Target is not a Model, no classify
         return target, target.__class__.__name__  # type: ignore


### PR DESCRIPTION
pyright-next is happy with the changes, but old pyright is not in the sdk-for-python repo. Ensuring we are clean for both versions (1.1.333 and 1.1.350)