### PR TITLE
check json regexp on first half of content type

### DIFF
--- a/packages/autorest.python/CHANGELOG.md
+++ b/packages/autorest.python/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release
 
+## 2024-04-23 - 6.13.14
+
+| Library                                                                 | Min Version |
+| ----------------------------------------------------------------------- | ----------- |
+| `@autorest/core`                                                        | `3.9.2`     |
+| `@autorest/modelerfour`                                                 | `4.24.3`    |
+| `azure-core` dep of generated code                                      | `1.30.0`    |
+| `isodate` dep of generated code                                         | `0.6.1`     |
+| `msrest` dep of generated code (If generating legacy code)              | `0.7.1`     |
+| `azure-mgmt-core` dep of generated code (If generating mgmt plane code) | `1.3.2`     |
+| `typing-extensions` dep of generated code (If generating with constants)| `4.0.1`     |
+
+**Bug Fixes**
+
+- Json serialize input bodies whose default content type is a JSON type with a charset encoding section #2542
+
 ## 2024-04-22 - 6.13.13
 
 | Library                                                                 | Min Version |

--- a/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/builder_serializer.py
@@ -59,6 +59,10 @@ OperationType = TypeVar(
 )
 
 
+def _json_serializable(content_type: str) -> bool:
+    return bool(JSON_REGEXP.match(content_type.split(";")[0].strip().lower()))
+
+
 def _need_type_ignore(builder: OperationType) -> bool:
     for excep in builder.non_default_errors:
         for status_code in excep.status_codes:
@@ -813,7 +817,7 @@ class _OperationSerializer(
                 f"'{body_param.type.serialization_type}'{is_xml_cmd}{serialization_ctxt_cmd})"
             )
         elif self.code_model.options["models_mode"] == "dpg":
-            if JSON_REGEXP.match(body_param.default_content_type):
+            if _json_serializable(body_param.default_content_type):
                 if hasattr(body_param.type, "encode") and body_param.type.encode:  # type: ignore
                     create_body_call = (
                         f"_{body_kwarg_name} = json.dumps({body_param.client_name}, "
@@ -1157,7 +1161,7 @@ class _OperationSerializer(
                     )
                     response_attr = (
                         "json"
-                        if JSON_REGEXP.match(str(response.default_content_type))
+                        if _json_serializable(str(response.default_content_type))
                         else "text"
                     )
                     deserialize_code.append("deserialized = _deserialize(")

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.13.13",
+  "version": "6.13.14",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "prepare": "node run-python3.js prepare.py",

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Release
 
+## 2023-04-23 - 0.23.5
+
+| Library                                                                 | Min Version   |
+| ----------------------------------------------------------------------- | ------------- |
+| `@typespec/compiler`                                                    | `0.55.0`      |
+| `@typespec/http`                                                        | `0.55.0`      |
+| `@typespec/rest`                                                        | `0.55.0`      |
+| `@typespec/versioning`                                                  | `0.55.0`      |
+| `@azure-tools/typespec-azure-core`                                      | `0.41.4`      |
+| `@azure-tools/typespec-client-generator-core`                           | `0.41.2`      |
+| `azure-core` dep of generated code                                      | `1.30.0`      |
+| `corehttp` dep of generated code                                        | `1.0.0b3`     |
+| `isodate` dep of generated code                                         | `0.6.1`       |
+| `azure-mgmt-core` dep of generated code (If generating mgmt plane code) | `1.3.2`       |
+| `typing-extensions` dep of generated code                               | `4.6.0`       |
+
+**Bug Fixes**
+
+- Json serialize input bodies whose default content type is a JSON type with a charset encoding section #2542
+
 ## 2023-04-22 - 0.23.4
 
 | Library                                                                 | Min Version   |

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-python",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://github.com/Azure/autorest.python",


### PR DESCRIPTION
Currently, we just do `JSON_REGEXP.match` on the full default content type string itself. The `JSON_REGEXP` (which we've copied from core), ensures that the content type ends with the string `"json"`. However, in content types with charsets, i.e. `"application/cloud-events+json; charset=utf-8"`, we fail this check because we don't split on `";"` first.

This PR checks that a input model is expected to be json serializable by first splitting the content type on the `";"` string, then checking it against the `JSON_REGEXP`.

This was causing a bug in event grid serialization, since we weren't json encoding one of their models before sending it to the service

cc @l0lawrence 