### PR TITLE
optimize black

### DIFF
--- a/packages/autorest.python/autorest/black/__init__.py
+++ b/packages/autorest.python/autorest/black/__init__.py
@@ -37,7 +37,15 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
                 [
                     Path(f)
                     for f in self.list_file()
-                    if all(item not in f for item in ("__pycache__", "node_modules"))
+                    if all(
+                        item not in f
+                        for item in (
+                            "__pycache__",
+                            "node_modules",
+                            ".tox",
+                            ".mypy_cache",
+                        )
+                    )
                     and Path(f).suffix == ".py"
                 ],
             )
@@ -45,8 +53,8 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
         return True
 
     def format_file(self, file: Path) -> None:
-        file_content = self.read_file(file)
         try:
+            file_content = self.read_file(file)
             file_content = black.format_file_contents(
                 file_content, fast=True, mode=_BLACK_MODE
             )

--- a/packages/autorest.python/autorest/black/__init__.py
+++ b/packages/autorest.python/autorest/black/__init__.py
@@ -63,7 +63,8 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
         except:  # pylint: disable=bare-except
             _LOGGER.error("Error: failed to format %s", file)
             raise
-        self.write_file(file, file_content)
+        else:
+            self.write_file(file, file_content)
 
 
 class BlackScriptPluginAutorest(BlackScriptPlugin, PluginAutorest):

--- a/packages/typespec-python/README.md
+++ b/packages/typespec-python/README.md
@@ -1,1 +1,1 @@
-# Cadl Python Client Emitter
+# Typespec Python Client Emitter


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.python/issues/2497

The PR includes 2 parts:
- skip `.tox`/`.mypy_cache` for black
- try/catch file.read so that trackback could show which file fails.