### PR TITLE
Upgrade pip when creating venv

### DIFF
--- a/packages/autorest.python/ChangeLog.md
+++ b/packages/autorest.python/ChangeLog.md
@@ -1,5 +1,21 @@
 # Release
 
+## 2024-03-21 - 6.13.6
+
+| Library                                                                 | Min Version |
+| ----------------------------------------------------------------------- | ----------- |
+| `@autorest/core`                                                        | `3.9.2`     |
+| `@autorest/modelerfour`                                                 | `4.24.3`    |
+| `azure-core` dep of generated code                                      | `1.30.0`    |
+| `isodate` dep of generated code                                         | `0.6.1`     |
+| `msrest` dep of generated code (If generating legacy code)              | `0.7.1`     |
+| `azure-mgmt-core` dep of generated code (If generating mgmt plane code) | `1.3.2`     |
+| `typing-extensions` dep of generated code (If generating with constants)| `4.0.1`     |
+
+**Bug Fixes**
+
+- Upgrade pip when creating venv #2447
+
 ## 2024-03-21 - 6.13.5
 
 | Library                                                                 | Min Version |

--- a/packages/autorest.python/autorest/postprocess/__init__.py
+++ b/packages/autorest.python/autorest/postprocess/__init__.py
@@ -52,7 +52,7 @@ class PostProcessPlugin(Plugin):  # pylint: disable=abstract-method
             env_builder = EnvBuilder(with_pip=True)
             self.venv_context = env_builder.ensure_directories(venv_path)
         else:
-            env_builder = ExtendedEnvBuilder(with_pip=True)
+            env_builder = ExtendedEnvBuilder(with_pip=True, upgrade_deps=True)
             env_builder.create(venv_path)
             self.venv_context = env_builder.context
             python_run(

--- a/packages/autorest.python/autorest/postprocess/venvtools.py
+++ b/packages/autorest.python/autorest/postprocess/venvtools.py
@@ -20,7 +20,10 @@ class ExtendedEnvBuilder(venv.EnvBuilder):
 
     def __init__(self, *args, **kwargs):
         self.context = None
-        super(ExtendedEnvBuilder, self).__init__(*args, **kwargs)
+        if sys.version_info < (3, 9, 0):
+            # Not supported on Python 3.8, and we don't need it
+            kwargs.pop("upgrade_deps", None)
+        super().__init__(*args, **kwargs)
 
     def ensure_directories(self, env_dir):
         self.context = super(ExtendedEnvBuilder, self).ensure_directories(env_dir)
@@ -34,6 +37,7 @@ def create(
     symlinks=False,
     with_pip=False,
     prompt=None,
+    upgrade_deps=False,
 ):
     """Create a virtual environment in a directory."""
     builder = ExtendedEnvBuilder(
@@ -42,6 +46,7 @@ def create(
         symlinks=symlinks,
         with_pip=with_pip,
         prompt=prompt,
+        upgrade_deps=upgrade_deps,
     )
     builder.create(env_dir)
     return builder.context

--- a/packages/autorest.python/install.py
+++ b/packages/autorest.python/install.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import sys
-if not sys.version_info >= (3, 7, 0):
+if not sys.version_info >= (3, 8, 0):
     raise Exception("Autorest for Python extension requires Python 3.8 at least")
 
 try:
@@ -32,13 +32,12 @@ _ROOT_DIR = Path(__file__).parent
 
 def main():
     venv_path = _ROOT_DIR / "venv"
-    venv_prexists = venv_path.exists()
 
-    if venv_prexists:
+    if venv_path.exists():
         env_builder = venv.EnvBuilder(with_pip=True)
         venv_context = env_builder.ensure_directories(venv_path)
     else:
-        env_builder = ExtendedEnvBuilder(with_pip=True)
+        env_builder = ExtendedEnvBuilder(with_pip=True, upgrade_deps=True)
         env_builder.create(venv_path)
         venv_context = env_builder.context
 

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.13.5",
+  "version": "6.13.6",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "prepare": "node run-python3.js prepare.py",

--- a/packages/autorest.python/start.py
+++ b/packages/autorest.python/start.py
@@ -23,7 +23,7 @@ def main():
 
     assert venv_prexists  # Otherwise install was not done
 
-    env_builder = venv.EnvBuilder(with_pip=True)
+    env_builder = venv.EnvBuilder(with_pip=True, upgrade_deps=True)
     venv_context = env_builder.ensure_directories(venv_path)
     python_run(venv_context, "autorest.jsonrpc.server", command=sys.argv[1:])
 

--- a/packages/autorest.python/venvtools.py
+++ b/packages/autorest.python/venvtools.py
@@ -21,6 +21,9 @@ class ExtendedEnvBuilder(venv.EnvBuilder):
 
     def __init__(self, *args, **kwargs):
         self.context = None
+        if sys.version_info < (3, 9, 0):
+            # Not supported on Python 3.8, and we don't need it
+            kwargs.pop("upgrade_deps", None)
         super().__init__(*args, **kwargs)
 
     def ensure_directories(self, env_dir):
@@ -29,11 +32,11 @@ class ExtendedEnvBuilder(venv.EnvBuilder):
 
 
 def create(env_dir, system_site_packages=False, clear=False,
-                    symlinks=False, with_pip=False, prompt=None):
+                    symlinks=False, with_pip=False, prompt=None, upgrade_deps=False):
     """Create a virtual environment in a directory."""
     builder = ExtendedEnvBuilder(system_site_packages=system_site_packages,
                                  clear=clear, symlinks=symlinks, with_pip=with_pip,
-                                 prompt=prompt)
+                                 prompt=prompt, upgrade_deps=upgrade_deps)
     builder.create(env_dir)
     return builder.context
 
