### PR TITLE
fix sdk regeneration pipeline

### DIFF
--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -35,7 +35,7 @@ def update_emitter_package(sdk_root: str, typespec_python_root: str):
 
     # update the emitter-package-lock.json
     try:
-        check_call("tsp-client --generate-lock-file", shell=True)
+        check_call("tsp-client generate-lock-file", shell=True)
     except Exception as e:
         logging.error("failed to update emitter-package-lock.json")
         logging.error(e)


### PR DESCRIPTION
Add step to update commit id in `tsp-location.yaml` to avoid failure caused by outdated typespec