### PR TITLE
switch typespec-python over to js

### DIFF
--- a/.chronus/changes/remove_tsx-2025-0-16-14-52-40.md
+++ b/.chronus/changes/remove_tsx-2025-0-16-14-52-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Remove tsx from `@azure-tools/typespec-python`

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -30,13 +30,13 @@
     "clean": "rimraf ./dist ./temp ./venv ./node_modules",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
-    "install": "tsx ./scripts/run-python3.ts ./scripts/install.py",
-    "prepare": "tsx ./scripts/run-python3.ts ./scripts/prepare.py",
-    "lint": "tsx ./scripts/eng/lint.ts",
+    "install": "node ./dist/scripts/run-python3.js ./scripts/install.py",
+    "prepare": "node ./dist/scripts/run-python3.js ./scripts/prepare.py",
+    "lint": "node ./dist/scripts/eng/lint.js",
     "lint:fix": "eslint . --fix --ext .ts",
-    "format": "npx prettier **/*.ts --write && tsx ./scripts/eng/format.ts",
-    "regenerate": "tsx ./scripts/eng/regenerate.ts",
-    "test": "tsx ./scripts/eng/run-tests.ts"
+    "format": "npx prettier **/*.ts --write && node ./dist/scripts/eng/format.js",
+    "regenerate": "node ./dist/scripts/eng/regenerate.js",
+    "test": "node ./dist/scripts/eng/run-tests.js"
   },
   "files": [
     "dist/**",
@@ -59,7 +59,6 @@
   "dependencies": {
     "js-yaml": "~4.1.0",
     "semver": "~7.6.2",
-    "tsx": "~4.19.1",
     "@typespec/http-client-python": "~0.6.5",
     "fs-extra": "~11.2.0"
   },

--- a/packages/typespec-python/scripts/run-python3.ts
+++ b/packages/typespec-python/scripts/run-python3.ts
@@ -4,7 +4,7 @@
 // path resolution algorithm as AutoRest so that the behavior
 // is fully consistent (and also supports AUTOREST_PYTHON_EXE).
 //
-// Invoke it like so: "tsx run-python3.ts script.py"
+// Invoke it like so: "node ./dist/scripts/run-python3.ts script.py"
 
 import cp from "child_process";
 import { patchPythonPath } from "./system-requirements.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       semver:
         specifier: ~7.6.2
         version: 7.6.3
-      tsx:
-        specifier: ~4.19.1
-        version: 4.19.2
     devDependencies:
       '@azure-tools/azure-http-specs':
         specifier: 0.1.0-alpha.5


### PR DESCRIPTION
fixes #2904 

We won't change autorest.python over to not have `tsx`. We aren't currently compiling in this repo, since the only ts code we have are scripts, and I would rather have clearer scripts in ts, then rewriting them all in js for an emitter that we are moving away from