### PR TITLE
Escape backslashes in docstring

### DIFF
--- a/packages/autorest.python/autorest/codegen/serializers/client_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/client_serializer.py
@@ -77,6 +77,7 @@ class ClientSerializer:
                 ":keyword int polling_interval: Default waiting time between two polls for LRO operations "
                 "if no Retry-After header is present."
             )
+        retval = [s.replace("\\", "\\\\") for s in retval]
         retval.append('"""')
         return retval
 

--- a/packages/autorest.python/autorest/codegen/serializers/model_serializer.py
+++ b/packages/autorest.python/autorest/codegen/serializers/model_serializer.py
@@ -17,11 +17,8 @@ def _documentation_string(
 ) -> List[str]:
     retval: List[str] = []
     sphinx_prefix = f":{description_keyword} {prop.client_name}:"
-    retval.append(
-        f"{sphinx_prefix} {prop.description(is_operation_file=False)}"
-        if prop.description(is_operation_file=False)
-        else sphinx_prefix
-    )
+    description = prop.description(is_operation_file=False).replace("\\", "\\\\")
+    retval.append(f"{sphinx_prefix} {description}" if description else sphinx_prefix)
     retval.append(
         f":{docstring_type_keyword} {prop.client_name}: {prop.type.docstring_type()}"
     )

--- a/packages/autorest.python/autorest/codegen/templates/enum.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/enum.py.jinja2
@@ -1,13 +1,13 @@
 
 class {{ enum.name }}({{ enum.value_type.type_annotation(is_operation_file=False) }}, Enum, metaclass=CaseInsensitiveEnumMeta):
     {% if enum.yaml_data.get("description") %}
-    """{{ enum.yaml_data["description"] | wordwrap(width=95, break_long_words=False, break_on_hyphens=False, wrapstring='\n    ') }}
+    """{{ op_tools.wrap_string(enum.yaml_data["description"], "\n    ") }}
     """
     {% endif %}
 
     {% for value in enum.values %}
     {{ value.name }} = {{ enum.value_type.get_declaration(value.value) }}
     {% if value.description(is_operation_file=False) %}
-    """{{ value.description(is_operation_file=False) | wordwrap(width=95, break_long_words=False, break_on_hyphens=False, wrapstring='\n    ') }}"""
+    """{{ op_tools.wrap_string(value.description(is_operation_file=False), "\n    ") }}"""
     {% endif %}
     {% endfor %}

--- a/packages/autorest.python/autorest/codegen/templates/enum_container.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/enum_container.py.jinja2
@@ -1,3 +1,4 @@
+{% import 'operation_tools.jinja2' as op_tools %}
 # coding=utf-8
 {{ code_model.options['license_header'] }}
 

--- a/packages/autorest.python/autorest/codegen/templates/model_container.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/model_container.py.jinja2
@@ -1,3 +1,4 @@
+{% import 'operation_tools.jinja2' as op_tools %}
 # coding=utf-8
 # pylint: disable=too-many-lines
 {{ code_model.options['license_header'] }}

--- a/packages/autorest.python/autorest/codegen/templates/model_dpg.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/model_dpg.py.jinja2
@@ -3,7 +3,7 @@
 
 
 {{ serializer.declare_model(model) }}
-    """{{ model.description(is_operation_file=False) | wordwrap(width=95, break_long_words=False, break_on_hyphens=False, wrapstring='\n    ')  }}
+    """{{ op_tools.wrap_string(model.description(is_operation_file=False), "\n    ") }}
     {% if model.discriminated_subtypes %}
 
     {{ serializer.discriminator_docstring(model) | wordwrap(width=95, break_long_words=False, break_on_hyphens=False, wrapstring='\n    ') }}
@@ -86,5 +86,5 @@
             setattr(self.properties, key, value)
         else:
             super().__setattr__(key, value)
-        {% endif %} 
-    {% endif %} 
+        {% endif %}
+    {% endif %}

--- a/packages/autorest.python/autorest/codegen/templates/model_msrest.py.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/model_msrest.py.jinja2
@@ -4,7 +4,7 @@
 {% set exist_constant = (model.properties | selectattr('constant') | first) is defined %}
 
 {{ serializer.declare_model(model) }}
-    """{{ model.description(is_operation_file=False) | wordwrap(width=95, break_long_words=False, break_on_hyphens=False, wrapstring='\n    ') }}
+    """{{ op_tools.wrap_string(model.description(is_operation_file=False), "\n    ") }}
     {% if model.discriminated_subtypes %}
 
     {{ serializer.discriminator_docstring(model) | wordwrap(width=95, break_long_words=False, break_on_hyphens=False, wrapstring='\n    ') }}

--- a/packages/autorest.python/autorest/codegen/templates/operation_tools.jinja2
+++ b/packages/autorest.python/autorest/codegen/templates/operation_tools.jinja2
@@ -1,4 +1,4 @@
-{% macro wrap_string(string, wrapstring, width=95) %}{{ string | wordwrap(width=width, break_long_words=False, break_on_hyphens=False, wrapstring=wrapstring)}}{% endmacro %}
+{% macro wrap_string(string, wrapstring, width=95) %}{{ string | replace("\\", "\\\\") | wordwrap(width=width, break_long_words=False, break_on_hyphens=False, wrapstring=wrapstring)}}{% endmacro %}
 
 {% macro description(builder, serializer) %}
 {% set example_template = serializer.example_template(builder) %}


### PR DESCRIPTION
If we escape backslashes in docstring, we won't face "invalid escape" warnings.

Fixes #2551
