### PR TITLE
fix release pipeline to unblock package release

### DIFF
--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -2,6 +2,9 @@
 trigger: none
 pr: none
 
+variables:
+  PythonVersion: "3.10"
+
 extends: 
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -2,9 +2,6 @@
 trigger: none
 pr: none
 
-variables:
-  PythonVersion: "3.10"
-
 extends: 
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -26,6 +23,11 @@ extends:
                 AutorestTestFolder: "$(Build.SourcesDirectory)/packages/autorest.python/test/"
 
             steps:
+                - task: UsePythonVersion@0
+                  displayName: "Use Python 3.10"
+                  inputs:
+                      versionSpec: 3.10
+
                 - script: npm install -g pnpm@9.5.0
                   displayName: Install PNPM 9.5.0
 

--- a/packages/autorest.python/requirements.txt
+++ b/packages/autorest.python/requirements.txt
@@ -9,6 +9,5 @@ pathspec==0.11.1
 platformdirs==3.2.0
 PyYAML==6.0.1
 tomli==2.0.1
-importlib_metadata==8.2.0
 setuptools==69.2.0
 json-rpc==1.14.0


### PR DESCRIPTION
https://github.com/Azure/autorest.python/pull/2718 doesn't fix the error of release pipeline.
Using python3.10 instead of 3.8 could avoid this error: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3993212&view=logs&j=19992227-62fb-5b50-4e29-3b72bd33eea1&t=9281c869-17dc-5ef7-6bc6-1c1da071debd