### PR TITLE
Fix ci failure

### DIFF
--- a/.chronus/changes/fix-ci-2024-09-11-2024-8-11-18-2-40.md
+++ b/.chronus/changes/fix-ci-2024-09-11-2024-8-11-18-2-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Fix "line-too-long" for docstring in operation

--- a/packages/typespec-python/generator/pygen/codegen/serializers/builder_serializer.py
+++ b/packages/typespec-python/generator/pygen/codegen/serializers/builder_serializer.py
@@ -7,6 +7,7 @@
 from abc import abstractmethod
 from collections import defaultdict
 from typing import Generic, List, Type, TypeVar, Dict, Union, Optional, cast
+import logging
 
 from ..models import (
     Operation,
@@ -284,8 +285,8 @@ class _BuilderBaseSerializer(Generic[BuilderType]):
         return description_list
 
     @staticmethod
-    def line_too_long(docs: List[str]) -> bool:
-        return any(len(line) > 120 for line in docs)
+    def line_too_long(docs: List[str], indentation: int = 0) -> bool:
+        return any(len(line) > (120 - indentation) for line in docs)
 
     def example_template(self, builder: BuilderType) -> List[str]:
         template = []

--- a/packages/typespec-python/generator/pygen/codegen/templates/operation_tools.jinja2
+++ b/packages/typespec-python/generator/pygen/codegen/templates/operation_tools.jinja2
@@ -2,10 +2,17 @@
 
 {% macro description(builder, serializer) %}
 {% set example_template = serializer.example_template(builder) %}
+{% set param_description_and_response_docstring = serializer.param_description_and_response_docstring(builder) %}
+{% set ns = namespace(line_too_long=false) %}
+{% for item in param_description_and_response_docstring %}
+    {% if item and serializer.line_too_long(wrap_string(item, wrapstring='\n ').split('\n'), 8) %}
+        {% set ns.line_too_long = true %}
+    {% endif %}
+{% endfor %}
     {% for description in serializer.description_and_summary(builder) %}
         {% if description %}
 {% set description = wrap_string(description, wrapstring='\n') %}
-            {% if serializer.line_too_long(example_template) and loop.first %}
+            {% if (serializer.line_too_long(example_template) or ns.line_too_long) and loop.first %}
 # pylint: disable=line-too-long
             {% endif %}
 {{ '"""' + description if loop.first else description }}
@@ -13,7 +20,7 @@
 
         {% endif %}
     {% endfor %}
-    {% for description in serializer.param_description_and_response_docstring(builder) %}
+    {% for description in param_description_and_response_docstring %}
         {% if description %}
 {{ wrap_string(description, wrapstring='\n ') }}
         {% else %}

--- a/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/operations/_operations.py
+++ b/packages/typespec-python/test/azure/generated/azure-resource-manager-models-resources/azure/resourcemanager/models/resources/aio/operations/_operations.py
@@ -2343,6 +2343,7 @@ class SingletonTrackedResourcesOperations:
     def list_by_resource_group(
         self, resource_group_name: str, **kwargs: Any
     ) -> AsyncIterable["_models.SingletonTrackedResource"]:
+        # pylint: disable=line-too-long
         """List SingletonTrackedResource resources by resource group.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.


### PR DESCRIPTION
There is ci failure time to time: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4126420&view=logs&j=2ed23d92-1639-5214-83cf-d1b54cba4ddb&t=be4632f5-f667-5ae0-ea2a-7d183fb1e72e.
It may be caused by `line-too-long` of docstring in operation.py:
![image](https://github.com/user-attachments/assets/4d18d30a-4fc5-4d3b-bfeb-b477583e3a70)
