### PR TITLE
Skip to format files under `venv` and `env`

### DIFF
--- a/.chronus/changes/exclue-venv-2024-6-22-15-39-49.md
+++ b/.chronus/changes/exclue-venv-2024-6-22-15-39-49.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Skip to format files under `venv` and `env`

--- a/.chronus/changes/exclue-venv-2024-6-22-15-39-49.md
+++ b/.chronus/changes/exclue-venv-2024-6-22-15-39-49.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-python"
 ---
 
-Skip to format files under `venv` and `env`
+Skip to format files under `venv`/`env` and any folder start with `.`

--- a/packages/typespec-python/generator/pygen/__init__.py
+++ b/packages/typespec-python/generator/pygen/__init__.py
@@ -54,7 +54,7 @@ class ReaderAndWriter:
             fd.write(file_content)
 
     def list_file(self) -> List[str]:
-        return [str(f) for f in self.output_folder.glob("**/*") if f.is_file()]
+        return [str(f.relative_to(self.output_folder)) for f in self.output_folder.glob("**/*") if f.is_file()]
 
 
 class Plugin(ReaderAndWriter, ABC):

--- a/packages/typespec-python/generator/pygen/black.py
+++ b/packages/typespec-python/generator/pygen/black.py
@@ -37,7 +37,7 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
                 [
                     Path(f)
                     for f in self.list_file()
-                    if Path(f).relative_to(self.output_folder).parts[0]
+                    if Path(f).parts[0]
                     not in (
                         "__pycache__",
                         "node_modules",

--- a/packages/typespec-python/generator/pygen/black.py
+++ b/packages/typespec-python/generator/pygen/black.py
@@ -41,11 +41,10 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
                     not in (
                         "__pycache__",
                         "node_modules",
-                        ".tox",
-                        ".mypy_cache",
                         "venv",
                         "env",
                     )
+                    and not Path(f).parts[0].startswith(".")
                     and Path(f).suffix == ".py"
                 ],
             )

--- a/packages/typespec-python/generator/pygen/black.py
+++ b/packages/typespec-python/generator/pygen/black.py
@@ -37,14 +37,14 @@ class BlackScriptPlugin(Plugin):  # pylint: disable=abstract-method
                 [
                     Path(f)
                     for f in self.list_file()
-                    if all(
-                        item not in f
-                        for item in (
-                            "__pycache__",
-                            "node_modules",
-                            ".tox",
-                            ".mypy_cache",
-                        )
+                    if Path(f).relative_to(self.output_folder).parts[0]
+                    not in (
+                        "__pycache__",
+                        "node_modules",
+                        ".tox",
+                        ".mypy_cache",
+                        "venv",
+                        "env",
                     )
                     and Path(f).suffix == ".py"
                 ],


### PR DESCRIPTION
fix https://github.com/Azure/autorest.python/issues/2705

regenerate sdk: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3981401&view=results
SDK regenerate PR: https://github.com/Azure/azure-sdk-for-python/pull/36561