### PR TITLE
Revert client signature `endpoint` to `base_url` to avoid breaking for Mgmt SDK

### DIFF
--- a/.chronus/changes/HEAD-2024-7-9-10-25-50.md
+++ b/.chronus/changes/HEAD-2024-7-9-10-25-50.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Revert client signature `endpoint` to `base_url` to avoid breaking for Mgmt SDK

--- a/packages/typespec-python/generator/pygen/codegen/models/parameter.py
+++ b/packages/typespec-python/generator/pygen/codegen/models/parameter.py
@@ -381,7 +381,11 @@ class ClientParameter(Parameter):
         ):
             # this means i am the base url
             return ParameterMethodLocation.KEYWORD_ONLY
-        if self.client_default_value is not None and self.code_model.options["from_typespec"]:
+        if (
+            self.client_default_value is not None
+            and self.code_model.options["from_typespec"]
+            and not self.code_model.options["azure_arm"]
+        ):
             return ParameterMethodLocation.KEYWORD_ONLY
         return ParameterMethodLocation.POSITIONAL
 

--- a/packages/typespec-python/scripts/regenerate.ts
+++ b/packages/typespec-python/scripts/regenerate.ts
@@ -210,7 +210,7 @@ function addOptions(spec: string, generatedFolder: string, flags: RegenerateFlag
         }
         if (options["emitter-output-dir"] === undefined) {
             const packageName = options["package-name"] || defaultPackageName(spec);
-            options["emitter-output-dir"] = `${generatedFolder}/test/${flags.flavor}/generated/${packageName}`;
+            options["emitter-output-dir"] = toPosix(`${generatedFolder}/test/${flags.flavor}/generated/${packageName}`);
         }
         if (flags.debug) {
             options["debug"] = "true";
@@ -218,7 +218,7 @@ function addOptions(spec: string, generatedFolder: string, flags: RegenerateFlag
         if (flags.flavor === "unbranded") {
             options["company-name"] = "Unbranded";
         }
-        options["examples-directory"] = join(dirname(spec), "examples");
+        options["examples-directory"] = toPosix(join(dirname(spec), "examples"));
         const configs = Object.entries(options).flatMap(([k, v]) => {
             return `--option @azure-tools/typespec-python.${k}=${v}`;
         });
@@ -231,7 +231,7 @@ async function _regenerateSingle(spec: string, flags: RegenerateFlags): Promise<
     // Perform some asynchronous operation here
     const options = addOptions(spec, PLUGIN_DIR, flags);
     const commandPromises = options.map((option) => {
-        const command = `tsp compile ${spec} --emit=${PLUGIN_DIR} ${option}`;
+        const command = `tsp compile ${spec} --emit=${toPosix(PLUGIN_DIR)} ${option}`;
         console.log(command);
         return executeCommand(command);
     });

--- a/packages/typespec-python/src/types.ts
+++ b/packages/typespec-python/src/types.ts
@@ -422,8 +422,10 @@ export function emitEndpointType<TServiceOperation extends SdkServiceOperation>(
 ): Record<string, any>[] {
     const params: Record<string, any>[] = [];
     for (const param of type.templateArguments) {
+        const paramBase = emitParamBase(context, param);
+        paramBase.clientName = context.arm ? "base_url" : paramBase.clientName;
         params.push({
-            ...emitParamBase(context, param),
+            ...paramBase,
             optional: Boolean(param.clientDefaultValue),
             wireName: param.name,
             location: "endpointPath",

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/_client.py
@@ -34,8 +34,8 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword base_url: Service host. Default value is "https://management.azure.com".
-    :paramtype base_url: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -46,7 +46,6 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
         self,
         credential: "TokenCredential",
         subscription_id: str,
-        *,
         base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/_client.py
@@ -34,8 +34,8 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword endpoint: Service host. Default value is "https://management.azure.com".
-    :paramtype endpoint: str
+    :keyword base_url: Service host. Default value is "https://management.azure.com".
+    :paramtype base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -47,12 +47,12 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
         credential: "TokenCredential",
         subscription_id: str,
         *,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         _endpoint = "{endpoint}"
         self._config = ManagedIdentityClientConfiguration(
-            credential=credential, subscription_id=subscription_id, endpoint=endpoint, **kwargs
+            credential=credential, subscription_id=subscription_id, base_url=base_url, **kwargs
         )
         _policies = kwargs.pop("policies", None)
         if _policies is None:
@@ -101,7 +101,7 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
 
         request_copy = deepcopy(request)
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         request_copy.url = self._client.format_url(request_copy.url, **path_format_arguments)

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/_configuration.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/_configuration.py
@@ -28,8 +28,8 @@ class ManagedIdentityClientConfiguration:  # pylint: disable=too-many-instance-a
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :param endpoint: Service host. Default value is "https://management.azure.com".
-    :type endpoint: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -40,7 +40,7 @@ class ManagedIdentityClientConfiguration:  # pylint: disable=too-many-instance-a
         self,
         credential: "TokenCredential",
         subscription_id: str,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         api_version: str = kwargs.pop("api_version", "2023-12-01-preview")
@@ -52,7 +52,7 @@ class ManagedIdentityClientConfiguration:  # pylint: disable=too-many-instance-a
 
         self.credential = credential
         self.subscription_id = subscription_id
-        self.endpoint = endpoint
+        self.base_url = base_url
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://management.azure.com/.default"])
         kwargs.setdefault("sdk_moniker", "resourcemanager-models-commontypes-managedidentity/{}".format(VERSION))

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/_client.py
@@ -34,8 +34,8 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword base_url: Service host. Default value is "https://management.azure.com".
-    :paramtype base_url: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -46,7 +46,6 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
         self,
         credential: "AsyncTokenCredential",
         subscription_id: str,
-        *,
         base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/_client.py
@@ -34,8 +34,8 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword endpoint: Service host. Default value is "https://management.azure.com".
-    :paramtype endpoint: str
+    :keyword base_url: Service host. Default value is "https://management.azure.com".
+    :paramtype base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -47,12 +47,12 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
         credential: "AsyncTokenCredential",
         subscription_id: str,
         *,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         _endpoint = "{endpoint}"
         self._config = ManagedIdentityClientConfiguration(
-            credential=credential, subscription_id=subscription_id, endpoint=endpoint, **kwargs
+            credential=credential, subscription_id=subscription_id, base_url=base_url, **kwargs
         )
         _policies = kwargs.pop("policies", None)
         if _policies is None:
@@ -103,7 +103,7 @@ class ManagedIdentityClient:  # pylint: disable=client-accepts-api-version-keywo
 
         request_copy = deepcopy(request)
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         request_copy.url = self._client.format_url(request_copy.url, **path_format_arguments)

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/_configuration.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/_configuration.py
@@ -28,8 +28,8 @@ class ManagedIdentityClientConfiguration:  # pylint: disable=too-many-instance-a
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :param endpoint: Service host. Default value is "https://management.azure.com".
-    :type endpoint: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -40,7 +40,7 @@ class ManagedIdentityClientConfiguration:  # pylint: disable=too-many-instance-a
         self,
         credential: "AsyncTokenCredential",
         subscription_id: str,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         api_version: str = kwargs.pop("api_version", "2023-12-01-preview")
@@ -52,7 +52,7 @@ class ManagedIdentityClientConfiguration:  # pylint: disable=too-many-instance-a
 
         self.credential = credential
         self.subscription_id = subscription_id
-        self.endpoint = endpoint
+        self.base_url = base_url
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://management.azure.com/.default"])
         kwargs.setdefault("sdk_moniker", "resourcemanager-models-commontypes-managedidentity/{}".format(VERSION))

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/operations/_operations.py
@@ -136,7 +136,7 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -523,7 +523,7 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -910,7 +910,7 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/operations/_operations.py
@@ -231,7 +231,7 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -618,7 +618,7 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1005,7 +1005,7 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/_client.py
@@ -37,8 +37,8 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword base_url: Service host. Default value is "https://management.azure.com".
-    :paramtype base_url: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -51,7 +51,6 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
         self,
         credential: "TokenCredential",
         subscription_id: str,
-        *,
         base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/_client.py
@@ -37,8 +37,8 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword endpoint: Service host. Default value is "https://management.azure.com".
-    :paramtype endpoint: str
+    :keyword base_url: Service host. Default value is "https://management.azure.com".
+    :paramtype base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -52,12 +52,12 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
         credential: "TokenCredential",
         subscription_id: str,
         *,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         _endpoint = "{endpoint}"
         self._config = ResourcesClientConfiguration(
-            credential=credential, subscription_id=subscription_id, endpoint=endpoint, **kwargs
+            credential=credential, subscription_id=subscription_id, base_url=base_url, **kwargs
         )
         _policies = kwargs.pop("policies", None)
         if _policies is None:
@@ -109,7 +109,7 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
 
         request_copy = deepcopy(request)
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         request_copy.url = self._client.format_url(request_copy.url, **path_format_arguments)

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/_configuration.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/_configuration.py
@@ -28,8 +28,8 @@ class ResourcesClientConfiguration:  # pylint: disable=too-many-instance-attribu
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :param endpoint: Service host. Default value is "https://management.azure.com".
-    :type endpoint: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -40,7 +40,7 @@ class ResourcesClientConfiguration:  # pylint: disable=too-many-instance-attribu
         self,
         credential: "TokenCredential",
         subscription_id: str,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         api_version: str = kwargs.pop("api_version", "2023-12-01-preview")
@@ -52,7 +52,7 @@ class ResourcesClientConfiguration:  # pylint: disable=too-many-instance-attribu
 
         self.credential = credential
         self.subscription_id = subscription_id
-        self.endpoint = endpoint
+        self.base_url = base_url
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://management.azure.com/.default"])
         kwargs.setdefault("sdk_moniker", "resourcemanager-models-resources/{}".format(VERSION))

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/_client.py
@@ -37,8 +37,8 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword endpoint: Service host. Default value is "https://management.azure.com".
-    :paramtype endpoint: str
+    :keyword base_url: Service host. Default value is "https://management.azure.com".
+    :paramtype base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -52,12 +52,12 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
         credential: "AsyncTokenCredential",
         subscription_id: str,
         *,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         _endpoint = "{endpoint}"
         self._config = ResourcesClientConfiguration(
-            credential=credential, subscription_id=subscription_id, endpoint=endpoint, **kwargs
+            credential=credential, subscription_id=subscription_id, base_url=base_url, **kwargs
         )
         _policies = kwargs.pop("policies", None)
         if _policies is None:
@@ -111,7 +111,7 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
 
         request_copy = deepcopy(request)
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         request_copy.url = self._client.format_url(request_copy.url, **path_format_arguments)

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/_client.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/_client.py
@@ -37,8 +37,8 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword base_url: Service host. Default value is "https://management.azure.com".
-    :paramtype base_url: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -51,7 +51,6 @@ class ResourcesClient:  # pylint: disable=client-accepts-api-version-keyword
         self,
         credential: "AsyncTokenCredential",
         subscription_id: str,
-        *,
         base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/_configuration.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/_configuration.py
@@ -28,8 +28,8 @@ class ResourcesClientConfiguration:  # pylint: disable=too-many-instance-attribu
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :param endpoint: Service host. Default value is "https://management.azure.com".
-    :type endpoint: str
+    :param base_url: Service host. Default value is "https://management.azure.com".
+    :type base_url: str
     :keyword api_version: The API version to use for this operation. Default value is
      "2023-12-01-preview". Note that overriding this default value may result in unsupported
      behavior.
@@ -40,7 +40,7 @@ class ResourcesClientConfiguration:  # pylint: disable=too-many-instance-attribu
         self,
         credential: "AsyncTokenCredential",
         subscription_id: str,
-        endpoint: str = "https://management.azure.com",
+        base_url: str = "https://management.azure.com",
         **kwargs: Any
     ) -> None:
         api_version: str = kwargs.pop("api_version", "2023-12-01-preview")
@@ -52,7 +52,7 @@ class ResourcesClientConfiguration:  # pylint: disable=too-many-instance-attribu
 
         self.credential = credential
         self.subscription_id = subscription_id
-        self.endpoint = endpoint
+        self.base_url = base_url
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://management.azure.com/.default"])
         kwargs.setdefault("sdk_moniker", "resourcemanager-models-resources/{}".format(VERSION))

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/operations/_operations.py
@@ -151,7 +151,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -221,7 +221,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -547,7 +547,7 @@ class TopLevelTrackedResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -608,7 +608,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -932,7 +932,7 @@ class TopLevelTrackedResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -979,7 +979,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1050,7 +1050,7 @@ class TopLevelTrackedResourcesOperations:
                 return cls(pipeline_response, None, {})  # type: ignore
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -1135,7 +1135,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1155,7 +1155,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1246,7 +1246,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1266,7 +1266,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1382,7 +1382,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1454,7 +1454,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1769,7 +1769,7 @@ class NestedProxyResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -1832,7 +1832,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -2145,7 +2145,7 @@ class NestedProxyResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -2197,7 +2197,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -2275,7 +2275,7 @@ class NestedProxyResourcesOperations:
                 return cls(pipeline_response, None, {})  # type: ignore
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -2359,7 +2359,7 @@ class NestedProxyResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -2379,7 +2379,7 @@ class NestedProxyResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/operations/_operations.py
@@ -482,7 +482,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -552,7 +552,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -878,7 +878,7 @@ class TopLevelTrackedResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -939,7 +939,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1263,7 +1263,7 @@ class TopLevelTrackedResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -1310,7 +1310,7 @@ class TopLevelTrackedResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1381,7 +1381,7 @@ class TopLevelTrackedResourcesOperations:
                 return cls(pipeline_response, None, {})  # type: ignore
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -1466,7 +1466,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1486,7 +1486,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1577,7 +1577,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1597,7 +1597,7 @@ class TopLevelTrackedResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -1713,7 +1713,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -1785,7 +1785,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -2100,7 +2100,7 @@ class NestedProxyResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -2163,7 +2163,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -2476,7 +2476,7 @@ class NestedProxyResourcesOperations:
             return deserialized
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -2528,7 +2528,7 @@ class NestedProxyResourcesOperations:
             params=_params,
         )
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
         _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
@@ -2606,7 +2606,7 @@ class NestedProxyResourcesOperations:
                 return cls(pipeline_response, None, {})  # type: ignore
 
         path_format_arguments = {
-            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.base_url", self._config.base_url, "str", skip_quote=True),
         }
 
         if polling is True:
@@ -2690,7 +2690,7 @@ class NestedProxyResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)
@@ -2710,7 +2710,7 @@ class NestedProxyResourcesOperations:
                 )
                 path_format_arguments = {
                     "endpoint": self._serialize.url(
-                        "self._config.endpoint", self._config.endpoint, "str", skip_quote=True
+                        "self._config.base_url", self._config.base_url, "str", skip_quote=True
                     ),
                 }
                 _request.url = self._client.format_url(_request.url, **path_format_arguments)

--- a/packages/typespec-python/test/azure/mock_api_tests/asynctests/test_azure_arm_models_resource_async.py
+++ b/packages/typespec-python/test/azure/mock_api_tests/asynctests/test_azure_arm_models_resource_async.py
@@ -1,0 +1,32 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+from azure.resourcemanager.models.resources.aio import ResourcesClient
+
+SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
+RESOURCE_GROUP_NAME = "test-rg"
+
+
+@pytest.mark.asyncio
+async def test_client_signature(credential, authentication_policy):
+    # make sure signautre order is correct
+    client1 = ResourcesClient(
+        credential, SUBSCRIPTION_ID, "http://localhost:3000", authentication_policy=authentication_policy
+    )
+    # make sure signautre name is correct
+    client2 = ResourcesClient(
+        credential=credential,
+        subscription_id=SUBSCRIPTION_ID,
+        base_url="http://localhost:3000",
+        authentication_policy=authentication_policy,
+    )
+    for client in [client1, client2]:
+        # make sure signautre order is correct
+        await client.top_level_tracked_resources.get(RESOURCE_GROUP_NAME, "top")
+        # make sure signautre name is correct
+        await client.top_level_tracked_resources.get(
+            resource_group_name=RESOURCE_GROUP_NAME, top_level_tracked_resource_name="top"
+        )

--- a/packages/typespec-python/test/azure/mock_api_tests/conftest.py
+++ b/packages/typespec-python/test/azure/mock_api_tests/conftest.py
@@ -129,3 +129,22 @@ def async_polling_method():
 
 
 # ================== after azure-core fix, the up code can be removed (end) ==================
+
+
+@pytest.fixture()
+def credential():
+    """I actually don't need anything, since the authentication policy
+    will bypass it.
+    """
+
+    class FakeCredential:
+        pass
+
+    return FakeCredential()
+
+
+@pytest.fixture()
+def authentication_policy():
+    from azure.core.pipeline.policies import SansIOHTTPPolicy
+
+    return SansIOHTTPPolicy()

--- a/packages/typespec-python/test/azure/mock_api_tests/test_azure_arm_models_resource.py
+++ b/packages/typespec-python/test/azure/mock_api_tests/test_azure_arm_models_resource.py
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from azure.resourcemanager.models.resources import ResourcesClient
+
+SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
+RESOURCE_GROUP_NAME = "test-rg"
+
+
+def test_client_signature(credential, authentication_policy):
+    # make sure signautre order is correct
+    client1 = ResourcesClient(
+        credential, SUBSCRIPTION_ID, "http://localhost:3000", authentication_policy=authentication_policy
+    )
+    # make sure signautre name is correct
+    client2 = ResourcesClient(
+        credential=credential,
+        subscription_id=SUBSCRIPTION_ID,
+        base_url="http://localhost:3000",
+        authentication_policy=authentication_policy,
+    )
+    for client in [client1, client2]:
+        # make sure signautre order is correct
+        client.top_level_tracked_resources.get(RESOURCE_GROUP_NAME, "top")
+        # make sure signautre name is correct
+        client.top_level_tracked_resources.get(
+            resource_group_name=RESOURCE_GROUP_NAME, top_level_tracked_resource_name="top"
+        )


### PR DESCRIPTION
Revert client signature `endpoint` to `base_url` to avoid breaking for Mgmt SDK