### PR TITLE
ci(consistency): declare contents: read on the Consistency workflow

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -10,6 +10,9 @@ on:
   merge_group:
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-changes:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `consistency.yml`, the lint / format / changelog-verify workflow that runs on PRs, pushes to `main`, and the merge group.

The sibling `prepare-auto-release-branch.yml` already declares a top-level `permissions:` block (granting `contents: write` there), so this PR follows the same style for the read-only workflow.

Verified by parsing the YAML with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/consistency.yml'))"`. No behavior change.