@@ -44,7 +47,7 @@ def create_venv_with_package(packages):
     packages should be an iterable of pip version instructio (e.g. package~=1.2.3)
     """
     with tempfile.TemporaryDirectory() as tempdir:
-        myenv = create(tempdir, with_pip=True)
+        myenv = create(tempdir, with_pip=True, upgrade_deps=True)
         pip_call = [
             myenv.env_exe,
             "-m",

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Release
 
+## 2023-03-12 - 0.22.3
+
+| Library                                                                 | Min Version   |
+| ----------------------------------------------------------------------- | ------------- |
+| `@typespec/compiler`                                                    | `0.54.0`      |
+| `@typespec/http`                                                        | `0.54.0`      |
+| `@typespec/rest`                                                        | `0.54.0`      |
+| `@typespec/versioning`                                                  | `0.54.0`      |
+| `@azure-tools/typespec-azure-core`                                      | `0.40.0`      |
+| `@azure-tools/typespec-client-generator-core`                           | `0.40.0`      |
+| `azure-core` dep of generated code                                      | `1.30.0`      |
+| `corehttp` dep of generated code                                        | `1.0.0b3`     |
+| `isodate` dep of generated code                                         | `0.6.1`       |
+| `azure-mgmt-core` dep of generated code (If generating mgmt plane code) | `1.3.2`       |
+| `typing-extensions` dep of generated code (If generating with constants)| `4.0.1`       |
+
+**Bug Fixes**
+
+- Upgrade pip when creating venv #2447
+
 ## 2023-03-12 - 0.22.2
 
 | Library                                                                 | Min Version   |

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure-tools/typespec-python",
-    "version": "0.22.2",
+    "version": "0.22.3",
     "author": "Microsoft Corporation",
     "description": "TypeSpec emitter for Python SDKs",
     "homepage": "https://github.com/Azure/autorest.python",


### PR DESCRIPTION
Should solve:
https://stackoverflow.com/questions/77238856/problems-installing-libraries-via-pip-after-installing-python-3-12
https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean

For instance:
![image](https://github.com/Azure/autorest.python/assets/1050156/b3011ccc-fd64-413e-9c04-a7be4f78bc48)
