### PR TITLE
release for typespec-python 0.36.0 && autorest.python 6.26.0

### DIFF
--- a/.chronus/changes/bump_version-2024-9-11-16-56-37.md
+++ b/.chronus/changes/bump_version-2024-9-11-16-56-37.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@azure-tools/typespec-python"
----
-
-Bump to typespec 0.61.0

--- a/.chronus/changes/bump_version-2024-9-12-11-41-53.md
+++ b/.chronus/changes/bump_version-2024-9-12-11-41-53.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@autorest/python"
----
-
-Bump http-client-python 0.3.0

--- a/packages/autorest.python/CHANGELOG.md
+++ b/packages/autorest.python/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release
 
+## 6.26.0
+
+### Bump dependencies
+
+- [#2867](https://github.com/Azure/autorest.python/pull/2867) Bump http-client-python 0.3.0
+
+
 ## 6.25.0
 
 No changes, version bump only.

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.25.0",
+  "version": "6.26.0",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "start": "node ./scripts/run-python3.js ./scripts/start.py",

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release
 
+## 0.36.0
+
+### Bump dependencies
+
+- [#2867](https://github.com/Azure/autorest.python/pull/2867) Bump to typespec 0.61.0
+
+
 ## 0.35.1
 
 ### Bug Fixes

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-python",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://github.com/Azure/autorest.python",


### PR DESCRIPTION
release for typespec-python 0.36.0 && autorest.python 6.26.0