### PR TITLE
docs: Add classic scenario for committing changes to autorest.python PR

### DIFF
--- a/.github/skills/copying-typespec-test-changes/SKILL.md
+++ b/.github/skills/copying-typespec-test-changes/SKILL.md
@@ -78,7 +78,7 @@ Run this command for each Python file that was created or modified.
 - **Formatting**: Always run `python -m black <file> -l 120` on changed Python files
 - **Scope**: Only copy files from the `generator/test` folder, ignore other changes
 - **Verify**: After copying, the test files should be identical between repos (after formatting)
-- **DO NOT address unrelated differences**: If you encounter existing discrepancies between the two repositories (such as in `requirements.txt` or other configuration files), refrain from trying to eliminate those differences. Focus solely on copying the modified code from the typespec pull request, disregarding any pre-existing variations.
+- **requirements.txt**: When updating `requirements.txt` files, only update dependencies with the `-e XXX` pattern (editable installs). Do NOT modify other dependencies in the file.
 
 ## Example usage
 


### PR DESCRIPTION
Updates the copying-typespec-test-changes skill documentation to include the classic scenario where users provide both a typespec PR link (source) and an autorest.python PR link (destination).

## Changes
- Renamed existing example to 'Basic usage (local changes only)'
- Added new 'Classic scenario (commit to autorest.python PR)' section
- Includes complete workflow for checking out PR branch, copying changes, and pushing commits
- Added important notes about commit messages and branch handling