### PR TITLE
move devDependency `@azure-tools/cadl-ranch` to typespec-python folder

### DIFF
--- a/.chronus/changes/update-package-2024-2024-9-31-9-52-24.md
+++ b/.chronus/changes/update-package-2024-2024-9-31-9-52-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: dependencies
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Add devDependency `@azure-tools/cadl-ranch`

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/Azure/autorest.python#readme",
   "devDependencies": {
     "@actions/github": "6.0.0",
-    "@azure-tools/cadl-ranch": "~0.16.0",
     "@chronus/chronus": "^0.12.1",
     "@chronus/github": "^0.4.4",
     "@eslint/js": "^9.11.1",

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -69,6 +69,7 @@
     "@azure-tools/typespec-autorest": "~0.47.0",
     "@azure-tools/cadl-ranch-expect": "~0.15.5",
     "@azure-tools/cadl-ranch-specs": "~0.39.0",
+    "@azure-tools/cadl-ranch": "~0.16.0",
     "@types/js-yaml": "~4.0.5",
     "@types/node": "~22.5.4",
     "@types/yargs": "~17.0.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@actions/github':
         specifier: 6.0.0
         version: 6.0.0
-      '@azure-tools/cadl-ranch':
-        specifier: ~0.16.0
-        version: 0.16.0(@typespec/versioning@0.61.0(@typespec/compiler@0.61.0))
       '@chronus/chronus':
         specifier: ^0.12.1
         version: 0.12.1
@@ -100,6 +97,9 @@ importers:
         specifier: 4.17.0
         version: 4.17.0
     devDependencies:
+      '@azure-tools/cadl-ranch':
+        specifier: ~0.16.0
+        version: 0.16.0(@typespec/versioning@0.61.0(@typespec/compiler@0.61.0))
       '@azure-tools/cadl-ranch-expect':
         specifier: ~0.15.5
         version: 0.15.5(@typespec/compiler@0.61.0)(@typespec/http@0.61.0(@typespec/compiler@0.61.0))(@typespec/rest@0.61.0(@typespec/compiler@0.61.0)(@typespec/http@0.61.0(@typespec/compiler@0.61.0)))(@typespec/versioning@0.61.0(@typespec/compiler@0.61.0))


### PR DESCRIPTION
Since only typespec-python use cadl-ranch, we shall move all related dependencies into this folder which is more convenient to manage.