### PR TITLE
Update nightly.yml for timeout limit

### DIFF
--- a/eng/pipelines/nightly.yml
+++ b/eng/pipelines/nightly.yml
@@ -17,6 +17,8 @@ resources:
 variables:
   PythonVersion: "3.10"
 
+timeoutInMinutes: 120
+
 steps:
     - script: npm install -g @typespec/compiler@next
       displayName: Install @typespec/compiler@next


### PR DESCRIPTION
https://dev.azure.com/azure-sdk/public/_build/results?buildId=3959124&view=results, default timeout is 60 minutes:
![image](https://github.com/user-attachments/assets/606ebcfc-9a46-4c28-b16a-e7134a9c0290)

However, all pipelines have a default step named `Finalize CodeQL (auto-injected)` which costs much time and sometimes cause nightly build timeout.

![image](https://github.com/user-attachments/assets/951b8992-b71e-44e7-a3a2-e207ee3bb6d1)
