### PR TITLE
add newline after `.. code-block:: python` directive in docstring for polymorphic response

### DIFF
--- a/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
@@ -639,6 +639,7 @@ class _OperationSerializer(
                 discriminator_name = cast(
                     Property, polymorphic_subtypes[0].discriminator
                 ).wire_name
+                retval.append("")
                 retval.append(
                     "# The response is polymorphic. The following are possible polymorphic "
                     f'responses based off discriminator "{discriminator_name}":'

--- a/packages/autorest.python/autorest/codegen/templates/operation_tools.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/operation_tools.jinja2
@@ -24,7 +24,6 @@
 
 Example:
     .. code-block:: python
-
     {% for template_line in example_template %}
         {% if template_line %}
             {% set wrap_amount = (template_line | length) - (template_line.lstrip() | length) + 10 %}

--- a/packages/autorest.python/autorest/codegen/templates/operation_tools.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/operation_tools.jinja2
@@ -24,6 +24,7 @@
 
 Example:
     .. code-block:: python
+
     {% for template_line in example_template %}
         {% if template_line %}
             {% set wrap_amount = (template_line | length) - (template_line.lstrip() | length) + 10 %}

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/aio/operations/_operations.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/aio/operations/_operations.py
@@ -3587,6 +3587,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -4011,6 +4012,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fish.type":
 
@@ -4079,6 +4081,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fish.type":
 
@@ -4166,6 +4169,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fish.type":
 
@@ -4252,6 +4256,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -4487,6 +4492,7 @@ class PolymorphismOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 complex_body = salmon
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -4524,6 +4530,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -4575,6 +4582,7 @@ class PolymorphismOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 complex_body = salmon
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -4975,6 +4983,7 @@ class PolymorphicrecursiveOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -5663,6 +5672,7 @@ class FlattencomplexOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/operations/_operations.py
+++ b/packages/autorest.python/test/vanilla/version-tolerant/Expected/AcceptanceTests/BodyComplexVersionTolerant/bodycomplexversiontolerant/operations/_operations.py
@@ -4384,6 +4384,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -4808,6 +4809,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fish.type":
 
@@ -4876,6 +4878,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fish.type":
 
@@ -4963,6 +4966,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fish.type":
 
@@ -5049,6 +5053,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -5284,6 +5289,7 @@ class PolymorphismOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 complex_body = salmon
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -5321,6 +5327,7 @@ class PolymorphismOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -5372,6 +5379,7 @@ class PolymorphismOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 complex_body = salmon
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -5772,6 +5780,7 @@ class PolymorphicrecursiveOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "fishtype":
 
@@ -6460,6 +6469,7 @@ class FlattencomplexOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/aio/operations/_operations.py
@@ -654,6 +654,7 @@ class RelativeModelInOperationOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/operations/_operations.py
@@ -824,6 +824,7 @@ class RelativeModelInOperationOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
@@ -176,6 +176,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -375,6 +376,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -439,6 +441,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -503,6 +506,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -702,6 +706,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -766,6 +771,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
@@ -58,6 +58,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -259,6 +260,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -323,6 +325,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -387,6 +390,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -586,6 +590,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -650,6 +655,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
@@ -144,6 +144,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -400,6 +401,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -656,6 +658,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -739,6 +742,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
@@ -56,6 +56,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -312,6 +313,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -568,6 +570,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -651,6 +654,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
@@ -158,6 +158,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -432,6 +433,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -706,6 +708,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -795,6 +798,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -884,6 +888,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
@@ -57,6 +57,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -331,6 +332,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -605,6 +607,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -694,6 +697,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -783,6 +787,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
@@ -508,6 +508,7 @@ class ExtendsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -1151,6 +1152,7 @@ class IsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
@@ -874,6 +874,7 @@ class ExtendsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -1517,6 +1518,7 @@ class IsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
@@ -174,6 +174,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -371,6 +372,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -434,6 +436,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -497,6 +500,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -694,6 +698,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -757,6 +762,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
@@ -56,6 +56,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -255,6 +256,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -318,6 +320,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -381,6 +384,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -578,6 +582,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -641,6 +646,7 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
@@ -142,6 +142,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -396,6 +397,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -650,6 +652,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -732,6 +735,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
@@ -54,6 +54,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -308,6 +309,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -562,6 +564,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -644,6 +647,7 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
@@ -156,6 +156,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -428,6 +429,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -700,6 +702,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -788,6 +791,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -876,6 +880,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
@@ -55,6 +55,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -327,6 +328,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -599,6 +601,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -687,6 +690,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -775,6 +779,7 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
@@ -502,6 +502,7 @@ class ExtendsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -1139,6 +1140,7 @@ class IsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
@@ -868,6 +868,7 @@ class ExtendsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 
@@ -1505,6 +1506,7 @@ class IsUnknownDiscriminatedOperations:
 
         Example:
             .. code-block:: python
+
                 # The response is polymorphic. The following are possible polymorphic responses based
                   off discriminator "kind":
 


### PR DESCRIPTION
Sphinx reports an error if there isn't a newline after a `.. code-block:: python` directive in the docstring: [Example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3550563&view=logs&j=e5b925a9-9650-5321-24fd-5d9499fe02b8&t=0d206e13-b346-5d3f-79e6-d5bfba9e089e&l=218).

We were missing a newline only in the polymorphic response case, so adding it in.