### PR TITLE
Move `@typespec/http-client-python` from "devDependencies" to "dependencies"

### DIFF
--- a/.chronus/changes/update-package-2024-9-24-8-33-7.md
+++ b/.chronus/changes/update-package-2024-9-24-8-33-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@autorest/python"
+---
+
+Move `@typespec/http-client-python` from "devDependencies" to "dependencies"

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -29,13 +29,13 @@
   },
   "homepage": "https://github.com/Azure/autorest.python/blob/main/README.md",
   "dependencies": {
+    "@typespec/http-client-python": "0.3.4",
     "@autorest/system-requirements": "~1.0.2",
     "fs-extra": "~11.2.0",
     "tsx": "4.17.0"
   },
   "devDependencies": {
     "@microsoft.azure/autorest.testserver": "^3.3.50",
-    "@typespec/http-client-python": "0.3.4",
     "chalk": "5.3.0",
     "typescript": "~5.1.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@autorest/system-requirements':
         specifier: ~1.0.2
         version: 1.0.2
+      '@typespec/http-client-python':
+        specifier: 0.3.4
+        version: 0.3.4(vm3zl3bny6zj5nharspdvjsyym)
       fs-extra:
         specifier: ~11.2.0
         version: 11.2.0
@@ -69,9 +72,6 @@ importers:
       '@microsoft.azure/autorest.testserver':
         specifier: ^3.3.50
         version: 3.3.50
-      '@typespec/http-client-python':
-        specifier: 0.3.4
-        version: 0.3.4(vm3zl3bny6zj5nharspdvjsyym)
       chalk:
         specifier: 5.3.0
         version: 5.3.0


### PR DESCRIPTION
Move `@typespec/http-client-python` from "devDependencies" to "dependencies"