### PR TITLE
Release 2025-12-15: Bump @typespec/http-client-python to 0.23.0

### DIFF
--- a/.chronus/changes/auto-microsoft-python-array-encode-2025-11-5-10-12-9.md
+++ b/.chronus/changes/auto-microsoft-python-array-encode-2025-11-5-10-12-9.md
@@ -1,8 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@autorest/python"
-  - "@azure-tools/typespec-python"
----
-
-Support encode for array of string in serialization and deserialization

--- a/.chronus/changes/auto-microsoft-python-fix-docstring-2025-11-10-10-23-28.md
+++ b/.chronus/changes/auto-microsoft-python-fix-docstring-2025-11-10-10-23-28.md
@@ -1,8 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@autorest/python"
-  - "@azure-tools/typespec-python"
----
-
-Fix bad indent

--- a/packages/autorest.python/CHANGELOG.md
+++ b/packages/autorest.python/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release
 
+## 6.45.0
+
+### Features
+
+- [#3280](https://github.com/Azure/autorest.python/pull/3280) Support encode for array of string in serialization and deserialization
+
+### Bug Fixes
+
+- [#3279](https://github.com/Azure/autorest.python/pull/3279) Fix bad indent
+
+
 ## 6.44.0
 
 ### Features

--- a/packages/autorest.python/package.json
+++ b/packages/autorest.python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/python",
-  "version": "6.44.0",
+  "version": "6.45.0",
   "description": "The Python extension for generators in AutoRest.",
   "scripts": {
     "start": "node ./scripts/run-python3.js ./scripts/start.py",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.python/blob/main/README.md",
   "dependencies": {
-    "@typespec/http-client-python": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz",
+    "@typespec/http-client-python": "~0.23.0",
     "@autorest/system-requirements": "~1.0.2",
     "fs-extra": "~11.2.0",
     "tsx": "~4.19.1"

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release
 
+## 0.56.0
+
+### Features
+
+- [#3280](https://github.com/Azure/autorest.python/pull/3280) Support encode for array of string in serialization and deserialization
+
+### Bug Fixes
+
+- [#3279](https://github.com/Azure/autorest.python/pull/3279) Fix bad indent
+
+
 ## 0.55.0
 
 ### Features

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-python",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://github.com/Azure/autorest.python",
@@ -67,7 +67,7 @@
     "js-yaml": "~4.1.0",
     "semver": "~7.6.2",
     "tsx": "~4.19.1",
-    "@typespec/http-client-python": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz",
+    "@typespec/http-client-python": "~0.23.0",
     "fs-extra": "~11.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ~1.0.2
         version: 1.0.2
       '@typespec/http-client-python':
-        specifier: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz
-        version: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz(v3ezv3vpzrskrlmsrgpsahan4y)
+        specifier: ~0.23.0
+        version: 0.23.0(v3ezv3vpzrskrlmsrgpsahan4y)
       fs-extra:
         specifier: ~11.2.0
         version: 11.2.0
@@ -82,8 +82,8 @@ importers:
   packages/typespec-python:
     dependencies:
       '@typespec/http-client-python':
-        specifier: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz
-        version: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz(v3ezv3vpzrskrlmsrgpsahan4y)
+        specifier: ~0.23.0
+        version: 0.23.0(v3ezv3vpzrskrlmsrgpsahan4y)
       fs-extra:
         specifier: ~11.2.0
         version: 11.2.0
@@ -1698,9 +1698,8 @@ packages:
     peerDependencies:
       '@typespec/compiler': ^1.7.0
 
-  '@typespec/http-client-python@https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz':
-    resolution: {tarball: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz}
-    version: 0.22.0
+  '@typespec/http-client-python@0.23.0':
+    resolution: {integrity: sha512-6iPSAAaPiG7dPkIlKs51RPoVNtW9J61/lvtb7II52MFk9LGUloxvoV+vxBcyFZsF23IyE/nRWgMNR7+VvNqy4Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@azure-tools/typespec-autorest': '>=0.63.0 <1.0.0'
@@ -6471,7 +6470,7 @@ snapshots:
     dependencies:
       '@typespec/compiler': 1.7.0(@types/node@24.1.0)
 
-  '@typespec/http-client-python@https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNTY2MzY4Mi9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX3B5dGhvbg2/content?format=file&subPath=%2Fpackages%2Ftypespec-http-client-python-0.22.0.tgz(v3ezv3vpzrskrlmsrgpsahan4y)':
+  '@typespec/http-client-python@0.23.0(v3ezv3vpzrskrlmsrgpsahan4y)':
     dependencies:
       '@azure-tools/typespec-autorest': 0.63.0(jatcyppoml3pt7y4asvrpw543q)
       '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.7.0(@types/node@24.1.0))(@typespec/http@1.7.0(@typespec/compiler@1.7.0(@types/node@24.1.0))(@typespec/streams@0.77.0(@typespec/compiler@1.7.0(@types/node@24.1.0))))(@typespec/rest@0.77.0(@typespec/compiler@1.7.0(@types/node@24.1.0))(@typespec/http@1.7.0(@typespec/compiler@1.7.0(@types/node@24.1.0))(@typespec/streams@0.77.0(@typespec/compiler@1.7.0(@types/node@24.1.0)))))


### PR DESCRIPTION
This PR bumps the dependency @typespec/http-client-python to version ~0.23.0.

Changes:
- Updated @autorest/python to version 6.45.0
- Updated @azure-tools/typespec-python to version 0.56.0
- Bumped @typespec/http-client-python dependency to ~0.23.0

Features:
- Support encode for array of string in serialization and deserialization

Bug Fixes:
- Fix bad indent