### PR TITLE
remove azure-devtools from generated dev reqs txt

### DIFF
--- a/packages/autorest.python/autorest/codegen/templates/packaging_templates/dev_requirements.txt.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/packaging_templates/dev_requirements.txt.jinja2
@@ -1,4 +1,3 @@
--e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
 {% if token_credential -%}


### PR DESCRIPTION
We deleted `azure-devtools` from azure-sdk-for-python