### PR TITLE
Remove sample from docstring

### DIFF
--- a/.chronus/changes/remove-sample-from-docstring-2024-7-15-15-33-37.md
+++ b/.chronus/changes/remove-sample-from-docstring-2024-7-15-15-33-37.md
@@ -1,0 +1,8 @@
+---
+changeKind: feature
+packages:
+  - "@autorest/python"
+  - "@azure-tools/typespec-python"
+---
+
+Remove samples from docstring of operation

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v1/aio/operations/_operation_group_one_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v1/aio/operations/_operation_group_one_operations.py
@@ -25,7 +25,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from ... import models as _models
 from ...operations._operation_group_one_operations import build_test_two_request
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v1/operations/_operation_group_one_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v1/operations/_operation_group_one_operations.py
@@ -25,7 +25,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from .. import models as _models
 from ..._serialization import Serializer
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/aio/operations/_operation_group_one_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/aio/operations/_operation_group_one_operations.py
@@ -26,7 +26,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from ... import models as _models
 from ...operations._operation_group_one_operations import build_test_three_request, build_test_two_request
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/aio/operations/_operation_group_two_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/aio/operations/_operation_group_two_operations.py
@@ -25,7 +25,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from ... import models as _models
 from ...operations._operation_group_two_operations import build_test_four_request
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/operations/_operation_group_one_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/operations/_operation_group_one_operations.py
@@ -26,7 +26,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from .. import models as _models
 from ..._serialization import Serializer
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/operations/_operation_group_two_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v2/operations/_operation_group_two_operations.py
@@ -25,7 +25,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from .. import models as _models
 from ..._serialization import Serializer
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_one_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_one_operations.py
@@ -32,7 +32,6 @@ from ...operations._operation_group_one_operations import (
     build_test_operation_group_paging_request,
     build_test_two_request,
 )
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/aio/operations/_operation_group_two_operations.py
@@ -26,7 +26,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from ... import models as _models
 from ...operations._operation_group_two_operations import build_test_five_request, build_test_four_request
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_one_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_one_operations.py
@@ -28,7 +28,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from .. import models as _models
 from ..._serialization import Serializer
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
+++ b/packages/autorest.python/samples/specification/multiapi/generated/azure/multiapi/sample/v3/operations/_operation_group_two_operations.py
@@ -26,7 +26,6 @@ from azure.mgmt.core.exceptions import ARMErrorFormat
 
 from .. import models as _models
 from ..._serialization import Serializer
-from .._vendor import MultiapiServiceClientMixinABC
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping

--- a/packages/typespec-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/typespec-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -535,9 +535,9 @@ class _OperationSerializer(_BuilderBaseSerializer[OperationType]):  # pylint: di
         return "response"
 
     def example_template(self, builder: OperationType) -> List[str]:
+        if self.code_model.options["models_mode"] in ("msrest", "dpg"):
+            return []
         retval = super().example_template(builder)
-        if self.code_model.options["models_mode"] == "msrest":
-            return retval
         for response in builder.responses:
             polymorphic_subtypes: List[ModelType] = []
             if not response.type:

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/aio/operations/_operations.py
@@ -72,14 +72,6 @@ class PublicOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.NoDecoratorModelInPublic
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -140,14 +132,6 @@ class PublicOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.PublicDecoratorModelInPublic
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -228,14 +212,6 @@ class InternalOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models._models.NoDecoratorModelInInternal
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -303,14 +279,6 @@ class InternalOperationOperations:
         :rtype:
          ~specs.azure.clientgenerator.core.access.models._models.InternalDecoratorModelInInternal
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -377,14 +345,6 @@ class InternalOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.PublicDecoratorModelInInternal
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -462,14 +422,6 @@ class SharedModelInOperationOperations:
         :return: SharedModel. The SharedModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.SharedModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -529,14 +481,6 @@ class SharedModelInOperationOperations:
         :return: SharedModel. The SharedModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.SharedModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -627,17 +571,6 @@ class RelativeModelInOperationOperations:
         :return: OuterModel. The OuterModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models._models.OuterModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "inner": {
-                        "name": "str"
-                    },
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -707,21 +640,6 @@ class RelativeModelInOperationOperations:
         :return: AbstractModel. The AbstractModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models._models.AbstractModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "real":
-                abstract_model = {
-                    "kind": "real",
-                    "name": "str"
-                }
-
-                # response body for status code(s): 200
-                response == abstract_model
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-access/specs/azure/clientgenerator/core/access/operations/_operations.py
@@ -246,14 +246,6 @@ class PublicOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.NoDecoratorModelInPublic
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -314,14 +306,6 @@ class PublicOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.PublicDecoratorModelInPublic
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -402,14 +386,6 @@ class InternalOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models._models.NoDecoratorModelInInternal
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -477,14 +453,6 @@ class InternalOperationOperations:
         :rtype:
          ~specs.azure.clientgenerator.core.access.models._models.InternalDecoratorModelInInternal
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -549,14 +517,6 @@ class InternalOperationOperations:
          MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.PublicDecoratorModelInInternal
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -634,14 +594,6 @@ class SharedModelInOperationOperations:
         :return: SharedModel. The SharedModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.SharedModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -701,14 +653,6 @@ class SharedModelInOperationOperations:
         :return: SharedModel. The SharedModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models.SharedModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -797,17 +741,6 @@ class RelativeModelInOperationOperations:
         :return: OuterModel. The OuterModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models._models.OuterModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "inner": {
-                        "name": "str"
-                    },
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -877,21 +810,6 @@ class RelativeModelInOperationOperations:
         :return: AbstractModel. The AbstractModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.access.models._models.AbstractModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "real":
