### PR TITLE
release for typespec-python 0.33.0

### DIFF
--- a/.chronus/changes/bump_dependencies-2024-8-19-16-21-8.md
+++ b/.chronus/changes/bump_dependencies-2024-8-19-16-21-8.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@azure-tools/typespec-python"
----
-
-bump dependencies

--- a/.chronus/changes/bump_tcgc-2024-8-23-11-25-33.md
+++ b/.chronus/changes/bump_tcgc-2024-8-23-11-25-33.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@azure-tools/typespec-python"
----
-
-bump to tcgc 0.46.1

--- a/.chronus/changes/fix-multipart-2024-2024-8-23-16-11-40.md
+++ b/.chronus/changes/fix-multipart-2024-2024-8-23-16-11-40.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-python"
----
-
-Remove useless model for multipart

--- a/packages/autorest.python/CHANGELOG.md
+++ b/packages/autorest.python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 6.23.0
+
+No changes, version bump only.
+
 ## 6.22.0
 
 ### Bug Fixes

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.22.0",
+  "version": "6.23.0",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "start": "node ./scripts/run-python3.js ./scripts/start.py",

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release
 
+## 0.33.0
+
+### Bump dependencies
+
+- [#2845](https://github.com/Azure/autorest.python/pull/2845) bump dependencies
+- [#2847](https://github.com/Azure/autorest.python/pull/2847) bump to tcgc 0.46.1
+
+
 ## 0.32.1
 
 ### Bug Fixes

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-python",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://github.com/Azure/autorest.python",


### PR DESCRIPTION
After bump tcgc@0.46.1, we need to release a new version of typespec-python to unblock ARM SDK release.