-                abstract_model = {
-                    "kind": "real",
-                    "name": "str"
-                }
-
-                # response body for status code(s): 200
-                response == abstract_model
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/aio/operations/_operations.py
@@ -80,14 +80,6 @@ class ModelInOperationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -151,14 +143,6 @@ class ModelInOperationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -219,14 +203,6 @@ class ModelInOperationOperations:
         :return: OutputModel. The OutputModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.OutputModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -307,23 +283,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "result": {
-                        "name": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -357,16 +316,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -400,16 +349,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -440,23 +379,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "result": {
-                        "name": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-client-generator-core-usage/specs/azure/clientgenerator/core/usage/operations/_operations.py
@@ -130,14 +130,6 @@ class ModelInOperationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -201,14 +193,6 @@ class ModelInOperationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -269,14 +253,6 @@ class ModelInOperationOperations:
         :return: OutputModel. The OutputModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.OutputModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -357,23 +333,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "result": {
-                        "name": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -407,16 +366,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -450,16 +399,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -490,23 +429,6 @@ class ModelInOperationOperations:
         :return: RoundTripModel. The RoundTripModel is compatible with MutableMapping
         :rtype: ~specs.azure.clientgenerator.core.usage.models.RoundTripModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "result": {
-                        "name": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "result": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/_operations/_operations.py
@@ -235,37 +235,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -286,23 +255,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -323,23 +275,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @distributed_trace
@@ -356,37 +291,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -466,37 +370,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -517,23 +390,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -554,23 +410,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @distributed_trace
@@ -587,37 +426,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -690,23 +498,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -791,23 +582,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.basic.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -954,23 +728,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-basic/specs/azure/core/basic/aio/_operations/_operations.py
@@ -70,37 +70,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -121,23 +90,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -158,23 +110,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -193,37 +128,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -303,37 +207,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -354,23 +227,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -391,23 +247,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -426,37 +265,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -529,23 +337,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -630,23 +421,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.basic.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -793,23 +567,6 @@ class BasicClientOperationsMixin(BasicClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.basic.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/_operations/_operations.py
@@ -203,21 +203,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
         :return: An instance of LROPoller that returns User. The User is compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "name": "str",
-                    "role": "str"
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
 
     @overload
@@ -238,15 +223,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
         :return: An instance of LROPoller that returns User. The User is compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
 
     @overload
@@ -267,15 +243,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
         :return: An instance of LROPoller that returns User. The User is compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
 
     @distributed_trace
@@ -294,21 +261,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
         :return: An instance of LROPoller that returns User. The User is compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "name": "str",
-                    "role": "str"
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -532,15 +484,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
          with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~specs.azure.core.lro.standard.models.ExportedUser]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 202
-                response == {
-                    "name": "str",
-                    "resourceUri": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-lro-standard/specs/azure/core/lro/standard/aio/_operations/_operations.py
@@ -129,21 +129,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
          MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "name": "str",
-                    "role": "str"
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
 
     @overload
@@ -165,15 +150,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
          MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
 
     @overload
@@ -195,15 +171,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
          MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
 
     @distributed_trace_async
@@ -223,21 +190,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
          MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~specs.azure.core.lro.standard.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "name": "str",
-                    "role": "str"
-                }
-
-                # response body for status code(s): 201, 200
-                response == {
-                    "name": "str",
-                    "role": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -463,15 +415,6 @@ class StandardClientOperationsMixin(StandardClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~specs.azure.core.lro.standard.models.ExportedUser]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 202
-                response == {
-                    "name": "str",
-                    "resourceUri": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azure-core-model/specs/azure/core/model/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-model/specs/azure/core/model/aio/operations/_operations.py
@@ -67,14 +67,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -138,14 +130,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -236,23 +220,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "embedding": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -269,16 +236,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -295,16 +252,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -318,23 +265,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "embedding": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-model/specs/azure/core/model/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-model/specs/azure/core/model/operations/_operations.py
@@ -111,14 +111,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -182,14 +174,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -280,23 +264,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "embedding": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -311,16 +278,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -337,16 +294,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace
@@ -360,23 +307,6 @@ class AzureCoreEmbeddingVectorOperations:
         :return: AzureEmbeddingModel. The AzureEmbeddingModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.model.models.AzureEmbeddingModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "embedding": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "embedding": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-page/specs/azure/core/page/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-page/specs/azure/core/page/aio/operations/_operations.py
@@ -71,14 +71,6 @@ class TwoModelsAsPageItemOperations:
         :return: An iterator like instance of FirstItem
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.FirstItem]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -162,14 +154,6 @@ class TwoModelsAsPageItemOperations:
         :return: An iterator like instance of SecondItem
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.SecondItem]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -255,23 +239,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -369,28 +336,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body_input = {
-                    "inputName": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -415,23 +360,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -456,23 +384,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @distributed_trace
@@ -494,28 +405,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body_input = {
-                    "inputName": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -608,23 +497,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azure-core-page/specs/azure/core/page/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-page/specs/azure/core/page/operations/_operations.py
@@ -174,14 +174,6 @@ class TwoModelsAsPageItemOperations:
         :return: An iterator like instance of FirstItem
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.FirstItem]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -265,14 +257,6 @@ class TwoModelsAsPageItemOperations:
         :return: An iterator like instance of SecondItem
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.SecondItem]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -358,23 +342,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -472,28 +439,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body_input = {
-                    "inputName": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -518,23 +463,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -559,23 +487,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
 
     @distributed_trace
@@ -597,28 +508,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body_input = {
-                    "inputName": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -711,23 +600,6 @@ class PageClientOperationsMixin(PageClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~specs.azure.core.page.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "etag": "str",
-                    "id": 0,
-                    "name": "str",
-                    "orders": [
-                        {
-                            "detail": "str",
-                            "id": 0,
-                            "userId": 0
-                        }
-                    ]
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azure-core-scalar/specs/azure/core/scalar/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-scalar/specs/azure/core/scalar/aio/operations/_operations.py
@@ -183,19 +183,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "location": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
 
     @overload
@@ -212,14 +199,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
 
     @overload
@@ -236,14 +215,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
 
     @distributed_trace_async
@@ -257,19 +228,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "location": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-scalar/specs/azure/core/scalar/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-scalar/specs/azure/core/scalar/operations/_operations.py
@@ -252,19 +252,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "location": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
 
     @overload
@@ -279,14 +266,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
 
     @overload
@@ -303,14 +282,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
 
     @distributed_trace
@@ -324,19 +295,6 @@ class AzureLocationScalarOperations:
         :return: AzureLocationModel. The AzureLocationModel is compatible with MutableMapping
         :rtype: ~specs.azure.core.scalar.models.AzureLocationModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "location": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/_operations/_operations.py
@@ -158,15 +158,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -252,19 +243,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "userActionValue": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
 
     @overload
@@ -283,14 +261,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
 
     @overload
@@ -309,14 +279,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
 
     @distributed_trace
@@ -333,19 +295,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "userActionValue": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-core-traits/specs/azure/core/traits/aio/_operations/_operations.py
@@ -77,15 +77,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: User. The User is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.User
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -171,19 +162,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "userActionValue": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
 
     @overload
@@ -202,14 +180,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
 
     @overload
@@ -228,14 +198,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
 
     @distributed_trace_async
@@ -252,19 +214,6 @@ class TraitsClientOperationsMixin(TraitsClientMixinABC):
         :return: UserActionResponse. The UserActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.core.traits.models.UserActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "userActionValue": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "userActionResult": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-example-basic/specs/azure/example/basic/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-example-basic/specs/azure/example/basic/_operations/_operations.py
@@ -93,41 +93,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -148,25 +113,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -193,25 +139,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -229,41 +156,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-example-basic/specs/azure/example/basic/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-example-basic/specs/azure/example/basic/aio/_operations/_operations.py
@@ -66,41 +66,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -121,25 +86,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -166,25 +112,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -202,41 +129,6 @@ class AzureExampleClientOperationsMixin(AzureExampleClientMixinABC):
         :return: ActionResponse. The ActionResponse is compatible with MutableMapping
         :rtype: ~specs.azure.example.basic.models.ActionResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "stringProperty": "str",
-                    "arrayProperty": [
-                        "str"
-                    ],
-                    "modelProperty": {
-                        "enumProperty": "str",
-                        "float32Property": 0.0,
-                        "int32Property": 0
-                    },
-                    "recordProperty": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/aio/operations/_operations.py
@@ -77,42 +77,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -195,75 +159,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -293,42 +188,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -358,42 +217,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace_async
@@ -421,75 +244,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -582,75 +336,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -680,42 +365,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -745,42 +394,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace_async
@@ -808,75 +421,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-common-types-managed-identity/azure/resourcemanager/models/commontypes/managedidentity/operations/_operations.py
@@ -172,42 +172,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -290,75 +254,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -388,42 +283,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -453,42 +312,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace
@@ -516,75 +339,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -677,75 +431,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -775,42 +460,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -840,42 +489,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace
@@ -903,75 +516,6 @@ class ManagedIdentityTrackedResourcesOperations:  # pylint: disable=name-too-lon
         :rtype:
          ~azure.resourcemanager.models.commontypes.managedidentity.models.ManagedIdentityTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str",
-                        "userAssignedIdentities": {
-                            "str": {
-                                "clientId": "str",
-                                "principalId": "str"
-                            }
-                        }
-                    },
-                    "name": "str",
-                    "properties": {
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/operations/_operations.py
@@ -102,32 +102,6 @@ class TopLevelTrackedResourcesOperations:
         :return: TopLevelTrackedResource. The TopLevelTrackedResource is compatible with MutableMapping
         :rtype: ~azure.resourcemanager.models.resources.models.TopLevelTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -282,55 +256,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -360,32 +285,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -415,32 +314,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace_async
@@ -467,55 +340,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -667,55 +491,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -745,32 +520,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -800,32 +549,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace_async
@@ -852,55 +575,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -1083,32 +757,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.async_paging.AsyncItemPaged[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -1195,32 +843,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.async_paging.AsyncItemPaged[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -1336,28 +958,6 @@ class NestedProxyResourcesOperations:
         :return: NestedProxyResource. The NestedProxyResource is compatible with MutableMapping
         :rtype: ~azure.resourcemanager.models.resources.models.NestedProxyResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1518,47 +1118,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1591,28 +1150,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1645,28 +1182,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace_async
@@ -1696,47 +1211,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -1894,47 +1368,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1967,28 +1400,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -2021,28 +1432,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace_async
@@ -2072,47 +1461,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.AsyncLROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -2310,28 +1658,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.async_paging.AsyncItemPaged[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/operations/_operations.py
@@ -433,32 +433,6 @@ class TopLevelTrackedResourcesOperations:
         :return: TopLevelTrackedResource. The TopLevelTrackedResource is compatible with MutableMapping
         :rtype: ~azure.resourcemanager.models.resources.models.TopLevelTrackedResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -613,55 +587,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -691,32 +616,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -746,32 +645,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace
@@ -798,55 +671,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -998,55 +822,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1076,32 +851,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1131,32 +880,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace
@@ -1183,55 +906,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -1414,32 +1088,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.paging.ItemPaged[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -1526,32 +1174,6 @@ class TopLevelTrackedResourcesOperations:
         :rtype:
          ~azure.core.paging.ItemPaged[~azure.resourcemanager.models.resources.models.TopLevelTrackedResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "location": "str",
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "tags": {
-                        "str": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}
@@ -1667,28 +1289,6 @@ class NestedProxyResourcesOperations:
         :return: NestedProxyResource. The NestedProxyResource is compatible with MutableMapping
         :rtype: ~azure.resourcemanager.models.resources.models.NestedProxyResource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1849,47 +1449,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1922,28 +1481,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -1976,28 +1513,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace
@@ -2027,47 +1542,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                resource = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 201
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -2225,47 +1699,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -2298,28 +1731,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @overload
@@ -2352,28 +1763,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
 
     @distributed_trace
@@ -2403,47 +1792,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.polling.LROPoller[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                properties = {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
-
-                # response body for status code(s): 200, 202
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}
@@ -2641,28 +1989,6 @@ class NestedProxyResourcesOperations:
         :rtype:
          ~azure.core.paging.ItemPaged[~azure.resourcemanager.models.resources.models.NestedProxyResource]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": "str",
-                    "name": "str",
-                    "properties": {
-                        "description": "str",
-                        "provisioningState": "str"
-                    },
-                    "systemData": {
-                        "createdAt": "2020-02-20 00:00:00",
-                        "createdBy": "str",
-                        "createdByType": "str",
-                        "lastModifiedAt": "2020-02-20 00:00:00",
-                        "lastModifiedBy": "str",
-                        "lastModifiedByType": "str"
-                    },
-                    "type": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/_operations/_operations.py
@@ -147,19 +147,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prompt": "str"
-                }
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
 
     @overload
@@ -179,14 +166,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
 
     @overload
@@ -206,14 +185,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
 
     @distributed_trace
@@ -231,19 +202,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.LROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prompt": "str"
-                }
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azurecore-lro-rpc/azurecore/lro/rpc/aio/_operations/_operations.py
@@ -122,19 +122,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prompt": "str"
-                }
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
 
     @overload
@@ -154,14 +141,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
 
     @overload
@@ -181,14 +160,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
 
     @distributed_trace_async
@@ -206,19 +177,6 @@ class RpcClientOperationsMixin(RpcClientMixinABC):
          compatible with MutableMapping
         :rtype: ~azure.core.polling.AsyncLROPoller[~azurecore.lro.rpc.models.GenerationResult]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prompt": "str"
-                }
-
-                # response body for status code(s): 202
-                response == {
-                    "data": "str"
-                }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/client-naming/client/naming/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/client-naming/client/naming/aio/operations/_operations.py
@@ -81,14 +81,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -134,14 +126,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -203,14 +187,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -256,14 +232,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -545,14 +513,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -598,14 +558,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -667,14 +619,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -720,14 +664,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -789,14 +725,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -843,14 +771,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/client-naming/client/naming/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/client-naming/client/naming/operations/_operations.py
@@ -206,14 +206,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -259,14 +251,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -328,14 +312,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -381,14 +357,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -668,14 +636,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -721,14 +681,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -790,14 +742,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -843,14 +787,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -912,14 +848,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -966,14 +894,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/aio/operations/_operations.py
@@ -301,19 +301,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -330,14 +317,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -354,14 +333,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @distributed_trace_async
@@ -375,19 +346,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -461,19 +419,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -490,14 +435,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -514,14 +451,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @distributed_trace_async
@@ -535,19 +464,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -621,19 +537,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -650,14 +553,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -674,14 +569,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @distributed_trace_async
@@ -695,19 +582,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -782,23 +656,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -816,16 +673,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -843,16 +690,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -868,23 +705,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/encode-bytes/encode/bytes/operations/_operations.py
@@ -580,19 +580,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -609,14 +596,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -633,14 +612,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @distributed_trace
@@ -654,19 +625,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -740,19 +698,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -769,14 +714,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -793,14 +730,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @distributed_trace
@@ -814,19 +743,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -900,19 +816,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -929,14 +832,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -953,14 +848,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @distributed_trace
@@ -974,19 +861,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1061,23 +935,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -1095,16 +952,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -1122,16 +969,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @distributed_trace
@@ -1147,23 +984,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/aio/operations/_operations.py
@@ -354,19 +354,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -383,14 +370,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -407,14 +386,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace_async
@@ -428,19 +399,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -514,19 +472,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -543,14 +488,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -567,14 +504,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace_async
@@ -588,19 +517,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -674,19 +590,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -703,14 +606,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -727,14 +622,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace_async
@@ -748,19 +635,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -835,19 +709,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -865,14 +726,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -890,14 +743,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace_async
@@ -913,19 +758,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1000,23 +832,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1034,16 +849,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1061,16 +866,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -1086,23 +881,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/encode-datetime/encode/datetime/operations/_operations.py
@@ -572,19 +572,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -601,14 +588,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -625,14 +604,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace
@@ -646,19 +617,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -732,19 +690,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -761,14 +706,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -785,14 +722,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace
@@ -806,19 +735,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -892,19 +808,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -921,14 +824,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -945,14 +840,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace
@@ -966,19 +853,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1053,19 +927,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1083,14 +944,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1108,14 +961,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @distributed_trace
@@ -1131,19 +976,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1218,23 +1050,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1252,16 +1067,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1279,16 +1084,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @distributed_trace
@@ -1304,23 +1099,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/aio/operations/_operations.py
@@ -402,19 +402,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -431,14 +418,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -455,14 +434,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @distributed_trace_async
@@ -476,19 +447,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -562,19 +520,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -591,14 +536,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -615,14 +552,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @distributed_trace_async
@@ -636,19 +565,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -723,19 +639,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -753,14 +656,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -778,14 +673,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @distributed_trace_async
@@ -801,19 +688,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -888,19 +762,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -918,14 +779,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -943,14 +796,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @distributed_trace_async
@@ -966,19 +811,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1053,19 +885,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1083,14 +902,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1108,14 +919,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @distributed_trace_async
@@ -1131,19 +934,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1218,23 +1008,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1252,16 +1025,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1279,16 +1042,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -1304,23 +1057,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/encode-duration/encode/duration/operations/_operations.py
@@ -626,19 +626,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -655,14 +642,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -679,14 +658,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @distributed_trace
@@ -700,19 +671,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -786,19 +744,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -815,14 +760,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -839,14 +776,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @distributed_trace
@@ -860,19 +789,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -947,19 +863,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -977,14 +880,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -1002,14 +897,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @distributed_trace
@@ -1025,19 +912,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1112,19 +986,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1142,14 +1003,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1167,14 +1020,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @distributed_trace
@@ -1190,19 +1035,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1277,19 +1109,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1307,14 +1126,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1332,14 +1143,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @distributed_trace
@@ -1355,19 +1158,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1442,23 +1232,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1476,16 +1249,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1503,16 +1266,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @distributed_trace
@@ -1528,23 +1281,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/_operations/_operations.py
@@ -163,35 +163,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -208,22 +179,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -240,22 +195,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace
@@ -269,35 +208,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -371,22 +281,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -432,22 +326,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -509,22 +387,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -570,22 +432,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -647,22 +493,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -708,22 +538,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -785,22 +599,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -846,22 +644,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -923,22 +705,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -984,22 +750,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1061,29 +811,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1100,19 +827,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1129,19 +843,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -1155,29 +856,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleanfalse/headasbooleanfalse/aio/_operations/_operations.py
@@ -64,35 +64,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -109,22 +80,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -141,22 +96,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -170,35 +109,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -272,22 +182,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -333,22 +227,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -410,22 +288,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -471,22 +333,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -548,22 +394,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -609,22 +439,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -686,22 +500,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -747,22 +545,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -824,22 +606,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -885,22 +651,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -962,29 +712,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1001,19 +728,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1030,19 +744,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -1056,29 +757,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/_operations/_operations.py
@@ -163,35 +163,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -208,22 +179,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -240,22 +195,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace
@@ -269,35 +208,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -371,22 +281,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -426,22 +320,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -504,22 +382,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -565,22 +427,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -642,22 +488,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -703,22 +533,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -780,22 +594,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -841,22 +639,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -918,22 +700,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -979,22 +745,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1056,29 +806,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1095,19 +822,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1124,19 +838,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -1150,29 +851,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/headasbooleantrue/headasbooleantrue/aio/_operations/_operations.py
@@ -64,35 +64,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -109,22 +80,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -141,22 +96,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -170,35 +109,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -272,22 +182,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -327,22 +221,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -405,22 +283,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -466,22 +328,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -543,22 +389,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -604,22 +434,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -681,22 +495,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -742,22 +540,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -819,22 +601,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -880,22 +646,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -957,29 +707,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -996,19 +723,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1025,19 +739,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -1051,29 +752,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/parameters-basic/parameters/basic/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/parameters-basic/parameters/basic/aio/operations/_operations.py
@@ -69,14 +69,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -122,14 +114,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -209,14 +193,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -264,14 +240,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/parameters-basic/parameters/basic/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/parameters-basic/parameters/basic/operations/_operations.py
@@ -100,14 +100,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -153,14 +145,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -240,14 +224,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -295,14 +271,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/aio/operations/_operations.py
@@ -75,14 +75,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -128,14 +120,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -200,14 +184,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -253,14 +229,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -328,14 +296,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -381,14 +341,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -450,14 +402,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -505,14 +449,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/parameters-body-optionality/parameters/bodyoptionality/operations/_operations.py
@@ -129,14 +129,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -182,14 +174,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -254,14 +238,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -307,14 +283,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -382,14 +350,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -435,14 +395,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -504,14 +456,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -559,14 +503,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/aio/operations/_operations.py
@@ -80,14 +80,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -135,14 +127,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -209,14 +193,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -262,14 +238,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -393,14 +361,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -458,14 +418,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -533,14 +485,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -600,14 +544,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -694,14 +630,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -749,14 +677,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -827,14 +747,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -900,14 +812,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -980,14 +884,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1053,14 +949,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1133,21 +1021,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -1237,21 +1110,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1331,15 +1189,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1417,15 +1266,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/parameters-spread/parameters/spread/operations/_operations.py
@@ -267,14 +267,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -322,14 +314,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -396,14 +380,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -449,14 +425,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -580,14 +548,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -645,14 +605,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -720,14 +672,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -787,14 +731,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -881,14 +817,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -936,14 +864,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1014,14 +934,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1087,14 +999,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1167,14 +1071,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1240,14 +1136,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1320,21 +1208,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -1424,21 +1297,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1518,15 +1376,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1604,15 +1453,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/aio/operations/_operations.py
@@ -257,14 +257,6 @@ class DifferentBodyOperations:
         :return: PngImageAsJson. The PngImageAsJson is compatible with MutableMapping
         :rtype: ~payload.contentnegotiation.models.PngImageAsJson
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "content": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-content-negotiation/payload/contentnegotiation/operations/_operations.py
@@ -307,14 +307,6 @@ class DifferentBodyOperations:
         :return: PngImageAsJson. The PngImageAsJson is compatible with MutableMapping
         :rtype: ~payload.contentnegotiation.models.PngImageAsJson
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "content": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-json-merge-patch/payload/jsonmergepatch/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-json-merge-patch/payload/jsonmergepatch/_operations/_operations.py
@@ -112,63 +112,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -183,36 +126,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -229,36 +142,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @distributed_trace
@@ -270,63 +153,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -400,62 +226,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -472,36 +242,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -518,36 +258,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @distributed_trace
@@ -559,62 +269,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -692,62 +346,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -764,36 +362,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -810,36 +378,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @distributed_trace
@@ -854,62 +392,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-json-merge-patch/payload/jsonmergepatch/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-json-merge-patch/payload/jsonmergepatch/aio/_operations/_operations.py
@@ -60,63 +60,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -133,36 +76,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -179,36 +92,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -220,63 +103,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -350,62 +176,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -422,36 +192,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -468,36 +208,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -511,62 +221,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -644,62 +298,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -716,36 +314,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -762,36 +330,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -806,62 +344,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/aio/operations/_operations.py
@@ -72,15 +72,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -105,15 +96,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -169,24 +151,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -211,24 +175,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -284,17 +230,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -319,17 +254,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -385,15 +309,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
 
     @overload
@@ -420,15 +335,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -484,19 +390,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -523,19 +416,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -591,15 +471,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
 
     @overload
@@ -626,15 +497,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -690,15 +552,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -725,15 +578,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -789,14 +633,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -825,14 +661,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-multipart/payload/multipart/operations/_operations.py
@@ -141,15 +141,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -174,15 +165,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -238,24 +220,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -280,24 +244,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -353,17 +299,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -388,17 +323,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -454,15 +378,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
 
     @overload
@@ -487,15 +402,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -551,19 +457,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -588,19 +481,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -656,15 +536,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
 
     @overload
@@ -689,15 +560,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -753,15 +615,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -788,15 +641,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -850,14 +694,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -886,14 +722,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/_operations/_operations.py
@@ -71,14 +71,6 @@ class PageableClientOperationsMixin(PageableClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.paging.ItemPaged[~payload.pageable.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/payload-pageable/payload/pageable/aio/_operations/_operations.py
@@ -48,14 +48,6 @@ class PageableClientOperationsMixin(PageableClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~payload.pageable.models.User]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/azure/generated/serialization-encoded-name-json/serialization/encodedname/json/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/serialization-encoded-name-json/serialization/encodedname/json/aio/operations/_operations.py
@@ -70,14 +70,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -123,14 +115,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -185,14 +169,6 @@ class PropertyOperations:
         :return: JsonEncodedNameModel. The JsonEncodedNameModel is compatible with MutableMapping
         :rtype: ~serialization.encodedname.json.models.JsonEncodedNameModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/serialization-encoded-name-json/serialization/encodedname/json/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/serialization-encoded-name-json/serialization/encodedname/json/operations/_operations.py
@@ -101,14 +101,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -154,14 +146,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -216,14 +200,6 @@ class PropertyOperations:
         :return: JsonEncodedNameModel. The JsonEncodedNameModel is compatible with MutableMapping
         :rtype: ~serialization.encodedname.json.models.JsonEncodedNameModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/special-words/specialwords/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/special-words/specialwords/aio/operations/_operations.py
@@ -170,14 +170,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -223,14 +215,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -292,14 +276,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -345,14 +321,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -414,14 +382,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -467,14 +427,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -536,14 +488,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -589,14 +533,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -658,14 +594,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -711,14 +639,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -780,14 +700,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -833,14 +745,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -902,14 +806,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -955,14 +851,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1024,14 +912,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1077,14 +957,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1146,14 +1018,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1199,14 +1063,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1268,14 +1124,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1321,14 +1169,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1390,14 +1230,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1443,14 +1275,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1512,14 +1336,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1565,14 +1381,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1634,14 +1442,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1687,14 +1487,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1756,14 +1548,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1809,14 +1593,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1878,14 +1654,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1931,14 +1699,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2000,14 +1760,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2053,14 +1805,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2122,14 +1866,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2175,14 +1911,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2244,14 +1972,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2297,14 +2017,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2366,14 +2078,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2419,14 +2123,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2488,14 +2184,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2541,14 +2229,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2610,14 +2290,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2663,14 +2335,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2732,14 +2396,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2785,14 +2441,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2854,14 +2502,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2907,14 +2547,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2976,14 +2608,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3029,14 +2653,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3098,14 +2714,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3151,14 +2759,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3220,14 +2820,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3273,14 +2865,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3342,14 +2926,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3395,14 +2971,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3464,14 +3032,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3517,14 +3077,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3586,14 +3138,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3639,14 +3183,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3708,14 +3244,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3761,14 +3289,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3830,14 +3350,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3883,14 +3395,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3952,14 +3456,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4005,14 +3501,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4074,14 +3562,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4127,14 +3607,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4214,14 +3686,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
 
     @overload
@@ -4267,14 +3731,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/special-words/specialwords/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/special-words/specialwords/operations/_operations.py
@@ -1190,14 +1190,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1243,14 +1235,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1312,14 +1296,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1365,14 +1341,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1434,14 +1402,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1487,14 +1447,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1556,14 +1508,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1609,14 +1553,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1678,14 +1614,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1731,14 +1659,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1800,14 +1720,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1853,14 +1765,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1922,14 +1826,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1975,14 +1871,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2044,14 +1932,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2097,14 +1977,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2166,14 +2038,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2219,14 +2083,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2288,14 +2144,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2341,14 +2189,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2410,14 +2250,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2463,14 +2295,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2532,14 +2356,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2585,14 +2401,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2654,14 +2462,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2707,14 +2507,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2776,14 +2568,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2829,14 +2613,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2898,14 +2674,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2951,14 +2719,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3020,14 +2780,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3073,14 +2825,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3142,14 +2886,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3195,14 +2931,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3264,14 +2992,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3317,14 +3037,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3386,14 +3098,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3439,14 +3143,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3508,14 +3204,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3561,14 +3249,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3630,14 +3310,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3683,14 +3355,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3752,14 +3416,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3805,14 +3461,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3874,14 +3522,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3927,14 +3567,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3996,14 +3628,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4049,14 +3673,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4118,14 +3734,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4171,14 +3779,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4240,14 +3840,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4293,14 +3885,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4362,14 +3946,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4415,14 +3991,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4484,14 +4052,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4537,14 +4097,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4606,14 +4158,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4659,14 +4203,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4728,14 +4264,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4781,14 +4309,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4850,14 +4370,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4903,14 +4415,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4972,14 +4476,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5025,14 +4521,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5094,14 +4582,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5147,14 +4627,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5234,14 +4706,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
 
     @overload
@@ -5287,14 +4751,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/aio/operations/_operations.py
@@ -92,14 +92,6 @@ class Int32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -163,14 +155,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -272,14 +256,6 @@ class Int64ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -343,14 +319,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -452,14 +420,6 @@ class BooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -523,14 +483,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -632,14 +584,6 @@ class StringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -703,14 +647,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -812,14 +748,6 @@ class Float32ValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -883,14 +811,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -992,14 +912,6 @@ class DatetimeValueOperations:
         :return: list of datetime
         :rtype: list[~datetime.datetime]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "2020-02-20 00:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1063,14 +975,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "2020-02-20 00:00:00"
-                ]
         """
 
     @overload
@@ -1172,14 +1076,6 @@ class DurationValueOperations:
         :return: list of timedelta
         :rtype: list[~datetime.timedelta]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "1 day, 0:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1243,14 +1139,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "1 day, 0:00:00"
-                ]
         """
 
     @overload
@@ -1352,14 +1240,6 @@ class UnknownValueOperations:
         :return: list of any
         :rtype: list[any]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {}
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1423,14 +1303,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {}
-                ]
         """
 
     @overload
@@ -1532,19 +1404,6 @@ class ModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1608,19 +1467,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload
@@ -1722,14 +1568,6 @@ class NullableFloatValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1793,14 +1631,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -1902,14 +1732,6 @@ class NullableInt32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1973,14 +1795,6 @@ class NullableInt32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -2082,14 +1896,6 @@ class NullableBooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2153,14 +1959,6 @@ class NullableBooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -2262,14 +2060,6 @@ class NullableStringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2333,14 +2123,6 @@ class NullableStringValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -2442,19 +2224,6 @@ class NullableModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2518,19 +2287,6 @@ class NullableModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload

--- a/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-array/typetest/array/operations/_operations.py
@@ -458,14 +458,6 @@ class Int32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -529,14 +521,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -638,14 +622,6 @@ class Int64ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -709,14 +685,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -818,14 +786,6 @@ class BooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -889,14 +849,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -998,14 +950,6 @@ class StringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1069,14 +1013,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -1178,14 +1114,6 @@ class Float32ValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1249,14 +1177,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -1358,14 +1278,6 @@ class DatetimeValueOperations:
         :return: list of datetime
         :rtype: list[~datetime.datetime]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "2020-02-20 00:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1429,14 +1341,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "2020-02-20 00:00:00"
-                ]
         """
 
     @overload
@@ -1538,14 +1442,6 @@ class DurationValueOperations:
         :return: list of timedelta
         :rtype: list[~datetime.timedelta]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "1 day, 0:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1609,14 +1505,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "1 day, 0:00:00"
-                ]
         """
 
     @overload
@@ -1718,14 +1606,6 @@ class UnknownValueOperations:
         :return: list of any
         :rtype: list[any]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {}
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1789,14 +1669,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {}
-                ]
         """
 
     @overload
@@ -1898,19 +1770,6 @@ class ModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1974,19 +1833,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload
@@ -2088,14 +1934,6 @@ class NullableFloatValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2159,14 +1997,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -2268,14 +2098,6 @@ class NullableInt32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2339,14 +2161,6 @@ class NullableInt32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -2448,14 +2262,6 @@ class NullableBooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2519,14 +2325,6 @@ class NullableBooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -2628,14 +2426,6 @@ class NullableStringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2699,14 +2489,6 @@ class NullableStringValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -2808,19 +2590,6 @@ class NullableModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2884,19 +2653,6 @@ class NullableModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload

--- a/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/aio/operations/_operations.py
@@ -86,14 +86,6 @@ class Int32ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -157,14 +149,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -266,14 +250,6 @@ class Int64ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -337,14 +313,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -446,14 +414,6 @@ class BooleanValueOperations:
         :return: dict mapping str to bool
         :rtype: dict[str, bool]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -517,14 +477,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": bool
-                }
         """
 
     @overload
@@ -626,14 +578,6 @@ class StringValueOperations:
         :return: dict mapping str to str
         :rtype: dict[str, str]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -697,14 +641,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "str"
-                }
         """
 
     @overload
@@ -806,14 +742,6 @@ class Float32ValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -877,14 +805,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload
@@ -986,14 +906,6 @@ class DatetimeValueOperations:
         :return: dict mapping str to datetime
         :rtype: dict[str, ~datetime.datetime]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1057,14 +969,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1166,14 +1070,6 @@ class DurationValueOperations:
         :return: dict mapping str to timedelta
         :rtype: dict[str, ~datetime.timedelta]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1237,14 +1133,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1346,14 +1234,6 @@ class UnknownValueOperations:
         :return: dict mapping str to any
         :rtype: dict[str, any]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1417,14 +1297,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {}
-                }
         """
 
     @overload
@@ -1526,19 +1398,6 @@ class ModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1602,19 +1461,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -1716,19 +1562,6 @@ class RecursiveModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1792,19 +1625,6 @@ class RecursiveModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -1906,14 +1726,6 @@ class NullableFloatValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1977,14 +1789,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload

--- a/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-dictionary/typetest/dictionary/operations/_operations.py
@@ -374,14 +374,6 @@ class Int32ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -445,14 +437,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -554,14 +538,6 @@ class Int64ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -625,14 +601,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -734,14 +702,6 @@ class BooleanValueOperations:
         :return: dict mapping str to bool
         :rtype: dict[str, bool]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -805,14 +765,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": bool
-                }
         """
 
     @overload
@@ -914,14 +866,6 @@ class StringValueOperations:
         :return: dict mapping str to str
         :rtype: dict[str, str]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -985,14 +929,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "str"
-                }
         """
 
     @overload
@@ -1094,14 +1030,6 @@ class Float32ValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1165,14 +1093,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload
@@ -1274,14 +1194,6 @@ class DatetimeValueOperations:
         :return: dict mapping str to datetime
         :rtype: dict[str, ~datetime.datetime]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1345,14 +1257,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1454,14 +1358,6 @@ class DurationValueOperations:
         :return: dict mapping str to timedelta
         :rtype: dict[str, ~datetime.timedelta]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1525,14 +1421,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1634,14 +1522,6 @@ class UnknownValueOperations:
         :return: dict mapping str to any
         :rtype: dict[str, any]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1705,14 +1585,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {}
-                }
         """
 
     @overload
@@ -1814,19 +1686,6 @@ class ModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1890,19 +1749,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2004,19 +1850,6 @@ class RecursiveModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2080,19 +1913,6 @@ class RecursiveModelValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2194,14 +2014,6 @@ class NullableFloatValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2265,14 +2077,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload

--- a/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/_operations/_operations.py
@@ -104,12 +104,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
 
     @overload
@@ -155,12 +149,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -278,12 +266,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -329,12 +311,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-empty/typetest/model/empty/aio/_operations/_operations.py
@@ -60,12 +60,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
 
     @overload
@@ -111,12 +105,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -234,12 +222,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -285,12 +267,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
@@ -176,21 +176,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -254,21 +239,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
 
     @overload
@@ -314,21 +284,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -383,21 +338,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -454,21 +394,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -525,21 +450,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -603,21 +513,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
 
     @overload
@@ -663,21 +558,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -732,21 +612,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -803,21 +668,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
@@ -58,21 +58,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -136,21 +121,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
 
     @overload
@@ -196,21 +166,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -267,21 +222,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -338,21 +278,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -409,21 +334,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -487,21 +397,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
 
     @overload
@@ -547,21 +442,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -616,21 +496,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -687,21 +552,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-flatten/typetest/model/flatten/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-flatten/typetest/model/flatten/_operations/_operations.py
@@ -93,27 +93,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -130,18 +109,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -158,18 +125,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -183,27 +138,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -277,33 +211,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -320,21 +227,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -351,21 +243,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -379,33 +256,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-flatten/typetest/model/flatten/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-flatten/typetest/model/flatten/aio/_operations/_operations.py
@@ -59,27 +59,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -96,18 +75,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -124,18 +91,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -149,27 +104,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -243,33 +177,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -286,21 +193,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -317,21 +209,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -345,33 +222,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
@@ -144,40 +144,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -241,40 +207,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -320,40 +252,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -408,40 +306,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -505,40 +369,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -584,40 +414,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -672,40 +468,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -762,40 +524,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
@@ -56,40 +56,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -153,40 +119,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -232,40 +164,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -320,40 +218,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -417,40 +281,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -496,40 +326,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -584,40 +380,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -674,40 +436,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_operations/_operations.py
@@ -104,16 +104,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -159,16 +149,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -223,16 +203,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -296,23 +266,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -327,16 +280,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -351,16 +294,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @distributed_trace
@@ -372,23 +305,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/aio/_operations/_operations.py
@@ -60,16 +60,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -115,16 +105,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -179,16 +159,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -252,23 +222,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -283,16 +236,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -309,16 +252,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @distributed_trace_async
@@ -330,23 +263,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/_operations/_operations.py
@@ -87,17 +87,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
 
     @overload
@@ -143,17 +132,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -208,17 +186,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: Extension. The Extension is compatible with MutableMapping
         :rtype: ~typetest.model.recursive.models.Extension
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-recursive/typetest/model/recursive/aio/_operations/_operations.py
@@ -56,17 +56,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
 
     @overload
@@ -112,17 +101,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -177,17 +155,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: Extension. The Extension is compatible with MutableMapping
         :rtype: ~typetest.model.recursive.models.Extension
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
@@ -158,46 +158,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -261,46 +221,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -346,46 +266,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -440,46 +320,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -543,46 +383,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -628,46 +428,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -722,46 +482,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -818,46 +538,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -914,21 +594,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Dinosaur. The Dinosaur is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Dinosaur
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "t-rex":
-                dinosaur = {
-                    "kind": "t-rex",
-                    "size": 0
-                }
-
-                # response body for status code(s): 200
-                response == dinosaur
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
@@ -57,46 +57,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -160,46 +120,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -245,46 +165,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -339,46 +219,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -442,46 +282,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -527,46 +327,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -621,46 +381,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -717,46 +437,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -813,21 +493,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Dinosaur. The Dinosaur is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Dinosaur
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "t-rex":
-                dinosaur = {
-                    "kind": "t-rex",
-                    "size": 0
-                }
-
-                # response body for status code(s): 200
-                response == dinosaur
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/_operations/_operations.py
@@ -104,14 +104,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -157,14 +149,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -219,14 +203,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: OutputRecord. The OutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.OutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -290,19 +266,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -319,14 +282,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -343,14 +298,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @distributed_trace
@@ -364,19 +311,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-usage/typetest/model/usage/aio/_operations/_operations.py
@@ -60,14 +60,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -113,14 +105,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -175,14 +159,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: OutputRecord. The OutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.OutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -246,19 +222,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -275,14 +238,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -299,14 +254,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -320,19 +267,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/_operations/_operations.py
@@ -163,35 +163,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -208,22 +179,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -240,22 +195,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace
@@ -269,35 +208,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -371,22 +281,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -426,22 +320,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -504,22 +382,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -565,22 +427,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -642,22 +488,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -703,22 +533,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -780,22 +594,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -841,22 +639,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -918,22 +700,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -979,22 +745,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1056,29 +806,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1095,19 +822,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1124,19 +838,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace
@@ -1150,29 +851,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-model-visibility/typetest/model/visibility/aio/_operations/_operations.py
@@ -64,35 +64,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -109,22 +80,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -141,22 +96,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @distributed_trace_async
@@ -170,35 +109,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -272,22 +182,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -327,22 +221,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -405,22 +283,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -466,22 +328,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -543,22 +389,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -604,22 +434,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -681,22 +495,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -742,22 +540,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -819,22 +601,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -880,22 +646,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -957,29 +707,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -996,19 +723,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1025,19 +739,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @distributed_trace_async
@@ -1051,29 +752,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
@@ -129,14 +129,6 @@ class ExtendsUnknownOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -200,14 +192,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -255,14 +239,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -337,16 +313,6 @@ class ExtendsUnknownDerivedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -415,16 +381,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -473,16 +429,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -557,23 +503,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDiscriminated
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -642,23 +571,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -707,23 +619,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -797,14 +692,6 @@ class IsUnknownOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -868,14 +755,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -923,14 +802,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1004,16 +875,6 @@ class IsUnknownDerivedOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1081,16 +942,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -1138,16 +989,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1222,23 +1063,6 @@ class IsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDiscriminated
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1307,23 +1131,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -1372,23 +1179,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1462,14 +1252,6 @@ class ExtendsStringOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsStringAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1533,14 +1315,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1588,14 +1362,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1669,14 +1435,6 @@ class IsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsStringAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1740,14 +1498,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1795,14 +1545,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1875,14 +1617,6 @@ class SpreadStringOperations:
         :return: SpreadStringRecord. The SpreadStringRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadStringRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1946,14 +1680,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2000,14 +1726,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2081,14 +1799,6 @@ class ExtendsFloatOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsFloatAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2152,14 +1862,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -2207,14 +1909,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2288,14 +1982,6 @@ class IsFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsFloatAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2359,14 +2045,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -2414,14 +2092,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2494,14 +2164,6 @@ class SpreadFloatOperations:
         :return: SpreadFloatRecord. The SpreadFloatRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadFloatRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2565,14 +2227,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -2619,14 +2273,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2700,16 +2346,6 @@ class ExtendsModelOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2773,16 +2409,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -2830,16 +2456,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2913,16 +2529,6 @@ class IsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2986,16 +2592,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3043,16 +2639,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3125,16 +2711,6 @@ class SpreadModelOperations:
         :return: SpreadModelRecord. The SpreadModelRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3198,16 +2774,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3254,16 +2820,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3337,18 +2893,6 @@ class ExtendsModelArrayOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelArrayAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3417,18 +2961,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3477,18 +3009,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3562,18 +3082,6 @@ class IsModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelArrayAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3637,18 +3145,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3696,18 +3192,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3780,18 +3264,6 @@ class SpreadModelArrayOperations:
         :return: SpreadModelArrayRecord. The SpreadModelArrayRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelArrayRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3855,18 +3327,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3914,18 +3374,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3999,14 +3447,6 @@ class SpreadDifferentStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4070,14 +3510,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -4125,14 +3557,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4206,14 +3630,6 @@ class SpreadDifferentFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4277,14 +3693,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4332,14 +3740,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4413,14 +3813,6 @@ class SpreadDifferentModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4484,14 +3876,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -4539,14 +3923,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4620,14 +3996,6 @@ class SpreadDifferentModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4691,14 +4059,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -4746,14 +4106,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4827,15 +4179,6 @@ class ExtendsDifferentSpreadStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4899,15 +4242,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -4955,15 +4289,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5037,15 +4362,6 @@ class ExtendsDifferentSpreadFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5109,15 +4425,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5165,15 +4472,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5247,17 +4545,6 @@ class ExtendsDifferentSpreadModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5321,17 +4608,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5379,17 +4655,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5463,19 +4728,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5539,19 +4791,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5599,19 +4838,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5684,14 +4910,6 @@ class MultipleSpreadOperations:
         :return: MultipleSpreadRecord. The MultipleSpreadRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.MultipleSpreadRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5755,14 +4973,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -5810,14 +5020,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5890,14 +5092,6 @@ class SpreadRecordUnionOperations:
         :return: SpreadRecordForUnion. The SpreadRecordForUnion is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForUnion
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5961,14 +5155,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -6016,14 +5202,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6097,14 +5275,6 @@ class SpreadRecordDiscriminatedUnionOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForDiscriminatedUnion
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6168,14 +5338,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6223,14 +5385,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6304,14 +5458,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6379,14 +5525,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6434,14 +5572,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6515,14 +5645,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6591,14 +5713,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6647,14 +5761,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6728,14 +5834,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion3
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6804,14 +5902,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6860,14 +5950,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
@@ -979,14 +979,6 @@ class ExtendsUnknownOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1050,14 +1042,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1105,14 +1089,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1187,16 +1163,6 @@ class ExtendsUnknownDerivedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1265,16 +1231,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -1323,16 +1279,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1407,23 +1353,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDiscriminated
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1492,23 +1421,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -1557,23 +1469,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1647,14 +1542,6 @@ class IsUnknownOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1718,14 +1605,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1773,14 +1652,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1854,16 +1725,6 @@ class IsUnknownDerivedOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1931,16 +1792,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -1988,16 +1839,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2072,23 +1913,6 @@ class IsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDiscriminated
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2157,23 +1981,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -2222,23 +2029,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2312,14 +2102,6 @@ class ExtendsStringOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsStringAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2383,14 +2165,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2438,14 +2212,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2519,14 +2285,6 @@ class IsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsStringAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2590,14 +2348,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2645,14 +2395,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2725,14 +2467,6 @@ class SpreadStringOperations:
         :return: SpreadStringRecord. The SpreadStringRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadStringRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2796,14 +2530,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2850,14 +2576,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2931,14 +2649,6 @@ class ExtendsFloatOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsFloatAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3002,14 +2712,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -3057,14 +2759,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3138,14 +2832,6 @@ class IsFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsFloatAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3209,14 +2895,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -3264,14 +2942,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3344,14 +3014,6 @@ class SpreadFloatOperations:
         :return: SpreadFloatRecord. The SpreadFloatRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadFloatRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3415,14 +3077,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -3469,14 +3123,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3550,16 +3196,6 @@ class ExtendsModelOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3623,16 +3259,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3680,16 +3306,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3763,16 +3379,6 @@ class IsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3836,16 +3442,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3893,16 +3489,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3975,16 +3561,6 @@ class SpreadModelOperations:
         :return: SpreadModelRecord. The SpreadModelRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4048,16 +3624,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -4104,16 +3670,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4187,18 +3743,6 @@ class ExtendsModelArrayOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelArrayAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4267,18 +3811,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4327,18 +3859,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4412,18 +3932,6 @@ class IsModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelArrayAdditionalProperties
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4487,18 +3995,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4546,18 +4042,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4630,18 +4114,6 @@ class SpreadModelArrayOperations:
         :return: SpreadModelArrayRecord. The SpreadModelArrayRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelArrayRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4705,18 +4177,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4764,18 +4224,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4849,14 +4297,6 @@ class SpreadDifferentStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4920,14 +4360,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -4975,14 +4407,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5056,14 +4480,6 @@ class SpreadDifferentFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5127,14 +4543,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5182,14 +4590,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5263,14 +4663,6 @@ class SpreadDifferentModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5334,14 +4726,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5389,14 +4773,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5470,14 +4846,6 @@ class SpreadDifferentModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5541,14 +4909,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5596,14 +4956,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5677,15 +5029,6 @@ class ExtendsDifferentSpreadStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5749,15 +5092,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -5805,15 +5139,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5887,15 +5212,6 @@ class ExtendsDifferentSpreadFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5959,15 +5275,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6015,15 +5322,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6097,17 +5395,6 @@ class ExtendsDifferentSpreadModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6171,17 +5458,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -6229,17 +5505,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6313,19 +5578,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayDerived
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6389,19 +5641,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -6449,19 +5688,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6534,14 +5760,6 @@ class MultipleSpreadOperations:
         :return: MultipleSpreadRecord. The MultipleSpreadRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.MultipleSpreadRecord
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6605,14 +5823,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -6660,14 +5870,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6740,14 +5942,6 @@ class SpreadRecordUnionOperations:
         :return: SpreadRecordForUnion. The SpreadRecordForUnion is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForUnion
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6811,14 +6005,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -6866,14 +6052,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6947,14 +6125,6 @@ class SpreadRecordDiscriminatedUnionOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForDiscriminatedUnion
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7018,14 +6188,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7073,14 +6235,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7154,14 +6308,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7229,14 +6375,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7284,14 +6422,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7365,14 +6495,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7441,14 +6563,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7497,14 +6611,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7578,14 +6684,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion3
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7654,14 +6752,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7710,14 +6800,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/aio/operations/_operations.py
@@ -92,15 +92,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -157,15 +148,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -229,15 +211,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -283,15 +256,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -353,15 +317,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -407,15 +362,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -488,15 +434,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -553,15 +490,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -625,15 +553,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -679,15 +598,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -749,15 +659,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -803,15 +704,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -884,15 +776,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -949,15 +832,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1021,15 +895,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1075,15 +940,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1145,15 +1001,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1199,15 +1046,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1280,15 +1118,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1345,15 +1174,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1417,15 +1237,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1471,15 +1282,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1541,15 +1343,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1595,15 +1388,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1676,17 +1460,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1743,17 +1516,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1821,17 +1583,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1877,17 +1628,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1953,17 +1693,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2009,17 +1738,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2093,19 +1811,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2163,19 +1868,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2243,19 +1935,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2301,19 +1980,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2379,19 +2045,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2437,19 +2090,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2523,17 +2163,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2591,17 +2220,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2669,17 +2287,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2726,17 +2333,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2802,17 +2398,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2859,17 +2444,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-nullable/typetest/property/nullable/operations/_operations.py
@@ -458,15 +458,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -523,15 +514,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -595,15 +577,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -649,15 +622,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -719,15 +683,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -773,15 +728,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -854,15 +800,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -919,15 +856,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -991,15 +919,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1045,15 +964,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1115,15 +1025,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1169,15 +1070,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1250,15 +1142,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1315,15 +1198,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1387,15 +1261,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1441,15 +1306,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1511,15 +1367,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1565,15 +1412,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1646,15 +1484,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1711,15 +1540,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1783,15 +1603,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1837,15 +1648,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1907,15 +1709,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1961,15 +1754,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2042,17 +1826,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2109,17 +1882,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2187,17 +1949,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2243,17 +1994,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2319,17 +2059,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2375,17 +2104,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2459,19 +2177,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2529,19 +2234,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2609,19 +2301,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2667,19 +2346,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2745,19 +2411,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2803,19 +2456,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2889,17 +2529,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2957,17 +2586,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3035,17 +2653,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -3092,17 +2699,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3168,17 +2764,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -3225,17 +2810,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/aio/operations/_operations.py
@@ -128,14 +128,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -192,14 +184,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -263,14 +247,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -316,14 +292,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -385,14 +353,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -438,14 +398,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -518,14 +470,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -582,14 +526,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -653,14 +589,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -706,14 +634,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -775,14 +695,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -828,14 +740,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -908,14 +812,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -972,14 +868,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1043,14 +931,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1096,14 +976,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1165,14 +1037,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1218,14 +1082,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1298,14 +1154,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1362,14 +1210,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1433,14 +1273,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1486,14 +1318,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1555,14 +1379,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1608,14 +1424,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1688,14 +1496,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1752,14 +1552,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1823,14 +1615,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -1876,14 +1660,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1945,14 +1721,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -1998,14 +1766,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2078,14 +1838,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2142,14 +1894,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2213,14 +1957,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -2266,14 +2002,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2335,14 +2063,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -2388,14 +2108,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2468,16 +2180,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2534,16 +2236,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2607,16 +2299,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -2662,16 +2344,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2733,16 +2405,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -2788,16 +2450,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2871,18 +2523,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2940,18 +2580,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3015,18 +2643,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3072,18 +2688,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3145,18 +2749,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3202,18 +2794,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3286,14 +2866,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3350,14 +2922,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3421,14 +2985,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -3474,14 +3030,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3543,14 +3091,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -3596,14 +3136,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3676,14 +3208,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3740,14 +3264,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3811,14 +3327,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -3864,14 +3372,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3933,14 +3433,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -3986,14 +3478,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4066,14 +3550,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4130,14 +3606,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4201,14 +3669,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -4254,14 +3714,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4323,14 +3775,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -4376,14 +3820,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4456,14 +3892,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4520,14 +3948,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4591,14 +4011,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -4644,14 +4056,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4713,14 +4117,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -4766,14 +4162,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4847,14 +4235,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4912,14 +4292,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4983,14 +4355,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5037,14 +4401,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5106,14 +4462,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5160,14 +4508,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5240,14 +4580,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5304,14 +4636,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5375,14 +4699,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -5428,14 +4744,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5497,14 +4805,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -5550,14 +4850,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5631,14 +4923,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5696,14 +4980,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5767,14 +5043,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5821,14 +5089,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5890,14 +5150,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5944,14 +5196,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6025,15 +5269,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6091,15 +5326,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6163,15 +5389,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -6218,15 +5435,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6288,15 +5496,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -6343,15 +5542,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-optional/typetest/property/optional/operations/_operations.py
@@ -966,14 +966,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1030,14 +1022,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1101,14 +1085,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -1154,14 +1130,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1223,14 +1191,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -1276,14 +1236,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1356,14 +1308,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1420,14 +1364,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1491,14 +1427,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -1544,14 +1472,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1613,14 +1533,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -1666,14 +1578,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1746,14 +1650,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1810,14 +1706,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1881,14 +1769,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1934,14 +1814,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2003,14 +1875,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -2056,14 +1920,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2136,14 +1992,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2200,14 +2048,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2271,14 +2111,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -2324,14 +2156,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2393,14 +2217,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -2446,14 +2262,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2526,14 +2334,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2590,14 +2390,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2661,14 +2453,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -2714,14 +2498,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2783,14 +2559,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -2836,14 +2604,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2916,14 +2676,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2980,14 +2732,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3051,14 +2795,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -3104,14 +2840,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3173,14 +2901,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -3226,14 +2946,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3306,16 +3018,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3372,16 +3074,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3445,16 +3137,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -3500,16 +3182,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3571,16 +3243,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -3626,16 +3288,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3709,18 +3361,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3778,18 +3418,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3853,18 +3481,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3910,18 +3526,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3983,18 +3587,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4040,18 +3632,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4124,14 +3704,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4188,14 +3760,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4259,14 +3823,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4312,14 +3868,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4381,14 +3929,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4434,14 +3974,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4514,14 +4046,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4578,14 +4102,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4649,14 +4165,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -4702,14 +4210,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4771,14 +4271,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -4824,14 +4316,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4904,14 +4388,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4968,14 +4444,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5039,14 +4507,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5092,14 +4552,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5161,14 +4613,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5214,14 +4658,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5294,14 +4730,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5358,14 +4786,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5429,14 +4849,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5482,14 +4894,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5551,14 +4955,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5604,14 +5000,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5685,14 +5073,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5750,14 +5130,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5821,14 +5193,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5875,14 +5239,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5944,14 +5300,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5998,14 +5346,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6078,14 +5418,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6142,14 +5474,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6213,14 +5537,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -6266,14 +5582,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6335,14 +5643,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -6388,14 +5688,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6469,14 +5761,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6534,14 +5818,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6605,14 +5881,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -6659,14 +5927,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6728,14 +5988,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -6782,14 +6034,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6863,15 +6107,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6929,15 +6164,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7001,15 +6227,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -7056,15 +6273,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7126,15 +6334,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -7181,15 +6380,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/_operations.py
@@ -122,14 +122,6 @@ class BooleanOperations:
         :return: BooleanProperty. The BooleanProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -193,14 +185,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
 
     @overload
@@ -246,14 +230,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -326,14 +302,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -397,14 +365,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -450,14 +410,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -530,14 +482,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -601,14 +545,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -654,14 +590,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -734,14 +662,6 @@ class IntOperations:
         :return: IntProperty. The IntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -805,14 +725,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
 
     @overload
@@ -858,14 +770,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -938,14 +842,6 @@ class FloatOperations:
         :return: FloatProperty. The FloatProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1009,14 +905,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1062,14 +950,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1142,14 +1022,6 @@ class DecimalOperations:
         :return: DecimalProperty. The DecimalProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DecimalProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1213,14 +1085,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1266,14 +1130,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1346,14 +1202,6 @@ class Decimal128Operations:
         :return: Decimal128Property. The Decimal128Property is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.Decimal128Property
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1417,14 +1265,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1470,14 +1310,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1550,14 +1382,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1621,14 +1445,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1674,14 +1490,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1754,14 +1562,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1825,14 +1625,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1878,14 +1670,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1958,14 +1742,6 @@ class EnumOperations:
         :return: EnumProperty. The EnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.EnumProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2029,14 +1805,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -2082,14 +1850,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2162,14 +1922,6 @@ class ExtensibleEnumOperations:
         :return: ExtensibleEnumProperty. The ExtensibleEnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ExtensibleEnumProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2233,14 +1985,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -2287,14 +2031,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2367,16 +2103,6 @@ class ModelOperations:
         :return: ModelProperty. The ModelProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2440,16 +2166,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
 
     @overload
@@ -2495,16 +2211,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2578,16 +2284,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2651,16 +2347,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -2707,16 +2393,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2789,16 +2465,6 @@ class CollectionsIntOperations:
         :return: CollectionsIntProperty. The CollectionsIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsIntProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2862,16 +2528,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -2918,16 +2574,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3001,18 +2647,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3076,18 +2710,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3134,18 +2756,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3219,16 +2829,6 @@ class DictionaryStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DictionaryStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3292,16 +2892,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -3348,16 +2938,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3493,12 +3073,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -3544,12 +3118,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3622,14 +3190,6 @@ class UnknownStringOperations:
         :return: UnknownStringProperty. The UnknownStringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3693,14 +3253,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -3747,14 +3299,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3827,14 +3371,6 @@ class UnknownIntOperations:
         :return: UnknownIntProperty. The UnknownIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownIntProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3898,14 +3434,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -3951,14 +3479,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4031,14 +3551,6 @@ class UnknownDictOperations:
         :return: UnknownDictProperty. The UnknownDictProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownDictProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4102,14 +3614,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4156,14 +3660,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4236,14 +3732,6 @@ class UnknownArrayOperations:
         :return: UnknownArrayProperty. The UnknownArrayProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4307,14 +3795,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4361,14 +3841,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4441,14 +3913,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4512,14 +3976,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4566,14 +4022,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4646,14 +4094,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4717,14 +4157,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -4770,14 +4202,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4850,14 +4274,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4921,14 +4337,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -4975,14 +4383,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5055,14 +4455,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5126,14 +4518,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5180,14 +4564,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5261,14 +4637,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionStringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5332,14 +4700,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5387,14 +4747,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5467,14 +4819,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionIntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5538,14 +4882,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -5592,14 +4928,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5673,14 +5001,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionFloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5744,14 +5064,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -5798,14 +5110,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5878,14 +5182,6 @@ class UnionEnumValueOperations:
         :return: UnionEnumValueProperty. The UnionEnumValueProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionEnumValueProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5949,14 +5245,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -6003,14 +5291,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/_operations.py
@@ -878,14 +878,6 @@ class BooleanOperations:
         :return: BooleanProperty. The BooleanProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -949,14 +941,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
 
     @overload
@@ -1002,14 +986,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1082,14 +1058,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1153,14 +1121,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -1206,14 +1166,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1286,14 +1238,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BytesProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1357,14 +1301,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -1410,14 +1346,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1490,14 +1418,6 @@ class IntOperations:
         :return: IntProperty. The IntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1561,14 +1481,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
 
     @overload
@@ -1614,14 +1526,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1694,14 +1598,6 @@ class FloatOperations:
         :return: FloatProperty. The FloatProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1765,14 +1661,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1818,14 +1706,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1898,14 +1778,6 @@ class DecimalOperations:
         :return: DecimalProperty. The DecimalProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DecimalProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1969,14 +1841,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -2022,14 +1886,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2102,14 +1958,6 @@ class Decimal128Operations:
         :return: Decimal128Property. The Decimal128Property is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.Decimal128Property
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2173,14 +2021,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -2226,14 +2066,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2306,14 +2138,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DatetimeProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2377,14 +2201,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -2430,14 +2246,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2510,14 +2318,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DurationProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2581,14 +2381,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -2634,14 +2426,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2714,14 +2498,6 @@ class EnumOperations:
         :return: EnumProperty. The EnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.EnumProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2785,14 +2561,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -2838,14 +2606,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2918,14 +2678,6 @@ class ExtensibleEnumOperations:
         :return: ExtensibleEnumProperty. The ExtensibleEnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ExtensibleEnumProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2989,14 +2741,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -3043,14 +2787,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3123,16 +2859,6 @@ class ModelOperations:
         :return: ModelProperty. The ModelProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3196,16 +2922,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
 
     @overload
@@ -3251,16 +2967,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3334,16 +3040,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3407,16 +3103,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -3463,16 +3149,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3545,16 +3221,6 @@ class CollectionsIntOperations:
         :return: CollectionsIntProperty. The CollectionsIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsIntProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3618,16 +3284,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -3674,16 +3330,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3757,18 +3403,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsModelProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3832,18 +3466,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3890,18 +3512,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3975,16 +3585,6 @@ class DictionaryStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DictionaryStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4048,16 +3648,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -4104,16 +3694,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4249,12 +3829,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -4300,12 +3874,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4378,14 +3946,6 @@ class UnknownStringOperations:
         :return: UnknownStringProperty. The UnknownStringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownStringProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4449,14 +4009,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4503,14 +4055,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4583,14 +4127,6 @@ class UnknownIntOperations:
         :return: UnknownIntProperty. The UnknownIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownIntProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4654,14 +4190,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4707,14 +4235,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4787,14 +4307,6 @@ class UnknownDictOperations:
         :return: UnknownDictProperty. The UnknownDictProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownDictProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4858,14 +4370,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4912,14 +4416,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4992,14 +4488,6 @@ class UnknownArrayOperations:
         :return: UnknownArrayProperty. The UnknownArrayProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownArrayProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5063,14 +4551,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -5117,14 +4597,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5197,14 +4669,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5268,14 +4732,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5322,14 +4778,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5402,14 +4850,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5473,14 +4913,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -5526,14 +4958,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5606,14 +5030,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5677,14 +5093,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -5731,14 +5139,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5811,14 +5211,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5882,14 +5274,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5936,14 +5320,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6017,14 +5393,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionStringLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6088,14 +5456,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -6143,14 +5503,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6223,14 +5575,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionIntLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6294,14 +5638,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -6348,14 +5684,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6429,14 +5757,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionFloatLiteralProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6500,14 +5820,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -6554,14 +5866,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6634,14 +5938,6 @@ class UnionEnumValueOperations:
         :return: UnionEnumValueProperty. The UnionEnumValueProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionEnumValueProperty
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6705,14 +6001,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -6759,14 +6047,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/aio/operations/_operations.py
@@ -805,14 +805,6 @@ class DecimalVerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -940,14 +932,6 @@ class Decimal128VerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-scalar/typetest/scalar/operations/_operations.py
@@ -1008,14 +1008,6 @@ class DecimalVerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1141,14 +1133,6 @@ class Decimal128VerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/aio/operations/_operations.py
@@ -85,14 +85,6 @@ class StringsOnlyOperations:
         :return: GetResponse9. The GetResponse9 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse9
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -156,14 +148,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
 
     @overload
@@ -213,14 +197,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -298,14 +274,6 @@ class StringExtensibleOperations:
         :return: GetResponse8. The GetResponse8 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse8
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -369,14 +337,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
 
     @overload
@@ -428,14 +388,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -513,14 +465,6 @@ class StringExtensibleNamedOperations:
         :return: GetResponse7. The GetResponse7 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse7
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -584,14 +528,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -647,14 +583,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -732,14 +660,6 @@ class IntsOnlyOperations:
         :return: GetResponse6. The GetResponse6 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse6
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -803,14 +723,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
 
     @overload
@@ -858,14 +770,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -943,14 +847,6 @@ class FloatsOnlyOperations:
         :return: GetResponse5. The GetResponse5 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse5
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1014,14 +910,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
 
     @overload
@@ -1069,14 +957,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1154,16 +1034,6 @@ class ModelsOnlyOperations:
         :return: GetResponse4. The GetResponse4 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse4
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1227,16 +1097,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -1284,16 +1144,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1371,17 +1221,6 @@ class EnumsOnlyOperations:
         :return: GetResponse3. The GetResponse3 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse3
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1445,17 +1284,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
 
     @overload
@@ -1503,17 +1331,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1591,17 +1408,6 @@ class StringAndArrayOperations:
         :return: GetResponse2. The GetResponse2 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1665,17 +1471,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
 
     @overload
@@ -1723,17 +1518,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1811,19 +1595,6 @@ class MixedLiteralsOperations:
         :return: GetResponse1. The GetResponse1 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1887,19 +1658,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
 
     @overload
@@ -1947,19 +1705,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2037,32 +1782,6 @@ class MixedTypesOperations:
         :return: GetResponse. The GetResponse is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2126,32 +1845,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2199,32 +1892,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/typetest-union/typetest/union/operations/_operations.py
@@ -347,14 +347,6 @@ class StringsOnlyOperations:
         :return: GetResponse9. The GetResponse9 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse9
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -418,14 +410,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
 
     @overload
@@ -475,14 +459,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -560,14 +536,6 @@ class StringExtensibleOperations:
         :return: GetResponse8. The GetResponse8 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse8
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -631,14 +599,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
 
     @overload
@@ -690,14 +650,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -775,14 +727,6 @@ class StringExtensibleNamedOperations:
         :return: GetResponse7. The GetResponse7 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse7
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -846,14 +790,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -909,14 +845,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -994,14 +922,6 @@ class IntsOnlyOperations:
         :return: GetResponse6. The GetResponse6 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse6
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1065,14 +985,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
 
     @overload
@@ -1120,14 +1032,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1205,14 +1109,6 @@ class FloatsOnlyOperations:
         :return: GetResponse5. The GetResponse5 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse5
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1276,14 +1172,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
 
     @overload
@@ -1331,14 +1219,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1416,16 +1296,6 @@ class ModelsOnlyOperations:
         :return: GetResponse4. The GetResponse4 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse4
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1489,16 +1359,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -1546,16 +1406,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1633,17 +1483,6 @@ class EnumsOnlyOperations:
         :return: GetResponse3. The GetResponse3 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse3
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1707,17 +1546,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
 
     @overload
@@ -1765,17 +1593,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1853,17 +1670,6 @@ class StringAndArrayOperations:
         :return: GetResponse2. The GetResponse2 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1927,17 +1733,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
 
     @overload
@@ -1985,17 +1780,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2073,19 +1857,6 @@ class MixedLiteralsOperations:
         :return: GetResponse1. The GetResponse1 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2149,19 +1920,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
 
     @overload
@@ -2209,19 +1967,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2299,32 +2044,6 @@ class MixedTypesOperations:
         :return: GetResponse. The GetResponse is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2388,32 +2107,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2461,32 +2154,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-added/versioning/added/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-added/versioning/added/aio/operations/_operations.py
@@ -76,23 +76,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -109,16 +92,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -135,16 +108,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -160,23 +123,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -256,23 +202,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -291,16 +220,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -319,16 +238,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -347,23 +256,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -439,23 +331,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -470,16 +345,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -494,16 +359,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -519,23 +374,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-added/versioning/added/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-added/versioning/added/operations/_operations.py
@@ -127,23 +127,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -158,16 +141,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -184,16 +157,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace
@@ -209,23 +172,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -305,23 +251,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -340,16 +269,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -368,16 +287,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace
@@ -394,23 +303,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -484,23 +376,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -515,16 +390,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -539,16 +404,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace
@@ -564,23 +419,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-madeoptional/versioning/madeoptional/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-madeoptional/versioning/madeoptional/_operations/_operations.py
@@ -88,21 +88,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -121,15 +106,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -148,15 +124,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @distributed_trace
@@ -172,21 +139,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-madeoptional/versioning/madeoptional/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-madeoptional/versioning/madeoptional/aio/_operations/_operations.py
@@ -63,21 +63,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -96,15 +81,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -123,15 +99,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -147,21 +114,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-removed/versioning/removed/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-removed/versioning/removed/_operations/_operations.py
@@ -74,23 +74,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -105,16 +88,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -129,16 +102,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace
@@ -150,23 +113,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-removed/versioning/removed/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-removed/versioning/removed/aio/_operations/_operations.py
@@ -56,23 +56,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -87,16 +70,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -111,16 +84,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -132,23 +95,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-renamedfrom/versioning/renamedfrom/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-renamedfrom/versioning/renamedfrom/aio/operations/_operations.py
@@ -74,23 +74,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -107,16 +90,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -133,16 +106,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -156,23 +119,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -252,23 +198,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -287,16 +216,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -315,16 +234,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace_async
@@ -340,23 +249,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-renamedfrom/versioning/renamedfrom/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-renamedfrom/versioning/renamedfrom/operations/_operations.py
@@ -112,23 +112,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -145,16 +128,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -171,16 +144,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace
@@ -194,23 +157,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -290,23 +236,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -325,16 +254,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -353,16 +272,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @distributed_trace
@@ -378,23 +287,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-typechangedfrom/versioning/typechangedfrom/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-typechangedfrom/versioning/typechangedfrom/_operations/_operations.py
@@ -82,21 +82,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -115,15 +100,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -142,15 +118,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @distributed_trace
@@ -164,21 +131,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/azure/generated/versioning-typechangedfrom/versioning/typechangedfrom/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/versioning-typechangedfrom/versioning/typechangedfrom/aio/_operations/_operations.py
@@ -58,21 +58,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -91,15 +76,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -118,15 +94,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @distributed_trace_async
@@ -142,21 +109,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/client-naming/client/naming/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/client-naming/client/naming/aio/operations/_operations.py
@@ -80,14 +80,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -132,14 +124,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -201,14 +185,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -253,14 +229,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -538,14 +506,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -590,14 +550,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -659,14 +611,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -711,14 +655,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -780,14 +716,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -833,14 +761,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/client-naming/client/naming/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/client-naming/client/naming/operations/_operations.py
@@ -205,14 +205,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -257,14 +249,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -326,14 +310,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -378,14 +354,6 @@ class ClientModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -661,14 +629,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -713,14 +673,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -782,14 +734,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
 
     @overload
@@ -834,14 +778,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "defaultName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -903,14 +839,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -956,14 +884,6 @@ class NamingClientOperationsMixin(NamingClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/aio/operations/_operations.py
@@ -296,19 +296,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -325,14 +312,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -349,14 +328,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     async def default(
@@ -369,19 +340,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -455,19 +413,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -484,14 +429,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -508,14 +445,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     async def base64(
@@ -528,19 +457,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -614,19 +530,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -643,14 +546,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -667,14 +562,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     async def base64url(
@@ -687,19 +574,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -774,23 +648,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -808,16 +665,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -835,16 +682,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     async def base64url_array(
@@ -859,23 +696,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-bytes/encode/bytes/operations/_operations.py
@@ -575,19 +575,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -604,14 +591,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -628,14 +607,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     def default(
@@ -648,19 +619,6 @@ class PropertyOperations:
         :return: DefaultBytesProperty. The DefaultBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.DefaultBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -734,19 +692,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -763,14 +708,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -787,14 +724,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     def base64(
@@ -807,19 +736,6 @@ class PropertyOperations:
         :return: Base64BytesProperty. The Base64BytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -893,19 +809,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -922,14 +825,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -946,14 +841,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
 
     def base64url(
@@ -966,19 +853,6 @@ class PropertyOperations:
         :return: Base64urlBytesProperty. The Base64urlBytesProperty is compatible with MutableMapping
         :rtype: ~encode.bytes.models.Base64urlBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1053,23 +927,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -1087,16 +944,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -1114,16 +961,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     def base64url_array(
@@ -1138,23 +975,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.bytes.models.Base64urlArrayBytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/aio/operations/_operations.py
@@ -348,19 +348,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -377,14 +364,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -401,14 +380,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     async def default(
@@ -421,19 +392,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -507,19 +465,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -536,14 +481,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -560,14 +497,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     async def rfc3339(
@@ -580,19 +509,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -666,19 +582,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -695,14 +598,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -719,14 +614,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     async def rfc7231(
@@ -739,19 +626,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -826,19 +700,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -856,14 +717,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -881,14 +734,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     async def unix_timestamp(
@@ -903,19 +748,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -990,23 +822,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1024,16 +839,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1051,16 +856,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     async def unix_timestamp_array(
@@ -1075,23 +870,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-datetime/encode/datetime/operations/_operations.py
@@ -566,19 +566,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -595,14 +582,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -619,14 +598,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     def default(
@@ -639,19 +610,6 @@ class PropertyOperations:
         :return: DefaultDatetimeProperty. The DefaultDatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.DefaultDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -725,19 +683,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -754,14 +699,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -778,14 +715,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     def rfc3339(
@@ -798,19 +727,6 @@ class PropertyOperations:
         :return: Rfc3339DatetimeProperty. The Rfc3339DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc3339DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -884,19 +800,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -913,14 +816,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -937,14 +832,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     def rfc7231(
@@ -957,19 +844,6 @@ class PropertyOperations:
         :return: Rfc7231DatetimeProperty. The Rfc7231DatetimeProperty is compatible with MutableMapping
         :rtype: ~encode.datetime.models.Rfc7231DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1044,19 +918,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1074,14 +935,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1099,14 +952,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
 
     def unix_timestamp(
@@ -1121,19 +966,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "2020-02-20 00:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1208,23 +1040,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1242,16 +1057,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     @overload
@@ -1269,16 +1074,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
 
     def unix_timestamp_array(
@@ -1293,23 +1088,6 @@ class PropertyOperations:
          compatible with MutableMapping
         :rtype: ~encode.datetime.models.UnixTimestampArrayDatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        "2020-02-20 00:00:00"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/aio/operations/_operations.py
@@ -395,19 +395,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -424,14 +411,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -448,14 +427,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     async def default(
@@ -468,19 +439,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -554,19 +512,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -583,14 +528,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -607,14 +544,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     async def iso8601(
@@ -627,19 +556,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -714,19 +630,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -744,14 +647,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -769,14 +664,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     async def int32_seconds(
@@ -791,19 +678,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -878,19 +752,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -908,14 +769,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -933,14 +786,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     async def float_seconds(
@@ -955,19 +800,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1042,19 +874,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1072,14 +891,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1097,14 +908,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     async def float64_seconds(
@@ -1119,19 +922,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1206,23 +996,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1240,16 +1013,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1267,16 +1030,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     async def float_seconds_array(
@@ -1291,23 +1044,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/encode-duration/encode/duration/operations/_operations.py
@@ -619,19 +619,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -648,14 +635,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -672,14 +651,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     def default(
@@ -692,19 +663,6 @@ class PropertyOperations:
         :return: DefaultDurationProperty. The DefaultDurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.DefaultDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -778,19 +736,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -807,14 +752,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -831,14 +768,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
 
     def iso8601(
@@ -851,19 +780,6 @@ class PropertyOperations:
         :return: ISO8601DurationProperty. The ISO8601DurationProperty is compatible with MutableMapping
         :rtype: ~encode.duration.models.ISO8601DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": "1 day, 0:00:00"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -938,19 +854,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -968,14 +871,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     @overload
@@ -993,14 +888,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
 
     def int32_seconds(
@@ -1015,19 +902,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Int32SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1102,19 +976,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1132,14 +993,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1157,14 +1010,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     def float_seconds(
@@ -1179,19 +1024,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1266,19 +1098,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1296,14 +1115,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     @overload
@@ -1321,14 +1132,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
 
     def float64_seconds(
@@ -1343,19 +1146,6 @@ class PropertyOperations:
          MutableMapping
         :rtype: ~encode.duration.models.Float64SecondsDurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1430,23 +1220,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1464,16 +1237,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     @overload
@@ -1491,16 +1254,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
 
     def float_seconds_array(
@@ -1515,23 +1268,6 @@ class PropertyOperations:
          with MutableMapping
         :rtype: ~encode.duration.models.FloatSecondsDurationArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "value": [
-                        0.0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "value": [
-                        0.0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/_operations/_operations.py
@@ -162,35 +162,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -207,22 +178,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -239,22 +194,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     def get_model(
@@ -267,35 +206,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -369,22 +279,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -429,22 +323,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -506,22 +384,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -566,22 +428,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -643,22 +489,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -703,22 +533,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -780,22 +594,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -840,22 +638,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -917,22 +699,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -977,22 +743,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1054,29 +804,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1093,19 +820,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1122,19 +836,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     def put_read_only_model(
@@ -1147,29 +848,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleanfalse/headasbooleanfalse/aio/_operations/_operations.py
@@ -63,35 +63,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -108,22 +79,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -140,22 +95,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     async def get_model(
@@ -168,35 +107,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -270,22 +180,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -330,22 +224,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -407,22 +285,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -467,22 +329,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -544,22 +390,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -604,22 +434,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -681,22 +495,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -741,22 +539,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -818,22 +600,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -878,22 +644,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -955,29 +705,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -994,19 +721,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1023,19 +737,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     async def put_read_only_model(
@@ -1048,29 +749,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleanfalse.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/_operations/_operations.py
@@ -162,35 +162,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -207,22 +178,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -239,22 +194,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     def get_model(
@@ -267,35 +206,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -369,22 +279,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -423,22 +317,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -501,22 +379,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -561,22 +423,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -638,22 +484,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -698,22 +528,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -775,22 +589,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -835,22 +633,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -912,22 +694,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -972,22 +738,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1049,29 +799,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1088,19 +815,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1117,19 +831,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     def put_read_only_model(
@@ -1142,29 +843,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/headasbooleantrue/headasbooleantrue/aio/_operations/_operations.py
@@ -63,35 +63,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -108,22 +79,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -140,22 +95,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     async def get_model(
@@ -168,35 +107,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -270,22 +180,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -324,22 +218,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -402,22 +280,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -462,22 +324,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -539,22 +385,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -599,22 +429,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -676,22 +490,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -736,22 +534,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -813,22 +595,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -873,22 +639,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -950,29 +700,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -989,19 +716,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1018,19 +732,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     async def put_read_only_model(
@@ -1043,29 +744,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~headasbooleantrue.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/parameters-basic/parameters/basic/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-basic/parameters/basic/aio/operations/_operations.py
@@ -68,14 +68,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -120,14 +112,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -207,14 +191,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -261,14 +237,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/parameters-basic/parameters/basic/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-basic/parameters/basic/operations/_operations.py
@@ -99,14 +99,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -151,14 +143,6 @@ class ExplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -238,14 +222,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -292,14 +268,6 @@ class ImplicitBodyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/aio/operations/_operations.py
@@ -74,14 +74,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -126,14 +118,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -198,14 +182,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -250,14 +226,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -325,14 +293,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -377,14 +337,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -446,14 +398,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -500,14 +444,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-body-optionality/parameters/bodyoptionality/operations/_operations.py
@@ -128,14 +128,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -180,14 +172,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -252,14 +236,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -304,14 +280,6 @@ class OptionalExplicitOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -379,14 +347,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -431,14 +391,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -500,14 +452,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -554,14 +498,6 @@ class BodyOptionalityClientOperationsMixin(BodyOptionalityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/aio/operations/_operations.py
@@ -79,14 +79,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -133,14 +125,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -207,14 +191,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -259,14 +235,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -389,14 +357,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -453,14 +413,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -528,14 +480,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -594,14 +538,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -688,14 +624,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -742,14 +670,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -820,14 +740,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -892,14 +804,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -972,14 +876,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1044,14 +940,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1124,21 +1012,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -1227,21 +1100,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1321,15 +1179,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1406,15 +1255,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/parameters-spread/parameters/spread/operations/_operations.py
@@ -266,14 +266,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -320,14 +312,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -394,14 +378,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -446,14 +422,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -576,14 +544,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -640,14 +600,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -715,14 +667,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -781,14 +725,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -875,14 +811,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -929,14 +857,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1007,14 +927,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1079,14 +991,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1159,14 +1063,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1231,14 +1127,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1311,21 +1199,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -1414,21 +1287,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredIntList": [
-                        0
-                    ],
-                    "requiredString": "str",
-                    "optionalInt": 0,
-                    "optionalStringList": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1508,15 +1366,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1593,15 +1442,6 @@ class AliasOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "age": 0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/aio/operations/_operations.py
@@ -252,14 +252,6 @@ class DifferentBodyOperations:
         :return: PngImageAsJson. The PngImageAsJson is compatible with MutableMapping
         :rtype: ~payload.contentnegotiation.models.PngImageAsJson
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "content": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-content-negotiation/payload/contentnegotiation/operations/_operations.py
@@ -302,14 +302,6 @@ class DifferentBodyOperations:
         :return: PngImageAsJson. The PngImageAsJson is compatible with MutableMapping
         :rtype: ~payload.contentnegotiation.models.PngImageAsJson
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "content": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-json-merge-patch/payload/jsonmergepatch/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-json-merge-patch/payload/jsonmergepatch/_operations/_operations.py
@@ -111,63 +111,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -182,36 +125,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -228,36 +141,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     def create_resource(self, body: Union[_models.Resource, JSON, IO[bytes]], **kwargs: Any) -> _models.Resource:
@@ -268,63 +151,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -398,62 +224,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -470,36 +240,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -516,36 +256,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     def update_resource(self, body: Union[_models.ResourcePatch, JSON, IO[bytes]], **kwargs: Any) -> _models.Resource:
@@ -556,62 +266,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -689,62 +343,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -761,36 +359,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -807,36 +375,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     def update_optional_resource(
@@ -850,62 +388,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-json-merge-patch/payload/jsonmergepatch/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-json-merge-patch/payload/jsonmergepatch/aio/_operations/_operations.py
@@ -59,63 +59,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -132,36 +75,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -178,36 +91,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     async def create_resource(self, body: Union[_models.Resource, JSON, IO[bytes]], **kwargs: Any) -> _models.Resource:
@@ -218,63 +101,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -348,62 +174,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -420,36 +190,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -466,36 +206,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     async def update_resource(
@@ -508,62 +218,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -641,62 +295,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -713,36 +311,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -759,36 +327,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     async def update_optional_resource(
@@ -802,62 +340,6 @@ class JsonMergePatchClientOperationsMixin(JsonMergePatchClientMixinABC):
         :return: Resource. The Resource is compatible with MutableMapping
         :rtype: ~payload.jsonmergepatch.models.Resource
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "array": [
-                        {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    ],
-                    "description": "str",
-                    "floatValue": 0.0,
-                    "innerModel": {
-                        "description": "str",
-                        "name": "str"
-                    },
-                    "intArray": [
-                        0
-                    ],
-                    "intValue": 0,
-                    "map": {
-                        "str": {
-                            "description": "str",
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/aio/operations/_operations.py
@@ -71,15 +71,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -103,15 +94,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -167,24 +149,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -208,24 +172,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -281,17 +227,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -315,17 +250,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -381,15 +305,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
 
     @overload
@@ -415,15 +330,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -479,19 +385,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -517,19 +410,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -585,15 +465,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
 
     @overload
@@ -619,15 +490,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -683,15 +545,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -717,15 +570,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -781,14 +625,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -816,14 +652,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-multipart/payload/multipart/operations/_operations.py
@@ -140,15 +140,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -172,15 +163,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -236,24 +218,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -277,24 +241,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "id": "str",
-                    "pictures": [filetype],
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -350,17 +296,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -384,17 +319,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "address": {
-                        "city": "str"
-                    },
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -450,15 +374,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
 
     @overload
@@ -482,15 +397,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "pictures": [filetype]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -546,19 +452,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -582,19 +475,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "previousAddresses": [
-                        {
-                            "city": "str"
-                        }
-                    ],
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -650,15 +530,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
 
     @overload
@@ -682,15 +553,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype,
-                    "picture": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -746,15 +608,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -780,15 +633,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": "str",
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -842,14 +686,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
 
     @overload
@@ -877,14 +713,6 @@ class FormDataOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "profileImage": filetype
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/_operations/_operations.py
@@ -69,14 +69,6 @@ class PageableClientOperationsMixin(PageableClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~corehttp.paging.ItemPaged[~payload.pageable.models.User]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/payload-pageable/payload/pageable/aio/_operations/_operations.py
@@ -46,14 +46,6 @@ class PageableClientOperationsMixin(PageableClientMixinABC):
         :return: An iterator like instance of User
         :rtype: ~corehttp.paging.AsyncItemPaged[~payload.pageable.models.User]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         _headers = kwargs.pop("headers", {}) or {}
         _params = kwargs.pop("params", {}) or {}

--- a/packages/typespec-python/test/unbranded/generated/serialization-encoded-name-json/serialization/encodedname/json/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/serialization-encoded-name-json/serialization/encodedname/json/aio/operations/_operations.py
@@ -69,14 +69,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -121,14 +113,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -182,14 +166,6 @@ class PropertyOperations:
         :return: JsonEncodedNameModel. The JsonEncodedNameModel is compatible with MutableMapping
         :rtype: ~serialization.encodedname.json.models.JsonEncodedNameModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/serialization-encoded-name-json/serialization/encodedname/json/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/serialization-encoded-name-json/serialization/encodedname/json/operations/_operations.py
@@ -100,14 +100,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
 
     @overload
@@ -152,14 +144,6 @@ class PropertyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -213,14 +197,6 @@ class PropertyOperations:
         :return: JsonEncodedNameModel. The JsonEncodedNameModel is compatible with MutableMapping
         :rtype: ~serialization.encodedname.json.models.JsonEncodedNameModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "wireName": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/special-words/specialwords/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/special-words/specialwords/aio/operations/_operations.py
@@ -169,14 +169,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -221,14 +213,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -290,14 +274,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -342,14 +318,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -411,14 +379,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -463,14 +423,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -532,14 +484,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -584,14 +528,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -653,14 +589,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -705,14 +633,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -774,14 +694,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -826,14 +738,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -895,14 +799,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -947,14 +843,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1016,14 +904,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1068,14 +948,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1137,14 +1009,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1189,14 +1053,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1258,14 +1114,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1310,14 +1158,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1379,14 +1219,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1431,14 +1263,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1500,14 +1324,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1552,14 +1368,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1621,14 +1429,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1673,14 +1473,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1742,14 +1534,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1794,14 +1578,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1863,14 +1639,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1915,14 +1683,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1984,14 +1744,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2036,14 +1788,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2105,14 +1849,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2157,14 +1893,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2226,14 +1954,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2278,14 +1998,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2347,14 +2059,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2399,14 +2103,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2468,14 +2164,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2520,14 +2208,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2589,14 +2269,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2641,14 +2313,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2710,14 +2374,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2762,14 +2418,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2831,14 +2479,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2883,14 +2523,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2952,14 +2584,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3004,14 +2628,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3073,14 +2689,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3125,14 +2733,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3194,14 +2794,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3246,14 +2838,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3315,14 +2899,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3367,14 +2943,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3436,14 +3004,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3488,14 +3048,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3557,14 +3109,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3609,14 +3153,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3678,14 +3214,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3730,14 +3258,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3799,14 +3319,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3851,14 +3363,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3920,14 +3424,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3972,14 +3468,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4041,14 +3529,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4093,14 +3573,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4180,14 +3652,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
 
     @overload
@@ -4232,14 +3696,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/special-words/specialwords/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/special-words/specialwords/operations/_operations.py
@@ -1189,14 +1189,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1241,14 +1233,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1310,14 +1294,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1362,14 +1338,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1431,14 +1399,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1483,14 +1443,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1552,14 +1504,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1604,14 +1548,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1673,14 +1609,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1725,14 +1653,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1794,14 +1714,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1846,14 +1758,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1915,14 +1819,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1967,14 +1863,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2036,14 +1924,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2088,14 +1968,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2157,14 +2029,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2209,14 +2073,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2278,14 +2134,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2330,14 +2178,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2399,14 +2239,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2451,14 +2283,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2520,14 +2344,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2572,14 +2388,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2641,14 +2449,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2693,14 +2493,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2762,14 +2554,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2814,14 +2598,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2883,14 +2659,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2935,14 +2703,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3004,14 +2764,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3056,14 +2808,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3125,14 +2869,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3177,14 +2913,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3246,14 +2974,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3298,14 +3018,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3367,14 +3079,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3419,14 +3123,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3488,14 +3184,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3540,14 +3228,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3609,14 +3289,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3661,14 +3333,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3730,14 +3394,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3782,14 +3438,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3851,14 +3499,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -3903,14 +3543,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3972,14 +3604,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4024,14 +3648,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4093,14 +3709,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4145,14 +3753,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4214,14 +3814,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4266,14 +3858,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4335,14 +3919,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4387,14 +3963,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4456,14 +4024,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4508,14 +4068,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4577,14 +4129,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4629,14 +4173,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4698,14 +4234,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4750,14 +4278,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4819,14 +4339,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4871,14 +4383,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4940,14 +4444,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4992,14 +4488,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5061,14 +4549,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5113,14 +4593,6 @@ class ModelsOperations:  # pylint: disable=too-many-public-methods
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5200,14 +4672,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
 
     @overload
@@ -5252,14 +4716,6 @@ class ModelPropertiesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "SameAsModel": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/aio/operations/_operations.py
@@ -90,14 +90,6 @@ class Int32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -161,14 +153,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -268,14 +252,6 @@ class Int64ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -339,14 +315,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -446,14 +414,6 @@ class BooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -517,14 +477,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -624,14 +576,6 @@ class StringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -695,14 +639,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -802,14 +738,6 @@ class Float32ValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -873,14 +801,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -980,14 +900,6 @@ class DatetimeValueOperations:
         :return: list of datetime
         :rtype: list[~datetime.datetime]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "2020-02-20 00:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1051,14 +963,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "2020-02-20 00:00:00"
-                ]
         """
 
     @overload
@@ -1158,14 +1062,6 @@ class DurationValueOperations:
         :return: list of timedelta
         :rtype: list[~datetime.timedelta]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "1 day, 0:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1229,14 +1125,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "1 day, 0:00:00"
-                ]
         """
 
     @overload
@@ -1336,14 +1224,6 @@ class UnknownValueOperations:
         :return: list of any
         :rtype: list[any]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {}
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1407,14 +1287,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {}
-                ]
         """
 
     @overload
@@ -1514,19 +1386,6 @@ class ModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1590,19 +1449,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload
@@ -1702,14 +1548,6 @@ class NullableFloatValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1773,14 +1611,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -1880,14 +1710,6 @@ class NullableInt32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1951,14 +1773,6 @@ class NullableInt32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -2058,14 +1872,6 @@ class NullableBooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2129,14 +1935,6 @@ class NullableBooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -2236,14 +2034,6 @@ class NullableStringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2307,14 +2097,6 @@ class NullableStringValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -2414,19 +2196,6 @@ class NullableModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2490,19 +2259,6 @@ class NullableModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload

--- a/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-array/typetest/array/operations/_operations.py
@@ -456,14 +456,6 @@ class Int32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -527,14 +519,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -634,14 +618,6 @@ class Int64ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -705,14 +681,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -812,14 +780,6 @@ class BooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -883,14 +843,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -990,14 +942,6 @@ class StringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1061,14 +1005,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -1168,14 +1104,6 @@ class Float32ValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1239,14 +1167,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -1346,14 +1266,6 @@ class DatetimeValueOperations:
         :return: list of datetime
         :rtype: list[~datetime.datetime]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "2020-02-20 00:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1417,14 +1329,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "2020-02-20 00:00:00"
-                ]
         """
 
     @overload
@@ -1524,14 +1428,6 @@ class DurationValueOperations:
         :return: list of timedelta
         :rtype: list[~datetime.timedelta]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "1 day, 0:00:00"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1595,14 +1491,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "1 day, 0:00:00"
-                ]
         """
 
     @overload
@@ -1702,14 +1590,6 @@ class UnknownValueOperations:
         :return: list of any
         :rtype: list[any]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {}
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1773,14 +1653,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {}
-                ]
         """
 
     @overload
@@ -1880,19 +1752,6 @@ class ModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1956,19 +1815,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload
@@ -2068,14 +1914,6 @@ class NullableFloatValueOperations:
         :return: list of float
         :rtype: list[float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2139,14 +1977,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0.0
-                ]
         """
 
     @overload
@@ -2246,14 +2076,6 @@ class NullableInt32ValueOperations:
         :return: list of int
         :rtype: list[int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2317,14 +2139,6 @@ class NullableInt32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    0
-                ]
         """
 
     @overload
@@ -2424,14 +2238,6 @@ class NullableBooleanValueOperations:
         :return: list of bool
         :rtype: list[bool]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    bool
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2495,14 +2301,6 @@ class NullableBooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    bool
-                ]
         """
 
     @overload
@@ -2602,14 +2400,6 @@ class NullableStringValueOperations:
         :return: list of str
         :rtype: list[str]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    "str"
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2673,14 +2463,6 @@ class NullableStringValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    "str"
-                ]
         """
 
     @overload
@@ -2780,19 +2562,6 @@ class NullableModelValueOperations:
         :return: list of InnerModel
         :rtype: list[~typetest.array.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2856,19 +2625,6 @@ class NullableModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = [
-                    {
-                        "property": "str",
-                        "children": [
-                            ...
-                        ]
-                    }
-                ]
         """
 
     @overload

--- a/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/aio/operations/_operations.py
@@ -84,14 +84,6 @@ class Int32ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -155,14 +147,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -262,14 +246,6 @@ class Int64ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -333,14 +309,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -440,14 +408,6 @@ class BooleanValueOperations:
         :return: dict mapping str to bool
         :rtype: dict[str, bool]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -511,14 +471,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": bool
-                }
         """
 
     @overload
@@ -618,14 +570,6 @@ class StringValueOperations:
         :return: dict mapping str to str
         :rtype: dict[str, str]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -689,14 +633,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "str"
-                }
         """
 
     @overload
@@ -796,14 +732,6 @@ class Float32ValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -867,14 +795,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload
@@ -974,14 +894,6 @@ class DatetimeValueOperations:
         :return: dict mapping str to datetime
         :rtype: dict[str, ~datetime.datetime]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1045,14 +957,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1152,14 +1056,6 @@ class DurationValueOperations:
         :return: dict mapping str to timedelta
         :rtype: dict[str, ~datetime.timedelta]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1223,14 +1119,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1330,14 +1218,6 @@ class UnknownValueOperations:
         :return: dict mapping str to any
         :rtype: dict[str, any]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1401,14 +1281,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {}
-                }
         """
 
     @overload
@@ -1508,19 +1380,6 @@ class ModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1584,19 +1443,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -1696,19 +1542,6 @@ class RecursiveModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1772,19 +1605,6 @@ class RecursiveModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -1884,14 +1704,6 @@ class NullableFloatValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1955,14 +1767,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload

--- a/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-dictionary/typetest/dictionary/operations/_operations.py
@@ -372,14 +372,6 @@ class Int32ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -443,14 +435,6 @@ class Int32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -550,14 +534,6 @@ class Int64ValueOperations:
         :return: dict mapping str to int
         :rtype: dict[str, int]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -621,14 +597,6 @@ class Int64ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0
-                }
         """
 
     @overload
@@ -728,14 +696,6 @@ class BooleanValueOperations:
         :return: dict mapping str to bool
         :rtype: dict[str, bool]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -799,14 +759,6 @@ class BooleanValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": bool
-                }
         """
 
     @overload
@@ -906,14 +858,6 @@ class StringValueOperations:
         :return: dict mapping str to str
         :rtype: dict[str, str]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -977,14 +921,6 @@ class StringValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "str"
-                }
         """
 
     @overload
@@ -1084,14 +1020,6 @@ class Float32ValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1155,14 +1083,6 @@ class Float32ValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload
@@ -1262,14 +1182,6 @@ class DatetimeValueOperations:
         :return: dict mapping str to datetime
         :rtype: dict[str, ~datetime.datetime]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1333,14 +1245,6 @@ class DatetimeValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1440,14 +1344,6 @@ class DurationValueOperations:
         :return: dict mapping str to timedelta
         :rtype: dict[str, ~datetime.timedelta]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1511,14 +1407,6 @@ class DurationValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1618,14 +1506,6 @@ class UnknownValueOperations:
         :return: dict mapping str to any
         :rtype: dict[str, any]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1689,14 +1569,6 @@ class UnknownValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {}
-                }
         """
 
     @overload
@@ -1796,19 +1668,6 @@ class ModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1872,19 +1731,6 @@ class ModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -1984,19 +1830,6 @@ class RecursiveModelValueOperations:
         :return: dict mapping str to InnerModel
         :rtype: dict[str, ~typetest.dictionary.models.InnerModel]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2060,19 +1893,6 @@ class RecursiveModelValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": {
-                        "property": "str",
-                        "children": {
-                            "str": ...
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2172,14 +1992,6 @@ class NullableFloatValueOperations:
         :return: dict mapping str to float
         :rtype: dict[str, float]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "str": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2243,14 +2055,6 @@ class NullableFloatValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "str": 0.0
-                }
         """
 
     @overload

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/_operations/_operations.py
@@ -103,12 +103,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
 
     @overload
@@ -153,12 +147,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -275,12 +263,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -325,12 +307,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-empty/typetest/model/empty/aio/_operations/_operations.py
@@ -59,12 +59,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
 
     @overload
@@ -109,12 +103,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -231,12 +219,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -281,12 +263,6 @@ class EmptyClientOperationsMixin(EmptyClientMixinABC):
         :return: EmptyInputOutput. The EmptyInputOutput is compatible with MutableMapping
         :rtype: ~typetest.model.empty.models.EmptyInputOutput
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/_operations/_operations.py
@@ -174,21 +174,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -252,21 +237,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
 
     @overload
@@ -311,21 +281,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -379,21 +334,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -449,21 +389,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -519,21 +444,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -597,21 +507,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
 
     @overload
@@ -656,21 +551,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -724,21 +604,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -794,21 +659,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-enumdiscriminator/typetest/model/enumdiscriminator/aio/_operations/_operations.py
@@ -56,21 +56,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -134,21 +119,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
 
     @overload
@@ -193,21 +163,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -263,21 +218,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -333,21 +273,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Dog. The Dog is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Dog
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "golden":
-                dog = {
-                    "kind": "golden",
-                    "weight": 0
-                }
-
-                # response body for status code(s): 200
-                response == dog
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -403,21 +328,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -481,21 +391,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
 
     @overload
@@ -540,21 +435,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -608,21 +488,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -678,21 +543,6 @@ class EnumDiscriminatorClientOperationsMixin(EnumDiscriminatorClientMixinABC):
         :return: Snake. The Snake is compatible with MutableMapping
         :rtype: ~typetest.model.enumdiscriminator.models.Snake
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "cobra":
-                snake = {
-                    "kind": "cobra",
-                    "length": 0
-                }
-
-                # response body for status code(s): 200
-                response == snake
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-flatten/typetest/model/flatten/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-flatten/typetest/model/flatten/_operations/_operations.py
@@ -92,27 +92,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -129,18 +108,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -157,18 +124,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     def put_flatten_model(
@@ -181,27 +136,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -275,33 +209,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -318,21 +225,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -349,21 +241,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     def put_nested_flatten_model(
@@ -376,33 +253,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-flatten/typetest/model/flatten/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-flatten/typetest/model/flatten/aio/_operations/_operations.py
@@ -58,27 +58,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -95,18 +74,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     @overload
@@ -123,18 +90,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
 
     async def put_flatten_model(
@@ -147,27 +102,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: FlattenModel. The FlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.FlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "age": 0,
-                        "description": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -241,33 +175,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -284,21 +191,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     @overload
@@ -315,21 +207,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
 
     async def put_nested_flatten_model(
@@ -342,33 +219,6 @@ class FlattenClientOperationsMixin(FlattenClientMixinABC):
         :return: NestedFlattenModel. The NestedFlattenModel is compatible with MutableMapping
         :rtype: ~typetest.model.flatten.models.NestedFlattenModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str",
-                    "properties": {
-                        "properties": {
-                            "age": 0,
-                            "description": "str"
-                        },
-                        "summary": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/_operations/_operations.py
@@ -142,40 +142,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -239,40 +205,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -317,40 +249,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -404,40 +302,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -501,40 +365,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -579,40 +409,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -666,40 +462,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -755,40 +517,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-nesteddiscriminator/typetest/model/nesteddiscriminator/aio/_operations/_operations.py
@@ -54,40 +54,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -151,40 +117,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -229,40 +161,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -316,40 +214,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -413,40 +277,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
 
     @overload
@@ -491,40 +321,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -578,40 +374,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -667,40 +429,6 @@ class NestedDiscriminatorClientOperationsMixin(NestedDiscriminatorClientMixinABC
         :return: Fish. The Fish is compatible with MutableMapping
         :rtype: ~typetest.model.nesteddiscriminator.models.Fish
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "salmon":
-                fish = {
-                    "age": 0,
-                    "kind": "salmon",
-                    "friends": [
-                        fish
-                    ],
-                    "hate": {
-                        "str": fish
-                    },
-                    "partner": fish
-                }
-
-                # JSON input template for discriminator value "goblin":
-                fish = {
-                    "age": 0,
-                    "kind": "goblin"
-                }
-
-                # JSON input template for discriminator value "saw":
-                fish = {
-                    "age": 0,
-                    "kind": "saw"
-                }
-
-                # response body for status code(s): 200
-                response == fish
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/_operations/_operations.py
@@ -103,16 +103,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -157,16 +147,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -220,16 +200,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -293,23 +263,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -324,16 +277,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -348,16 +291,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     def put_valid(self, input: Union[_models.Siamese, JSON, IO[bytes]], **kwargs: Any) -> _models.Siamese:
@@ -368,23 +301,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-notdiscriminated/typetest/model/notdiscriminated/aio/_operations/_operations.py
@@ -59,16 +59,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -113,16 +103,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -176,16 +156,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -249,23 +219,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -280,16 +233,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     @overload
@@ -306,16 +249,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
 
     async def put_valid(self, input: Union[_models.Siamese, JSON, IO[bytes]], **kwargs: Any) -> _models.Siamese:
@@ -326,23 +259,6 @@ class NotDiscriminatedClientOperationsMixin(NotDiscriminatedClientMixinABC):
         :return: Siamese. The Siamese is compatible with MutableMapping
         :rtype: ~typetest.model.notdiscriminated.models.Siamese
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "age": 0,
-                    "name": "str",
-                    "smart": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/_operations/_operations.py
@@ -86,17 +86,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
 
     @overload
@@ -141,17 +130,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -205,17 +183,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: Extension. The Extension is compatible with MutableMapping
         :rtype: ~typetest.model.recursive.models.Extension
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-recursive/typetest/model/recursive/aio/_operations/_operations.py
@@ -55,17 +55,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
 
     @overload
@@ -110,17 +99,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -174,17 +152,6 @@ class RecursiveClientOperationsMixin(RecursiveClientMixinABC):
         :return: Extension. The Extension is compatible with MutableMapping
         :rtype: ~typetest.model.recursive.models.Extension
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "level": 0,
-                    "extension": [
-                        ...
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/_operations/_operations.py
@@ -156,46 +156,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -259,46 +219,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -343,46 +263,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -436,46 +316,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -539,46 +379,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -623,46 +423,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -716,46 +476,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -811,46 +531,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -906,21 +586,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Dinosaur. The Dinosaur is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Dinosaur
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "t-rex":
-                dinosaur = {
-                    "kind": "t-rex",
-                    "size": 0
-                }
-
-                # response body for status code(s): 200
-                response == dinosaur
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-singlediscriminator/typetest/model/singlediscriminator/aio/_operations/_operations.py
@@ -55,46 +55,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -158,46 +118,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -242,46 +162,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -335,46 +215,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -438,46 +278,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
 
     @overload
@@ -522,46 +322,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                input = bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -615,46 +375,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -710,46 +430,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Bird. The Bird is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Bird
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "eagle":
-                bird = {
-                    "kind": "eagle",
-                    "wingspan": 0,
-                    "friends": [
-                        bird
-                    ],
-                    "hate": {
-                        "str": bird
-                    },
-                    "partner": bird
-                }
-
-                # JSON input template for discriminator value "goose":
-                bird = {
-                    "kind": "goose",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "seagull":
-                bird = {
-                    "kind": "seagull",
-                    "wingspan": 0
-                }
-
-                # JSON input template for discriminator value "sparrow":
-                bird = {
-                    "kind": "sparrow",
-                    "wingspan": 0
-                }
-
-                # response body for status code(s): 200
-                response == bird
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -805,21 +485,6 @@ class SingleDiscriminatorClientOperationsMixin(SingleDiscriminatorClientMixinABC
         :return: Dinosaur. The Dinosaur is compatible with MutableMapping
         :rtype: ~typetest.model.singlediscriminator.models.Dinosaur
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "t-rex":
-                dinosaur = {
-                    "kind": "t-rex",
-                    "size": 0
-                }
-
-                # response body for status code(s): 200
-                response == dinosaur
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/_operations/_operations.py
@@ -103,14 +103,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -155,14 +147,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -216,14 +200,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: OutputRecord. The OutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.OutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -287,19 +263,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -316,14 +279,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -340,14 +295,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     def input_and_output(
@@ -360,19 +307,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-usage/typetest/model/usage/aio/_operations/_operations.py
@@ -59,14 +59,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -111,14 +103,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -172,14 +156,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: OutputRecord. The OutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.OutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -243,19 +219,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -272,14 +235,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     @overload
@@ -296,14 +251,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
 
     async def input_and_output(
@@ -316,19 +263,6 @@ class UsageClientOperationsMixin(UsageClientMixinABC):
         :return: InputOutputRecord. The InputOutputRecord is compatible with MutableMapping
         :rtype: ~typetest.model.usage.models.InputOutputRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/_operations/_operations.py
@@ -162,35 +162,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -207,22 +178,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -239,22 +194,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     def get_model(
@@ -267,35 +206,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -369,22 +279,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -423,22 +317,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -501,22 +379,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -561,22 +423,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -638,22 +484,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -698,22 +528,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -775,22 +589,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -835,22 +633,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -912,22 +694,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -972,22 +738,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1049,29 +799,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1088,19 +815,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1117,19 +831,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     def put_read_only_model(
@@ -1142,29 +843,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-model-visibility/typetest/model/visibility/aio/_operations/_operations.py
@@ -63,35 +63,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -108,22 +79,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -140,22 +95,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     async def get_model(
@@ -168,35 +107,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: VisibilityModel. The VisibilityModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.VisibilityModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -270,22 +180,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -324,22 +218,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: bool
         :rtype: bool
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -402,22 +280,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -462,22 +324,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -539,22 +385,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -599,22 +429,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -676,22 +490,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -736,22 +534,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -813,22 +595,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -873,22 +639,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "createProp": [
-                        "str"
-                    ],
-                    "deleteProp": bool,
-                    "queryProp": 0,
-                    "readProp": "str",
-                    "updateProp": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -950,29 +700,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -989,19 +716,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -1018,19 +732,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
 
     async def put_read_only_model(
@@ -1043,29 +744,6 @@ class VisibilityClientOperationsMixin(VisibilityClientMixinABC):
         :return: ReadOnlyModel. The ReadOnlyModel is compatible with MutableMapping
         :rtype: ~typetest.model.visibility.models.ReadOnlyModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                input = {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "optionalNullableIntList": [
-                        0
-                    ],
-                    "optionalStringRecord": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/aio/operations/_operations.py
@@ -127,14 +127,6 @@ class ExtendsUnknownOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -198,14 +190,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -252,14 +236,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -333,16 +309,6 @@ class ExtendsUnknownDerivedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -411,16 +377,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -468,16 +424,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -551,23 +497,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDiscriminated
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -636,23 +565,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -700,23 +612,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -789,14 +684,6 @@ class IsUnknownOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -860,14 +747,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -914,14 +793,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -994,16 +865,6 @@ class IsUnknownDerivedOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1071,16 +932,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -1127,16 +978,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1210,23 +1051,6 @@ class IsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDiscriminated
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1295,23 +1119,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -1359,23 +1166,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1448,14 +1238,6 @@ class ExtendsStringOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsStringAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1519,14 +1301,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1573,14 +1347,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1653,14 +1419,6 @@ class IsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsStringAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1724,14 +1482,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1778,14 +1528,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1857,14 +1599,6 @@ class SpreadStringOperations:
         :return: SpreadStringRecord. The SpreadStringRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadStringRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1928,14 +1662,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1981,14 +1707,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2061,14 +1779,6 @@ class ExtendsFloatOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsFloatAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2132,14 +1842,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -2186,14 +1888,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2266,14 +1960,6 @@ class IsFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsFloatAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2337,14 +2023,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -2391,14 +2069,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2470,14 +2140,6 @@ class SpreadFloatOperations:
         :return: SpreadFloatRecord. The SpreadFloatRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadFloatRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2541,14 +2203,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -2594,14 +2248,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2674,16 +2320,6 @@ class ExtendsModelOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2747,16 +2383,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -2803,16 +2429,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2885,16 +2501,6 @@ class IsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2958,16 +2564,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3014,16 +2610,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3095,16 +2681,6 @@ class SpreadModelOperations:
         :return: SpreadModelRecord. The SpreadModelRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3168,16 +2744,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3223,16 +2789,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3305,18 +2861,6 @@ class ExtendsModelArrayOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelArrayAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3385,18 +2929,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3444,18 +2976,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3528,18 +3048,6 @@ class IsModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelArrayAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3603,18 +3111,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3661,18 +3157,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3744,18 +3228,6 @@ class SpreadModelArrayOperations:
         :return: SpreadModelArrayRecord. The SpreadModelArrayRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelArrayRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3819,18 +3291,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3877,18 +3337,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3961,14 +3409,6 @@ class SpreadDifferentStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4032,14 +3472,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -4086,14 +3518,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4166,14 +3590,6 @@ class SpreadDifferentFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4237,14 +3653,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -4291,14 +3699,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4371,14 +3771,6 @@ class SpreadDifferentModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4442,14 +3834,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -4496,14 +3880,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4576,14 +3952,6 @@ class SpreadDifferentModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4647,14 +4015,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -4701,14 +4061,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4781,15 +4133,6 @@ class ExtendsDifferentSpreadStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4853,15 +4196,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -4908,15 +4242,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4989,15 +4314,6 @@ class ExtendsDifferentSpreadFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5061,15 +4377,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5116,15 +4423,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5197,17 +4495,6 @@ class ExtendsDifferentSpreadModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5271,17 +4558,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5328,17 +4604,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5411,19 +4676,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5487,19 +4739,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5546,19 +4785,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5630,14 +4856,6 @@ class MultipleSpreadOperations:
         :return: MultipleSpreadRecord. The MultipleSpreadRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.MultipleSpreadRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5701,14 +4919,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -5755,14 +4965,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5834,14 +5036,6 @@ class SpreadRecordUnionOperations:
         :return: SpreadRecordForUnion. The SpreadRecordForUnion is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForUnion
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5905,14 +5099,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -5959,14 +5145,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6039,14 +5217,6 @@ class SpreadRecordDiscriminatedUnionOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForDiscriminatedUnion
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6110,14 +5280,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6164,14 +5326,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6244,14 +5398,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6319,14 +5465,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6373,14 +5511,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6453,14 +5583,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6529,14 +5651,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6584,14 +5698,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6664,14 +5770,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion3
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6740,14 +5838,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -6795,14 +5885,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-additionalproperties/typetest/property/additionalproperties/operations/_operations.py
@@ -977,14 +977,6 @@ class ExtendsUnknownOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1048,14 +1040,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1102,14 +1086,6 @@ class ExtendsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1183,16 +1159,6 @@ class ExtendsUnknownDerivedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1261,16 +1227,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -1318,16 +1274,6 @@ class ExtendsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1401,23 +1347,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.ExtendsUnknownAdditionalPropertiesDiscriminated
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1486,23 +1415,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -1550,23 +1462,6 @@ class ExtendsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                extends_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = extends_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1639,14 +1534,6 @@ class IsUnknownOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1710,14 +1597,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -1764,14 +1643,6 @@ class IsUnknownOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1844,16 +1715,6 @@ class IsUnknownDerivedOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1921,16 +1782,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
 
     @overload
@@ -1977,16 +1828,6 @@ class IsUnknownDerivedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "index": 0,
-                    "name": "str",
-                    "age": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2060,23 +1901,6 @@ class IsUnknownDiscriminatedOperations:
         :rtype:
          ~typetest.property.additionalproperties.models.IsUnknownAdditionalPropertiesDiscriminated
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The response is polymorphic. The following are possible polymorphic responses based
-                  off discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # response body for status code(s): 200
-                response == is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2145,23 +1969,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
 
     @overload
@@ -2209,23 +2016,6 @@ class IsUnknownDiscriminatedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # The input is polymorphic. The following are possible polymorphic inputs based off
-                  discriminator "kind":
-
-                # JSON input template for discriminator value "derived":
-                is_unknown_additional_properties_discriminated = {
-                    "index": 0,
-                    "kind": "derived",
-                    "name": "str",
-                    "age": 0.0
-                }
-
-                # JSON input template you can fill out and use as your body input.
-                body = is_unknown_additional_properties_discriminated
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2298,14 +2088,6 @@ class ExtendsStringOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsStringAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2369,14 +2151,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2423,14 +2197,6 @@ class ExtendsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2503,14 +2269,6 @@ class IsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsStringAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2574,14 +2332,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2628,14 +2378,6 @@ class IsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2707,14 +2449,6 @@ class SpreadStringOperations:
         :return: SpreadStringRecord. The SpreadStringRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadStringRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2778,14 +2512,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -2831,14 +2557,6 @@ class SpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2911,14 +2629,6 @@ class ExtendsFloatOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsFloatAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2982,14 +2692,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -3036,14 +2738,6 @@ class ExtendsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3116,14 +2810,6 @@ class IsFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsFloatAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3187,14 +2873,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -3241,14 +2919,6 @@ class IsFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3320,14 +2990,6 @@ class SpreadFloatOperations:
         :return: SpreadFloatRecord. The SpreadFloatRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadFloatRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3391,14 +3053,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -3444,14 +3098,6 @@ class SpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3524,16 +3170,6 @@ class ExtendsModelOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3597,16 +3233,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3653,16 +3279,6 @@ class ExtendsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3735,16 +3351,6 @@ class IsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3808,16 +3414,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -3864,16 +3460,6 @@ class IsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3945,16 +3531,6 @@ class SpreadModelOperations:
         :return: SpreadModelRecord. The SpreadModelRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4018,16 +3594,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
 
     @overload
@@ -4073,16 +3639,6 @@ class SpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": {
-                        "state": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4155,18 +3711,6 @@ class ExtendsModelArrayOperations:
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.ExtendsModelArrayAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4235,18 +3779,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4294,18 +3826,6 @@ class ExtendsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4378,18 +3898,6 @@ class IsModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.IsModelArrayAdditionalProperties
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4453,18 +3961,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4511,18 +4007,6 @@ class IsModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4594,18 +4078,6 @@ class SpreadModelArrayOperations:
         :return: SpreadModelArrayRecord. The SpreadModelArrayRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadModelArrayRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4669,18 +4141,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4727,18 +4187,6 @@ class SpreadModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": [
-                        {
-                            "state": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4811,14 +4259,6 @@ class SpreadDifferentStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4882,14 +4322,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -4936,14 +4368,6 @@ class SpreadDifferentStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5016,14 +4440,6 @@ class SpreadDifferentFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5087,14 +4503,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5141,14 +4549,6 @@ class SpreadDifferentFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5221,14 +4621,6 @@ class SpreadDifferentModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5292,14 +4684,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5346,14 +4730,6 @@ class SpreadDifferentModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5426,14 +4802,6 @@ class SpreadDifferentModelArrayOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5497,14 +4865,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -5551,14 +4911,6 @@ class SpreadDifferentModelArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5631,15 +4983,6 @@ class ExtendsDifferentSpreadStringOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadStringDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5703,15 +5046,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
 
     @overload
@@ -5758,15 +5092,6 @@ class ExtendsDifferentSpreadStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": "str",
-                    "id": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5839,15 +5164,6 @@ class ExtendsDifferentSpreadFloatOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadFloatDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5911,15 +5227,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
 
     @overload
@@ -5966,15 +5273,6 @@ class ExtendsDifferentSpreadFloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": 0.0,
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6047,17 +5345,6 @@ class ExtendsDifferentSpreadModelOperations:
          MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6121,17 +5408,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -6178,17 +5454,6 @@ class ExtendsDifferentSpreadModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": {
-                        "state": "str"
-                    },
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6261,19 +5526,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.DifferentSpreadModelArrayDerived
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6337,19 +5589,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
 
     @overload
@@ -6396,19 +5635,6 @@ class ExtendsDifferentSpreadModelArrayOperations:  # pylint: disable=name-too-lo
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "derivedProp": [
-                        {
-                            "state": "str"
-                        }
-                    ],
-                    "knownProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6480,14 +5706,6 @@ class MultipleSpreadOperations:
         :return: MultipleSpreadRecord. The MultipleSpreadRecord is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.MultipleSpreadRecord
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6551,14 +5769,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -6605,14 +5815,6 @@ class MultipleSpreadOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6684,14 +5886,6 @@ class SpreadRecordUnionOperations:
         :return: SpreadRecordForUnion. The SpreadRecordForUnion is compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForUnion
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6755,14 +5949,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
 
     @overload
@@ -6809,14 +5995,6 @@ class SpreadRecordUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "flag": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6889,14 +6067,6 @@ class SpreadRecordDiscriminatedUnionOperations:
          with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForDiscriminatedUnion
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6960,14 +6130,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7014,14 +6176,6 @@ class SpreadRecordDiscriminatedUnionOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7094,14 +6248,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7169,14 +6315,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7223,14 +6361,6 @@ class SpreadRecordNonDiscriminatedUnionOperations:  # pylint: disable=name-too-l
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7303,14 +6433,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7379,14 +6501,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7434,14 +6548,6 @@ class SpreadRecordNonDiscriminatedUnion2Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7514,14 +6620,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
          compatible with MutableMapping
         :rtype: ~typetest.property.additionalproperties.models.SpreadRecordForNonDiscriminatedUnion3
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7590,14 +6688,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
 
     @overload
@@ -7645,14 +6735,6 @@ class SpreadRecordNonDiscriminatedUnion3Operations:  # pylint: disable=name-too-
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "name": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/aio/operations/_operations.py
@@ -90,15 +90,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -154,15 +145,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -226,15 +208,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -279,15 +252,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -349,15 +313,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -402,15 +357,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -482,15 +428,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -546,15 +483,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -618,15 +546,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -671,15 +590,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -741,15 +651,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -794,15 +695,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -874,15 +766,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -938,15 +821,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1010,15 +884,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1063,15 +928,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1133,15 +989,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1186,15 +1033,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1266,15 +1104,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1330,15 +1159,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1402,15 +1222,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1455,15 +1266,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1525,15 +1327,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1578,15 +1371,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1658,17 +1442,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1724,17 +1497,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1802,17 +1564,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1857,17 +1608,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1933,17 +1673,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1988,17 +1717,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2071,19 +1789,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2140,19 +1845,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2220,19 +1912,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2277,19 +1956,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2355,19 +2021,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2412,19 +2065,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2497,17 +2137,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2564,17 +2193,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2642,17 +2260,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2698,17 +2305,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2774,17 +2370,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2830,17 +2415,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-nullable/typetest/property/nullable/operations/_operations.py
@@ -456,15 +456,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -520,15 +511,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -592,15 +574,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -645,15 +618,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -715,15 +679,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -768,15 +723,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "str",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -848,15 +794,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -912,15 +849,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -984,15 +912,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1037,15 +956,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1107,15 +1017,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1160,15 +1061,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": bytes("bytes", encoding="utf-8"),
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1240,15 +1132,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1304,15 +1187,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1376,15 +1250,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1429,15 +1294,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1499,15 +1355,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1552,15 +1399,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "2020-02-20 00:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1632,15 +1470,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1696,15 +1525,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1768,15 +1588,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1821,15 +1632,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1891,15 +1693,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -1944,15 +1737,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": "1 day, 0:00:00",
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2024,17 +1808,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2090,17 +1863,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2168,17 +1930,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2223,17 +1974,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2299,17 +2039,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2354,17 +2083,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        bytes("bytes", encoding="utf-8")
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2437,19 +2155,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2506,19 +2211,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2586,19 +2278,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2643,19 +2322,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2721,19 +2387,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -2778,19 +2431,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        {
-                            "property": "str"
-                        }
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2863,17 +2503,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2930,17 +2559,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.nullable.models.CollectionsStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3008,17 +2626,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -3064,17 +2671,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3140,17 +2736,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
 
     @overload
@@ -3196,17 +2781,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "nullableProperty": [
-                        "str"
-                    ],
-                    "requiredProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/aio/operations/_operations.py
@@ -126,14 +126,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -189,14 +181,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -260,14 +244,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -312,14 +288,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -381,14 +349,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -433,14 +393,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -512,14 +464,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -575,14 +519,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -646,14 +582,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -698,14 +626,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -767,14 +687,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -819,14 +731,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -898,14 +802,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -961,14 +857,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1032,14 +920,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1084,14 +964,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1153,14 +1025,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1205,14 +1069,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1284,14 +1140,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1347,14 +1195,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1418,14 +1258,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1470,14 +1302,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1539,14 +1363,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1591,14 +1407,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1670,14 +1478,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1733,14 +1533,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1804,14 +1596,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -1856,14 +1640,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1925,14 +1701,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -1977,14 +1745,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2056,14 +1816,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2119,14 +1871,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2190,14 +1934,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -2242,14 +1978,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2311,14 +2039,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -2363,14 +2083,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2442,16 +2154,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2507,16 +2209,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2580,16 +2272,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -2634,16 +2316,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2705,16 +2377,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -2759,16 +2421,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2841,18 +2493,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2909,18 +2549,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2984,18 +2612,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3040,18 +2656,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3113,18 +2717,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3169,18 +2761,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3252,14 +2832,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3315,14 +2887,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3386,14 +2950,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -3438,14 +2994,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3507,14 +3055,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -3559,14 +3099,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3638,14 +3170,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3701,14 +3225,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3772,14 +3288,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -3824,14 +3332,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3893,14 +3393,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -3945,14 +3437,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4024,14 +3508,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4087,14 +3563,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4158,14 +3626,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -4210,14 +3670,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4279,14 +3731,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -4331,14 +3775,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4410,14 +3846,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4473,14 +3901,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4544,14 +3964,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -4596,14 +4008,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4665,14 +4069,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -4717,14 +4113,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4797,14 +4185,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4861,14 +4241,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4932,14 +4304,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4985,14 +4349,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5054,14 +4410,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5107,14 +4455,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5186,14 +4526,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5249,14 +4581,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5320,14 +4644,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -5372,14 +4688,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5441,14 +4749,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -5493,14 +4793,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5573,14 +4865,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5637,14 +4921,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5708,14 +4984,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5761,14 +5029,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5830,14 +5090,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5883,14 +5135,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5963,15 +5207,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6028,15 +5263,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6100,15 +5326,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -6154,15 +5371,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6224,15 +5432,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -6278,15 +5477,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-optional/typetest/property/optional/operations/_operations.py
@@ -964,14 +964,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1027,14 +1019,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1098,14 +1082,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -1150,14 +1126,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1219,14 +1187,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -1271,14 +1231,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1350,14 +1302,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1413,14 +1357,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1484,14 +1420,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -1536,14 +1464,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1605,14 +1525,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -1657,14 +1569,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1736,14 +1640,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1799,14 +1695,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1870,14 +1758,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1922,14 +1802,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1991,14 +1863,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -2043,14 +1907,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2122,14 +1978,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2185,14 +2033,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2256,14 +2096,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -2308,14 +2140,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2377,14 +2201,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -2429,14 +2245,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2508,14 +2316,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2571,14 +2371,6 @@ class PlainDateOperations:
         :return: PlainDateProperty. The PlainDateProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainDateProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2642,14 +2434,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -2694,14 +2478,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2763,14 +2539,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
 
     @overload
@@ -2815,14 +2583,6 @@ class PlainDateOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2894,14 +2654,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2957,14 +2709,6 @@ class PlainTimeOperations:
         :return: PlainTimeProperty. The PlainTimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.PlainTimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3028,14 +2772,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -3080,14 +2816,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3149,14 +2877,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
 
     @overload
@@ -3201,14 +2921,6 @@ class PlainTimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "12:30:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3280,16 +2992,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3345,16 +3047,6 @@ class CollectionsByteOperations:
         :return: CollectionsByteProperty. The CollectionsByteProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsByteProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3418,16 +3110,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -3472,16 +3154,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3543,16 +3215,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
 
     @overload
@@ -3597,16 +3259,6 @@ class CollectionsByteOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        bytes("bytes", encoding="utf-8")
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3679,18 +3331,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3747,18 +3387,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3822,18 +3450,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3878,18 +3494,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3951,18 +3555,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -4007,18 +3599,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4090,14 +3670,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4153,14 +3725,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.StringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4224,14 +3788,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4276,14 +3832,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4345,14 +3893,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4397,14 +3937,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4476,14 +4008,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4539,14 +4063,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.IntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4610,14 +4126,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -4662,14 +4170,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4731,14 +4231,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -4783,14 +4275,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4862,14 +4346,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4925,14 +4401,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.FloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4996,14 +4464,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5048,14 +4508,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5117,14 +4569,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -5169,14 +4613,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5248,14 +4684,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5311,14 +4739,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.BooleanLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5382,14 +4802,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5434,14 +4846,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5503,14 +4907,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5555,14 +4951,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5635,14 +5023,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5699,14 +5079,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionStringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5770,14 +5142,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5823,14 +5187,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5892,14 +5248,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5945,14 +5293,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6024,14 +5364,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6087,14 +5419,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.optional.models.UnionIntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6158,14 +5482,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -6210,14 +5526,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6279,14 +5587,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
 
     @overload
@@ -6331,14 +5631,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6411,14 +5703,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6475,14 +5759,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.UnionFloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6546,14 +5822,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -6599,14 +5867,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6668,14 +5928,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
 
     @overload
@@ -6721,14 +5973,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 1.25
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6801,15 +6045,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6866,15 +6101,6 @@ class RequiredAndOptionalOperations:
          MutableMapping
         :rtype: ~typetest.property.optional.models.RequiredAndOptionalProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6938,15 +6164,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -6992,15 +6209,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -7062,15 +6270,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
 
     @overload
@@ -7116,15 +6315,6 @@ class RequiredAndOptionalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "requiredProperty": 0,
-                    "optionalProperty": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/aio/operations/_operations.py
@@ -120,14 +120,6 @@ class BooleanOperations:
         :return: BooleanProperty. The BooleanProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -191,14 +183,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
 
     @overload
@@ -243,14 +227,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -322,14 +298,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -393,14 +361,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -445,14 +405,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -524,14 +476,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -595,14 +539,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -647,14 +583,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -726,14 +654,6 @@ class IntOperations:
         :return: IntProperty. The IntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -797,14 +717,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
 
     @overload
@@ -849,14 +761,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -928,14 +832,6 @@ class FloatOperations:
         :return: FloatProperty. The FloatProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -999,14 +895,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1051,14 +939,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1130,14 +1010,6 @@ class DecimalOperations:
         :return: DecimalProperty. The DecimalProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DecimalProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1201,14 +1073,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1253,14 +1117,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1332,14 +1188,6 @@ class Decimal128Operations:
         :return: Decimal128Property. The Decimal128Property is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.Decimal128Property
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1403,14 +1251,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1455,14 +1295,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1534,14 +1366,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1605,14 +1429,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -1657,14 +1473,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1736,14 +1544,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1807,14 +1607,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -1859,14 +1651,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1938,14 +1722,6 @@ class EnumOperations:
         :return: EnumProperty. The EnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.EnumProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2009,14 +1785,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -2061,14 +1829,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2140,14 +1900,6 @@ class ExtensibleEnumOperations:
         :return: ExtensibleEnumProperty. The ExtensibleEnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ExtensibleEnumProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2211,14 +1963,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -2264,14 +2008,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2343,16 +2079,6 @@ class ModelOperations:
         :return: ModelProperty. The ModelProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2416,16 +2142,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
 
     @overload
@@ -2470,16 +2186,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2552,16 +2258,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2625,16 +2321,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -2680,16 +2366,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2761,16 +2437,6 @@ class CollectionsIntOperations:
         :return: CollectionsIntProperty. The CollectionsIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsIntProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2834,16 +2500,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -2889,16 +2545,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2971,18 +2617,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3046,18 +2680,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3103,18 +2725,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3187,16 +2797,6 @@ class DictionaryStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DictionaryStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3260,16 +2860,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -3315,16 +2905,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3459,12 +3039,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -3509,12 +3083,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3586,14 +3154,6 @@ class UnknownStringOperations:
         :return: UnknownStringProperty. The UnknownStringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3657,14 +3217,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -3710,14 +3262,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3789,14 +3333,6 @@ class UnknownIntOperations:
         :return: UnknownIntProperty. The UnknownIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownIntProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3860,14 +3396,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -3912,14 +3440,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3991,14 +3511,6 @@ class UnknownDictOperations:
         :return: UnknownDictProperty. The UnknownDictProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownDictProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4062,14 +3574,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4115,14 +3619,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4194,14 +3690,6 @@ class UnknownArrayOperations:
         :return: UnknownArrayProperty. The UnknownArrayProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4265,14 +3753,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4318,14 +3798,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4397,14 +3869,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4468,14 +3932,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -4521,14 +3977,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4600,14 +4048,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4671,14 +4111,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -4723,14 +4155,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4802,14 +4226,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4873,14 +4289,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -4926,14 +4334,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5005,14 +4405,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5076,14 +4468,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5129,14 +4513,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5209,14 +4585,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionStringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5280,14 +4648,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5334,14 +4694,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5413,14 +4765,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionIntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5484,14 +4828,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -5537,14 +4873,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5617,14 +4945,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionFloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5688,14 +5008,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -5741,14 +5053,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5820,14 +5124,6 @@ class UnionEnumValueOperations:
         :return: UnionEnumValueProperty. The UnionEnumValueProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionEnumValueProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5891,14 +5187,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -5944,14 +5232,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-property-valuetypes/typetest/property/valuetypes/operations/_operations.py
@@ -876,14 +876,6 @@ class BooleanOperations:
         :return: BooleanProperty. The BooleanProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -947,14 +939,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
 
     @overload
@@ -999,14 +983,6 @@ class BooleanOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bool
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1078,14 +1054,6 @@ class StringOperations:
         :return: StringProperty. The StringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1149,14 +1117,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -1201,14 +1161,6 @@ class StringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1280,14 +1232,6 @@ class BytesOperations:
         :return: BytesProperty. The BytesProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BytesProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1351,14 +1295,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
 
     @overload
@@ -1403,14 +1339,6 @@ class BytesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": bytes("bytes", encoding="utf-8")
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1482,14 +1410,6 @@ class IntOperations:
         :return: IntProperty. The IntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1553,14 +1473,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
 
     @overload
@@ -1605,14 +1517,6 @@ class IntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1684,14 +1588,6 @@ class FloatOperations:
         :return: FloatProperty. The FloatProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1755,14 +1651,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -1807,14 +1695,6 @@ class FloatOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1886,14 +1766,6 @@ class DecimalOperations:
         :return: DecimalProperty. The DecimalProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DecimalProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1957,14 +1829,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -2009,14 +1873,6 @@ class DecimalOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2088,14 +1944,6 @@ class Decimal128Operations:
         :return: Decimal128Property. The Decimal128Property is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.Decimal128Property
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2159,14 +2007,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
 
     @overload
@@ -2211,14 +2051,6 @@ class Decimal128Operations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 0.0
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2290,14 +2122,6 @@ class DatetimeOperations:
         :return: DatetimeProperty. The DatetimeProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DatetimeProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2361,14 +2185,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
 
     @overload
@@ -2413,14 +2229,6 @@ class DatetimeOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "2020-02-20 00:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2492,14 +2300,6 @@ class DurationOperations:
         :return: DurationProperty. The DurationProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DurationProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2563,14 +2363,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
 
     @overload
@@ -2615,14 +2407,6 @@ class DurationOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "1 day, 0:00:00"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2694,14 +2478,6 @@ class EnumOperations:
         :return: EnumProperty. The EnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.EnumProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2765,14 +2541,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -2817,14 +2585,6 @@ class EnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2896,14 +2656,6 @@ class ExtensibleEnumOperations:
         :return: ExtensibleEnumProperty. The ExtensibleEnumProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ExtensibleEnumProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2967,14 +2719,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -3020,14 +2764,6 @@ class ExtensibleEnumOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3099,16 +2835,6 @@ class ModelOperations:
         :return: ModelProperty. The ModelProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.ModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3172,16 +2898,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
 
     @overload
@@ -3226,16 +2942,6 @@ class ModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "property": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3308,16 +3014,6 @@ class CollectionsStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3381,16 +3077,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
 
     @overload
@@ -3436,16 +3122,6 @@ class CollectionsStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        "str"
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3517,16 +3193,6 @@ class CollectionsIntOperations:
         :return: CollectionsIntProperty. The CollectionsIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsIntProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3590,16 +3256,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
 
     @overload
@@ -3645,16 +3301,6 @@ class CollectionsIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        0
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3727,18 +3373,6 @@ class CollectionsModelOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.CollectionsModelProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3802,18 +3436,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
 
     @overload
@@ -3859,18 +3481,6 @@ class CollectionsModelOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": [
-                        {
-                            "property": "str"
-                        }
-                    ]
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -3943,16 +3553,6 @@ class DictionaryStringOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.DictionaryStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4016,16 +3616,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
 
     @overload
@@ -4071,16 +3661,6 @@ class DictionaryStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {
-                        "str": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4215,12 +3795,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
 
     @overload
@@ -4265,12 +3839,6 @@ class NeverOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {}
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4342,14 +3910,6 @@ class UnknownStringOperations:
         :return: UnknownStringProperty. The UnknownStringProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownStringProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4413,14 +3973,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4466,14 +4018,6 @@ class UnknownStringOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4545,14 +4089,6 @@ class UnknownIntOperations:
         :return: UnknownIntProperty. The UnknownIntProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownIntProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4616,14 +4152,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4668,14 +4196,6 @@ class UnknownIntOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4747,14 +4267,6 @@ class UnknownDictOperations:
         :return: UnknownDictProperty. The UnknownDictProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownDictProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4818,14 +4330,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -4871,14 +4375,6 @@ class UnknownDictOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -4950,14 +4446,6 @@ class UnknownArrayOperations:
         :return: UnknownArrayProperty. The UnknownArrayProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnknownArrayProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5021,14 +4509,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
 
     @overload
@@ -5074,14 +4554,6 @@ class UnknownArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": {}
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5153,14 +4625,6 @@ class StringLiteralOperations:
         :return: StringLiteralProperty. The StringLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.StringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5224,14 +4688,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -5277,14 +4733,6 @@ class StringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5356,14 +4804,6 @@ class IntLiteralOperations:
         :return: IntLiteralProperty. The IntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.IntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5427,14 +4867,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -5479,14 +4911,6 @@ class IntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5558,14 +4982,6 @@ class FloatLiteralOperations:
         :return: FloatLiteralProperty. The FloatLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.FloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5629,14 +5045,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -5682,14 +5090,6 @@ class FloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5761,14 +5161,6 @@ class BooleanLiteralOperations:
         :return: BooleanLiteralProperty. The BooleanLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.BooleanLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5832,14 +5224,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
 
     @overload
@@ -5885,14 +5269,6 @@ class BooleanLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": True
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -5965,14 +5341,6 @@ class UnionStringLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionStringLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6036,14 +5404,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
 
     @overload
@@ -6090,14 +5450,6 @@ class UnionStringLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "hello"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6169,14 +5521,6 @@ class UnionIntLiteralOperations:
         :return: UnionIntLiteralProperty. The UnionIntLiteralProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionIntLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6240,14 +5584,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
 
     @overload
@@ -6293,14 +5629,6 @@ class UnionIntLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 42
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6373,14 +5701,6 @@ class UnionFloatLiteralOperations:
          MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionFloatLiteralProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6444,14 +5764,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
 
     @overload
@@ -6497,14 +5809,6 @@ class UnionFloatLiteralOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": 43.125
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6576,14 +5880,6 @@ class UnionEnumValueOperations:
         :return: UnionEnumValueProperty. The UnionEnumValueProperty is compatible with MutableMapping
         :rtype: ~typetest.property.valuetypes.models.UnionEnumValueProperty
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -6647,14 +5943,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
 
     @overload
@@ -6700,14 +5988,6 @@ class UnionEnumValueOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "property": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/aio/operations/_operations.py
@@ -791,14 +791,6 @@ class DecimalVerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -924,14 +916,6 @@ class Decimal128VerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-scalar/typetest/scalar/operations/_operations.py
@@ -994,14 +994,6 @@ class DecimalVerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1125,14 +1117,6 @@ class Decimal128VerifyOperations:
         :return: list of decimal.Decimal
         :rtype: list[~decimal.Decimal]
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == [
-                    0.0
-                ]
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/aio/operations/_operations.py
@@ -83,14 +83,6 @@ class StringsOnlyOperations:
         :return: GetResponse9. The GetResponse9 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse9
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -154,14 +146,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
 
     @overload
@@ -210,14 +194,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -294,14 +270,6 @@ class StringExtensibleOperations:
         :return: GetResponse8. The GetResponse8 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse8
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -365,14 +333,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
 
     @overload
@@ -423,14 +383,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -507,14 +459,6 @@ class StringExtensibleNamedOperations:
         :return: GetResponse7. The GetResponse7 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse7
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -578,14 +522,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -640,14 +576,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -724,14 +652,6 @@ class IntsOnlyOperations:
         :return: GetResponse6. The GetResponse6 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse6
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -795,14 +715,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
 
     @overload
@@ -849,14 +761,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -933,14 +837,6 @@ class FloatsOnlyOperations:
         :return: GetResponse5. The GetResponse5 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse5
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1004,14 +900,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
 
     @overload
@@ -1058,14 +946,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1142,16 +1022,6 @@ class ModelsOnlyOperations:
         :return: GetResponse4. The GetResponse4 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse4
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1215,16 +1085,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -1271,16 +1131,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1357,17 +1207,6 @@ class EnumsOnlyOperations:
         :return: GetResponse3. The GetResponse3 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse3
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1431,17 +1270,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
 
     @overload
@@ -1488,17 +1316,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1575,17 +1392,6 @@ class StringAndArrayOperations:
         :return: GetResponse2. The GetResponse2 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1649,17 +1455,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
 
     @overload
@@ -1706,17 +1501,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1793,19 +1577,6 @@ class MixedLiteralsOperations:
         :return: GetResponse1. The GetResponse1 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1869,19 +1640,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
 
     @overload
@@ -1928,19 +1686,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2017,32 +1762,6 @@ class MixedTypesOperations:
         :return: GetResponse. The GetResponse is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2106,32 +1825,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2178,32 +1871,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/typetest-union/typetest/union/operations/_operations.py
@@ -345,14 +345,6 @@ class StringsOnlyOperations:
         :return: GetResponse9. The GetResponse9 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse9
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -416,14 +408,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
 
     @overload
@@ -472,14 +456,6 @@ class StringsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "a"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -556,14 +532,6 @@ class StringExtensibleOperations:
         :return: GetResponse8. The GetResponse8 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse8
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -627,14 +595,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
 
     @overload
@@ -685,14 +645,6 @@ class StringExtensibleOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "b"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -769,14 +721,6 @@ class StringExtensibleNamedOperations:
         :return: GetResponse7. The GetResponse7 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse7
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -840,14 +784,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -902,14 +838,6 @@ class StringExtensibleNamedOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -986,14 +914,6 @@ class IntsOnlyOperations:
         :return: GetResponse6. The GetResponse6 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse6
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1057,14 +977,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
 
     @overload
@@ -1111,14 +1023,6 @@ class IntsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1195,14 +1099,6 @@ class FloatsOnlyOperations:
         :return: GetResponse5. The GetResponse5 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse5
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1266,14 +1162,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
 
     @overload
@@ -1320,14 +1208,6 @@ class FloatsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": 1.1
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1404,16 +1284,6 @@ class ModelsOnlyOperations:
         :return: GetResponse4. The GetResponse4 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse4
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1477,16 +1347,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
 
     @overload
@@ -1533,16 +1393,6 @@ class ModelsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "name": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1619,17 +1469,6 @@ class EnumsOnlyOperations:
         :return: GetResponse3. The GetResponse3 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse3
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1693,17 +1532,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
 
     @overload
@@ -1750,17 +1578,6 @@ class EnumsOnlyOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "lr": "left",
-                        "ud": "up"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1837,17 +1654,6 @@ class StringAndArrayOperations:
         :return: GetResponse2. The GetResponse2 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -1911,17 +1717,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
 
     @overload
@@ -1968,17 +1763,6 @@ class StringAndArrayOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": "str",
-                        "string": "str"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2055,19 +1839,6 @@ class MixedLiteralsOperations:
         :return: GetResponse1. The GetResponse1 is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2131,19 +1902,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
 
     @overload
@@ -2190,19 +1948,6 @@ class MixedLiteralsOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "booleanLiteral": "a",
-                        "floatLiteral": "a",
-                        "intLiteral": "a",
-                        "stringLiteral": "a"
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2279,32 +2024,6 @@ class MixedTypesOperations:
         :return: GetResponse. The GetResponse is compatible with MutableMapping
         :rtype: ~typetest.union.models.GetResponse
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -2368,32 +2087,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
 
     @overload
@@ -2440,32 +2133,6 @@ class MixedTypesOperations:
         :return: None
         :rtype: None
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": {
-                        "array": [
-                            {
-                                "name": "str"
-                            }
-                        ],
-                        "boolean": {
-                            "name": "str"
-                        },
-                        "int": {
-                            "name": "str"
-                        },
-                        "literal": {
-                            "name": "str"
-                        },
-                        "model": {
-                            "name": "str"
-                        }
-                    }
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-added/versioning/added/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-added/versioning/added/aio/operations/_operations.py
@@ -75,23 +75,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -108,16 +91,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -134,16 +107,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @api_version_validation(
@@ -158,23 +121,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -254,23 +200,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -289,16 +218,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -317,16 +236,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @api_version_validation(
@@ -344,23 +253,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -436,23 +328,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -467,16 +342,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -491,16 +356,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @api_version_validation(
@@ -515,23 +370,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-added/versioning/added/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-added/versioning/added/operations/_operations.py
@@ -126,23 +126,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -157,16 +140,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -183,16 +156,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @api_version_validation(
@@ -207,23 +170,6 @@ class InterfaceV2Operations:
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -303,23 +249,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -338,16 +267,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -366,16 +285,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @api_version_validation(
@@ -391,23 +300,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV1. The ModelV1 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV1
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -481,23 +373,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -512,16 +387,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -536,16 +401,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @api_version_validation(
@@ -560,23 +415,6 @@ class AddedClientOperationsMixin(AddedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.added.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-madeoptional/versioning/madeoptional/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-madeoptional/versioning/madeoptional/_operations/_operations.py
@@ -87,21 +87,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -120,15 +105,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -147,15 +123,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     def test(
@@ -170,21 +137,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-madeoptional/versioning/madeoptional/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-madeoptional/versioning/madeoptional/aio/_operations/_operations.py
@@ -62,21 +62,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -95,15 +80,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     @overload
@@ -122,15 +98,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
 
     async def test(
@@ -145,21 +112,6 @@ class MadeOptionalClientOperationsMixin(MadeOptionalClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.madeoptional.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "prop": "str",
-                    "changedProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-removed/versioning/removed/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-removed/versioning/removed/_operations/_operations.py
@@ -73,23 +73,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -104,16 +87,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -128,16 +101,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     def v2(self, body: Union[_models.ModelV2, JSON, IO[bytes]], **kwargs: Any) -> _models.ModelV2:
@@ -148,23 +111,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-removed/versioning/removed/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-removed/versioning/removed/aio/_operations/_operations.py
@@ -55,23 +55,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -86,16 +69,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -110,16 +83,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
 
     async def v2(self, body: Union[_models.ModelV2, JSON, IO[bytes]], **kwargs: Any) -> _models.ModelV2:
@@ -130,23 +93,6 @@ class RemovedClientOperationsMixin(RemovedClientMixinABC):
         :return: ModelV2. The ModelV2 is compatible with MutableMapping
         :rtype: ~versioning.removed.models.ModelV2
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "prop": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-renamedfrom/versioning/renamedfrom/aio/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-renamedfrom/versioning/renamedfrom/aio/operations/_operations.py
@@ -73,23 +73,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -106,16 +89,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -132,16 +105,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     async def new_op_in_new_interface(
@@ -154,23 +117,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -250,23 +196,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -285,16 +214,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -313,16 +232,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     async def new_op(
@@ -337,23 +246,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-renamedfrom/versioning/renamedfrom/operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-renamedfrom/versioning/renamedfrom/operations/_operations.py
@@ -111,23 +111,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -144,16 +127,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -170,16 +143,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     def new_op_in_new_interface(
@@ -192,23 +155,6 @@ class NewInterfaceOperations:
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,
@@ -288,23 +234,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -323,16 +252,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     @overload
@@ -351,16 +270,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
 
     def new_op(
@@ -375,23 +284,6 @@ class RenamedFromClientOperationsMixin(RenamedFromClientMixinABC):
         :return: NewModel. The NewModel is compatible with MutableMapping
         :rtype: ~versioning.renamedfrom.models.NewModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "enumProp": "str",
-                    "newProp": "str",
-                    "unionProp": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-typechangedfrom/versioning/typechangedfrom/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-typechangedfrom/versioning/typechangedfrom/_operations/_operations.py
@@ -81,21 +81,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -114,15 +99,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -141,15 +117,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     def test(self, body: Union[_models.TestModel, JSON, IO[bytes]], *, param: str, **kwargs: Any) -> _models.TestModel:
@@ -162,21 +129,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,

--- a/packages/typespec-python/test/unbranded/generated/versioning-typechangedfrom/versioning/typechangedfrom/aio/_operations/_operations.py
+++ b/packages/typespec-python/test/unbranded/generated/versioning-typechangedfrom/versioning/typechangedfrom/aio/_operations/_operations.py
@@ -57,21 +57,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -90,15 +75,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     @overload
@@ -117,15 +93,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
 
     async def test(
@@ -140,21 +107,6 @@ class TypeChangedFromClientOperationsMixin(TypeChangedFromClientMixinABC):
         :return: TestModel. The TestModel is compatible with MutableMapping
         :rtype: ~versioning.typechangedfrom.models.TestModel
         :raises ~corehttp.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
-
-                # response body for status code(s): 200
-                response == {
-                    "changedProp": "str",
-                    "prop": "str"
-                }
         """
         error_map: MutableMapping[int, Type[HttpResponseError]] = {
             401: ClientAuthenticationError,


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.python/issues/2714

As discussed in https://github.com/Azure/autorest.python/issues/2714#issuecomment-2247946860, autorest/typespec-python already supports generate samples based on swagger/tsp examples, there is no need to generate samples in docstring.
